### PR TITLE
feat: Karpathy/Cherny session-digest discipline + /correct skill + CI

### DIFF
--- a/.claude/hooks/digest-activity-tracker.ps1
+++ b/.claude/hooks/digest-activity-tracker.ps1
@@ -1,0 +1,24 @@
+# PostToolUse hook (matcher: Edit|Write|Bash) — increments mutation counter.
+# /digest skill resets the counter on invocation. Karpathy R4.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+$repoRoot = & git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) { exit 0 }
+
+$digestDir   = Join-Path $repoRoot 'state/digests'
+$counterPath = Join-Path $digestDir '.activity-counter'
+
+if (-not (Test-Path $digestDir)) {
+    New-Item -ItemType Directory -Path $digestDir -Force | Out-Null
+}
+
+$count = 0
+if (Test-Path $counterPath) {
+    $raw = (Get-Content $counterPath -Raw).Trim()
+    if ($raw -match '^\d+$') { $count = [int]$raw }
+}
+$count++
+
+Set-Content -Path $counterPath -Value $count -Encoding UTF8
+exit 0

--- a/.claude/hooks/digest-staleness-nudge.ps1
+++ b/.claude/hooks/digest-staleness-nudge.ps1
@@ -1,0 +1,40 @@
+# UserPromptSubmit hook — emits an additionalContext nudge when state has drifted
+# from the last /digest. Karpathy R1+R4. Silent when digest is fresh.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+$repoRoot = & git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) { exit 0 }
+
+$latest  = Join-Path $repoRoot 'state/digests/latest.md'
+$counter = Join-Path $repoRoot 'state/digests/.activity-counter'
+
+$digestAgeMin = $null
+if (Test-Path $latest) {
+    $digestAgeMin = [int]((Get-Date) - (Get-Item $latest).LastWriteTime).TotalMinutes
+}
+
+$mutationCount = 0
+if (Test-Path $counter) {
+    $raw = (Get-Content $counter -Raw).Trim()
+    if ($raw -match '^\d+$') { $mutationCount = [int]$raw }
+}
+
+$shouldNudge = $false
+$reason = ''
+if ($null -eq $digestAgeMin) {
+    $shouldNudge = $true
+    $reason = "No session digest exists yet. Invoke /digest at your next natural breakpoint."
+} elseif ($digestAgeMin -gt 30 -and $mutationCount -gt 10) {
+    $shouldNudge = $true
+    $reason = "Last digest $digestAgeMin min ago; $mutationCount mutations since. Karpathy R4: task complete != goal achieved — consider /digest to mark success criteria status."
+} elseif ($digestAgeMin -gt 90) {
+    $shouldNudge = $true
+    $reason = "Last digest $digestAgeMin min ago. Session drifting — invoke /digest before the next compaction."
+}
+
+if (-not $shouldNudge) { exit 0 }
+
+$payload = @{ additionalContext = "[digest-nudge] $reason" } | ConvertTo-Json -Compress
+Write-Output $payload
+exit 0

--- a/.claude/hooks/digest-stop-finalize.ps1
+++ b/.claude/hooks/digest-stop-finalize.ps1
@@ -3,6 +3,15 @@
 
 $ErrorActionPreference = 'SilentlyContinue'
 
+function Get-SafeYaml {
+    param([string]$Value, [int]$MaxLen = 200)
+    if ($null -eq $Value -or $Value -eq '') { return 'null' }
+    $cleaned = ($Value -replace '[\r\n]', ' ')
+    if ($cleaned.Length -gt $MaxLen) { $cleaned = $cleaned.Substring(0, $MaxLen) + '...' }
+    $escaped = $cleaned -replace "'", "''"
+    return "'$escaped'"
+}
+
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
 
@@ -43,10 +52,10 @@ schema_version: 1
 session_id: stop-finalize
 written_at: $tsIso
 trigger: stop-hook-finalize
-branch: $branch
-head_sha: $headSha
-head_subject: $headSubj
-open_pr: $openPr
+branch: $(Get-SafeYaml $branch)
+head_sha: $(Get-SafeYaml $headSha)
+head_subject: $(Get-SafeYaml $headSubj)
+open_pr: $(Get-SafeYaml $openPr)
 ---
 
 # Session digest (Stop-hook finalize — /digest not invoked in last 10 min)

--- a/.claude/hooks/digest-stop-finalize.ps1
+++ b/.claude/hooks/digest-stop-finalize.ps1
@@ -1,0 +1,64 @@
+# Stop hook — writes a finalize digest if /digest hasn't run in the last 10 min.
+# Karpathy R4: every session boundary is a goal-driven checkpoint.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+$repoRoot = & git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) { exit 0 }
+
+$digestDir = Join-Path $repoRoot 'state/digests'
+$archDir   = Join-Path $digestDir 'archive'
+$latest    = Join-Path $digestDir 'latest.md'
+
+if (Test-Path $latest) {
+    $age = (Get-Date) - (Get-Item $latest).LastWriteTime
+    if ($age.TotalMinutes -lt 10) { exit 0 }
+}
+
+New-Item -ItemType Directory -Path $digestDir, $archDir -Force | Out-Null
+
+$tsFile = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
+$tsIso  = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+
+if (Test-Path $latest) {
+    Copy-Item $latest (Join-Path $archDir "$tsFile-stop.md") -Force
+}
+
+$branch   = & git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null
+$headSha  = & git -C $repoRoot rev-parse --short HEAD 2>$null
+$headSubj = & git -C $repoRoot log -1 --format='%s' 2>$null
+
+$openPr = $null
+if (Get-Command gh -ErrorAction SilentlyContinue) {
+    $prJson = & gh pr view --json number 2>$null
+    if ($prJson) {
+        try { $openPr = "#$(($prJson | ConvertFrom-Json).number)" } catch {}
+    }
+}
+$prLine = if ($openPr) { "**Open PR:** $openPr`n" } else { '' }
+
+$digest = @"
+---
+schema_version: 1
+session_id: stop-finalize
+written_at: $tsIso
+trigger: stop-hook-finalize
+branch: $branch
+head_sha: $headSha
+head_subject: $headSubj
+open_pr: $openPr
+---
+
+# Session digest (Stop-hook finalize — /digest not invoked in last 10 min)
+
+**Branch:** $branch @ $headSha — $headSubj
+$prLine
+## Model-driven sections
+
+_Session ended without a recent ``/digest``. Next session: re-orient from
+``git log`` + open PR. Prior digests (if any) are in ``state/digests/archive/``._
+"@
+
+Set-Content -Path $latest -Value $digest -Encoding UTF8
+& (Join-Path $repoRoot '.claude/hooks/digest-validate.ps1') -DigestPath $latest 2>$null
+exit 0

--- a/.claude/hooks/digest-validate.ps1
+++ b/.claude/hooks/digest-validate.ps1
@@ -1,0 +1,52 @@
+# Validates state/digests/latest.md frontmatter against docs/contracts/digest-schema.json.
+# Karpathy R11: every AI step declares an output schema; runtime rejects mismatches.
+
+param([string]$DigestPath)
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+$repoRoot = & git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) { exit 0 }
+
+if (-not $DigestPath) {
+    $DigestPath = Join-Path $repoRoot 'state/digests/latest.md'
+}
+if (-not (Test-Path $DigestPath)) { exit 0 }
+
+$content = Get-Content $DigestPath -Raw
+if ($content -notmatch '(?s)^---\r?\n(.*?)\r?\n---') {
+    Write-Error "digest-validate: missing or malformed YAML frontmatter in $DigestPath"
+    exit 1
+}
+
+$fmRaw = $matches[1]
+$fm = @{}
+foreach ($line in ($fmRaw -split "`r?`n")) {
+    if ($line -match '^\s*([\w_]+)\s*:\s*(.*?)\s*$') {
+        $key = $matches[1]
+        $val = $matches[2]
+        if ($val -eq 'null' -or $val -eq '') { $val = $null }
+        $fm[$key] = $val
+    }
+}
+
+$required = @('schema_version', 'session_id', 'written_at', 'trigger', 'branch', 'head_sha', 'head_subject')
+foreach ($k in $required) {
+    if (-not $fm.ContainsKey($k) -or $null -eq $fm[$k]) {
+        Write-Error "digest-validate: required field '$k' missing or null"
+        exit 1
+    }
+}
+
+if ($fm['schema_version'] -ne '1') {
+    Write-Error "digest-validate: schema_version must be 1 (got '$($fm['schema_version'])')"
+    exit 1
+}
+
+$validTriggers = @('digest-skill', 'precompact-hook-fallback', 'stop-hook-finalize', 'auto-write-routine')
+if ($fm['trigger'] -notin $validTriggers) {
+    Write-Error "digest-validate: trigger '$($fm['trigger'])' not in $($validTriggers -join ', ')"
+    exit 1
+}
+
+exit 0

--- a/.claude/hooks/precompact-digest.ps1
+++ b/.claude/hooks/precompact-digest.ps1
@@ -1,0 +1,71 @@
+# PreCompact hook — archives state/digests/latest.md and writes a metadata-only
+# fallback if /digest wasn't invoked before compaction.
+
+$ErrorActionPreference = 'SilentlyContinue'
+$WarningPreference     = 'SilentlyContinue'
+
+$repoRoot = & git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) { exit 0 }
+
+$digestDir = Join-Path $repoRoot 'state/digests'
+$archDir   = Join-Path $digestDir 'archive'
+$latest    = Join-Path $digestDir 'latest.md'
+New-Item -ItemType Directory -Path $digestDir, $archDir -Force | Out-Null
+
+$sessionId = 'unknown'
+try {
+    $stdinRaw = [Console]::In.ReadToEnd()
+    if ($stdinRaw) {
+        $payload = $stdinRaw | ConvertFrom-Json
+        if ($payload.session_id) { $sessionId = $payload.session_id }
+    }
+} catch {}
+
+$ts     = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+$tsFile = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
+
+if (Test-Path $latest) {
+    Copy-Item $latest (Join-Path $archDir "$tsFile-$sessionId.md") -Force
+    $age = (Get-Date) - (Get-Item $latest).LastWriteTime
+    if ($age.TotalMinutes -lt 30) { exit 0 }
+}
+
+$branch   = & git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null
+$headSha  = & git -C $repoRoot rev-parse --short HEAD 2>$null
+$headSubj = & git -C $repoRoot log -1 --format='%s' 2>$null
+
+$openPr = $null
+if (Get-Command gh -ErrorAction SilentlyContinue) {
+    $prJson = & gh pr view --json number 2>$null
+    if ($prJson) {
+        try { $openPr = "#$(($prJson | ConvertFrom-Json).number)" } catch {}
+    }
+}
+$prLine = if ($openPr) { "**Open PR:** $openPr`n" } else { '' }
+
+$digest = @"
+---
+schema_version: 1
+session_id: $sessionId
+written_at: $ts
+trigger: precompact-hook-fallback
+branch: $branch
+head_sha: $headSha
+head_subject: $headSubj
+open_pr: $openPr
+---
+
+# Session digest (fallback — /digest was not invoked before compaction)
+
+**Branch:** $branch @ $headSha — $headSubj
+$prLine
+## Model-driven sections
+
+_No ``/digest`` invocation was captured before this compaction. Re-orient from
+``git log`` and the open PR. Invoke ``/digest`` mid-session to populate the
+**Next action**, **In-flight**, **Live hypotheses**, **Open questions**, and
+**Do NOT carry forward** sections before the next compaction event._
+"@
+
+Set-Content -Path $latest -Value $digest -Encoding UTF8
+exit 0

--- a/.claude/hooks/precompact-digest.ps1
+++ b/.claude/hooks/precompact-digest.ps1
@@ -4,6 +4,23 @@
 $ErrorActionPreference = 'SilentlyContinue'
 $WarningPreference     = 'SilentlyContinue'
 
+function Get-SafeId {
+    param([string]$Value, [string]$Fallback = 'unknown', [int]$MaxLen = 64)
+    if (-not $Value) { return $Fallback }
+    $cleaned = $Value -replace '[\r\n\t]', ''
+    if ($cleaned.Length -gt $MaxLen) { $cleaned = $cleaned.Substring(0, $MaxLen) }
+    if ($cleaned -match '^[A-Za-z0-9._\-]+$') { return $cleaned }
+    return $Fallback
+}
+function Get-SafeYaml {
+    param([string]$Value, [int]$MaxLen = 200)
+    if ($null -eq $Value -or $Value -eq '') { return 'null' }
+    $cleaned = ($Value -replace '[\r\n]', ' ')
+    if ($cleaned.Length -gt $MaxLen) { $cleaned = $cleaned.Substring(0, $MaxLen) + '...' }
+    $escaped = $cleaned -replace "'", "''"
+    return "'$escaped'"
+}
+
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
 
@@ -24,8 +41,9 @@ try {
 $ts     = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
 $tsFile = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
 
+$safeSession = Get-SafeId $sessionId
 if (Test-Path $latest) {
-    Copy-Item $latest (Join-Path $archDir "$tsFile-$sessionId.md") -Force
+    Copy-Item $latest (Join-Path $archDir "$tsFile-$safeSession.md") -Force
     $age = (Get-Date) - (Get-Item $latest).LastWriteTime
     if ($age.TotalMinutes -lt 30) { exit 0 }
 }
@@ -46,13 +64,13 @@ $prLine = if ($openPr) { "**Open PR:** $openPr`n" } else { '' }
 $digest = @"
 ---
 schema_version: 1
-session_id: $sessionId
+session_id: $(Get-SafeYaml $sessionId)
 written_at: $ts
 trigger: precompact-hook-fallback
-branch: $branch
-head_sha: $headSha
-head_subject: $headSubj
-open_pr: $openPr
+branch: $(Get-SafeYaml $branch)
+head_sha: $(Get-SafeYaml $headSha)
+head_subject: $(Get-SafeYaml $headSubj)
+open_pr: $(Get-SafeYaml $openPr)
 ---
 
 # Session digest (fallback — /digest was not invoked before compaction)

--- a/.claude/hooks/sessionstart-digest.ps1
+++ b/.claude/hooks/sessionstart-digest.ps1
@@ -1,0 +1,31 @@
+# SessionStart hook — emits state/digests/latest.md to stdout for additionalContext
+# injection. Skips silently if missing or >24h stale.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+$repoRoot = & git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) { exit 0 }
+
+$latest = Join-Path $repoRoot 'state/digests/latest.md'
+if (-not (Test-Path $latest)) { exit 0 }
+
+$age = (Get-Date) - (Get-Item $latest).LastWriteTime
+if ($age.TotalHours -gt 24) {
+    Write-Host ''
+    Write-Host "Session digest exists but is >24h old — skipping injection. Run /digest to refresh." -ForegroundColor DarkGray
+    Write-Host ''
+    exit 0
+}
+
+$ageStr = if ($age.TotalMinutes -lt 60) {
+    "$([int]$age.TotalMinutes) min"
+} else {
+    "$([int]$age.TotalHours)h $([int]$age.Minutes)m"
+}
+
+Write-Host ''
+Write-Host "=== Session digest (last written $ageStr ago) ===" -ForegroundColor Cyan
+Get-Content $latest -Raw | Write-Host
+Write-Host '=== End digest ===' -ForegroundColor Cyan
+Write-Host ''
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,5 +4,58 @@
     "context7@claude-plugins-official": true,
     "claude-mem@thedotmack": true,
     "discord@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File .claude/hooks/precompact-digest.ps1"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File .claude/hooks/sessionstart-digest.ps1"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File .claude/hooks/digest-staleness-nudge.ps1"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File .claude/hooks/digest-activity-tracker.ps1"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File .claude/hooks/digest-stop-finalize.ps1"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -File .claude/hooks/precompact-digest.ps1"
+            "command": "pwsh -NoProfile -Command \"& $env:CLAUDE_PROJECT_DIR/.claude/hooks/precompact-digest.ps1\""
           }
         ]
       }
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -File .claude/hooks/sessionstart-digest.ps1"
+            "command": "pwsh -NoProfile -Command \"& $env:CLAUDE_PROJECT_DIR/.claude/hooks/sessionstart-digest.ps1\""
           }
         ]
       }
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -File .claude/hooks/digest-staleness-nudge.ps1"
+            "command": "pwsh -NoProfile -Command \"& $env:CLAUDE_PROJECT_DIR/.claude/hooks/digest-staleness-nudge.ps1\""
           }
         ]
       }
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -File .claude/hooks/digest-activity-tracker.ps1"
+            "command": "pwsh -NoProfile -Command \"& $env:CLAUDE_PROJECT_DIR/.claude/hooks/digest-activity-tracker.ps1\""
           }
         ]
       }
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -File .claude/hooks/digest-stop-finalize.ps1"
+            "command": "pwsh -NoProfile -Command \"& $env:CLAUDE_PROJECT_DIR/.claude/hooks/digest-stop-finalize.ps1\""
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -Command \"& $env:CLAUDE_PROJECT_DIR/.claude/hooks/precompact-digest.ps1\""
+            "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/.claude/hooks/precompact-digest.ps1"
           }
         ]
       }
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -Command \"& $env:CLAUDE_PROJECT_DIR/.claude/hooks/sessionstart-digest.ps1\""
+            "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/.claude/hooks/sessionstart-digest.ps1"
           }
         ]
       }
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -Command \"& $env:CLAUDE_PROJECT_DIR/.claude/hooks/digest-staleness-nudge.ps1\""
+            "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/.claude/hooks/digest-staleness-nudge.ps1"
           }
         ]
       }
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -Command \"& $env:CLAUDE_PROJECT_DIR/.claude/hooks/digest-activity-tracker.ps1\""
+            "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/.claude/hooks/digest-activity-tracker.ps1"
           }
         ]
       }
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pwsh -NoProfile -Command \"& $env:CLAUDE_PROJECT_DIR/.claude/hooks/digest-stop-finalize.ps1\""
+            "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/.claude/hooks/digest-stop-finalize.ps1"
           }
         ]
       }

--- a/.claude/skills/correct/SKILL.md
+++ b/.claude/skills/correct/SKILL.md
@@ -29,14 +29,24 @@ the correction apply to *future* work, not just this edit?
 2. **Confirm** (one line, skip if user already explicitly said so):
    > Adding rule to CLAUDE.md: <rule>. OK?
 
-3. **Append** to `CLAUDE.md` under `## Session-learned rules` (create the
-   section if missing — last section so new entries append). Format:
+3. **Sanitize the rule text** (required — closes persistent-prompt-injection):
+   - Truncate to 200 chars max.
+   - Strip ` ``` `, `---`, `<!-- -->`, and section headers (`#`/`##`/`###` at line start).
+   - If the rule contains bare shell verbs followed by URL or pipe
+     (`curl ... |`, `bash -c`, `wget`, `pwsh -Command`, `eval`, `exec`),
+     **stop and ask the user to rephrase**. Don't paraphrase.
+   - Strip leading/trailing whitespace; collapse newlines.
 
-   ```markdown
-   - **<YYYY-MM-DD>**: <rule>. (<one-line reason>)
+4. **Append** to `CLAUDE.md` under `## Session-learned rules`, wrapped in
+   a fenced block tagged `untrusted-correction`:
+
+   ````markdown
+   ```untrusted-correction
+   - **<YYYY-MM-DD>**: <sanitized rule>. (<one-line reason>)
    ```
+   ````
 
-4. **Report**:
+5. **Report**:
    > Rule added to CLAUDE.md: <rule>
 
 ## Anti-patterns

--- a/.claude/skills/correct/SKILL.md
+++ b/.claude/skills/correct/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: correct
+description: Self-improvement reflex. When the user corrects an approach ("no, don't do that", "we discussed this before", "stop X"), captures the lesson as a permanent project rule appended to CLAUDE.md so the pattern doesn't repeat in this or future sessions. Cherny called this "the most important loop" in his 2026 Sequoia talk.
+allowed-tools: Read, Edit, Bash
+last_verified: 2026-05-14
+karpathy_rule: R-self-improvement (Cherny's "most important loop")
+---
+
+# /correct
+
+Turns a user correction into a permanent rule appended to `CLAUDE.md`.
+
+## When to run
+
+- User says **"no, don't do that"** / **"stop X"** / **"we discussed this before"**.
+- User overrides a recommendation with a reason that would apply to future work.
+- User points out a recurring pattern you should avoid.
+
+**Do NOT** invoke for typo corrections or one-off style nudges. Bar: would
+the correction apply to *future* work, not just this edit?
+
+## How to run
+
+1. **Identify the rule.** One sentence, imperative, with the *why*.
+   - Good: "Never amend commits after CI passes — force-push hides the
+     original test result."
+   - Bad: "Stop amending commits."
+
+2. **Confirm** (one line, skip if user already explicitly said so):
+   > Adding rule to CLAUDE.md: <rule>. OK?
+
+3. **Append** to `CLAUDE.md` under `## Session-learned rules` (create the
+   section if missing — last section so new entries append). Format:
+
+   ```markdown
+   - **<YYYY-MM-DD>**: <rule>. (<one-line reason>)
+   ```
+
+4. **Report**:
+   > Rule added to CLAUDE.md: <rule>
+
+## Anti-patterns
+
+- Vague rules ("be careful with state management") — name the pattern or skip.
+- Over-eager capture — typos aren't rules.
+- Code-style catalogs — those go in style files, not CLAUDE.md.
+- Confusing with /learnings — /learnings = surprises (facts to grep);
+  /correct = behavioural rules (do/don't next time).
+
+## Why this exists
+
+Cherny's "most important loop" from the 2026 Sequoia AI Ascent talk: when
+corrected, update the localized machine, not just this turn's code.
+Without /correct, the next session repeats the pattern because nothing
+persisted the rule.
+
+## Related
+
+- `/digest` — captures session state.
+- `/learnings` — captures surprises into `docs/solutions/`.
+- `CLAUDE.md` — the persistent rule store this skill writes to.

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -84,6 +84,26 @@ When a prior digest exists, this section reports the status delta:
 7. Validate: `pwsh -NoProfile -File .claude/hooks/digest-validate.ps1`. Non-zero = fix.
 8. Report: `Digest updated: <branch>@<sha> · next: <one-line> · criteria: <N>`.
 
+## Driving criteria autonomously with `/goal`
+
+After writing the digest, **consider `/goal <condition>` (native Claude
+Code v2.1.139+) for substantial autonomous work**. `/goal` mechanizes
+Karpathy R4: a small fast model evaluates after every turn whether the
+condition holds and either fires another turn or clears the goal.
+
+Use `/goal` when the Next action has:
+
+- A verifiable end state (build green, tests pass, file count under budget)
+- 5+ minutes of expected autonomous work
+- An evaluator-checkable result (checked against the transcript — no
+  tool calls)
+
+Skip `/goal` for short tasks, visual/UX judgement, or ambiguous specs.
+
+When `/goal` lands a "yes," the next `/digest` should mark the
+corresponding `success_criteria` entry as `achieved` with the `/goal`
+evidence.
+
 ## Anti-patterns
 
 - Transcript capture — git log is the transcript.

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: digest
+description: Capture meaningful session state (current cursor, in-flight work, live hypotheses, open questions, do-NOT-carry-forward, success criteria) to state/digests/latest.md so the next session — including one after auto-compaction — can re-enter without re-discovering context cold. Distinct from /learnings (which captures surprises). Validates against docs/contracts/digest-schema.json.
+allowed-tools: Bash, Read, Write, Edit
+last_verified: 2026-05-14
+karpathy_rules: [R1-think-before-coding, R4-goal-driven-execution]
+---
+
+# /digest
+
+Captures the **meaningful state of the current session** to
+`state/digests/latest.md`. The `.claude/hooks/sessionstart-digest.ps1` hook
+reads it on the next session start and emits it as `additionalContext` for
+the model. Pairs with `.claude/hooks/precompact-digest.ps1` which provides
+a metadata-only fallback when /digest isn't invoked before auto-compaction.
+
+## When to run
+
+- **Before compaction is imminent** (context feels >60% full).
+- **At a natural breakpoint** — after finishing a feature, before a risky
+  operation, before handing off to another agent.
+- **Before launching long-running background work.**
+
+**Do NOT** invoke on every message or tool call.
+
+## What it captures
+
+```yaml
+---
+schema_version: 1
+session_id: <session_id>
+written_at: <RFC3339 UTC>
+trigger: digest-skill
+branch: <git branch>
+head_sha: <short SHA>
+head_subject: <commit subject>
+open_pr: <"#N" or null>
+last_model_update: <RFC3339 UTC>
+success_criteria:
+  - criterion: "<testable assertion for the Next action>"
+    status: pending | in-progress | achieved | abandoned
+    evidence: "<file:line | PR# | metric path | null>"
+---
+
+# Session digest — <branch> @ <sha>
+
+## Next action
+
+ONE imperative sentence. Must map 1:1 to `success_criteria` entries.
+
+## In-flight
+
+Work currently mid-execution. file/feature, step N of total, next sub-step.
+
+## Live hypotheses
+
+Working hypotheses to inherit. *Unconfirmed*; don't promote to MEMORY.md yet.
+
+## Open questions
+
+Numbered. Questions you would ask the user if they walked in now.
+
+## Do NOT carry forward
+
+**Highest-leverage field.** Things the next session must NOT re-propose.
+
+## Prior success criteria status (Karpathy R4)
+
+When a prior digest exists, this section reports the status delta:
+
+- ✅ achieved: <prior criterion> — evidence: <file:line | commit | PR>
+- ⏳ in-progress: <prior criterion> — last touched: <where>
+- ⛔ abandoned: <prior criterion> — reason: <one sentence>
+```
+
+## How to run
+
+1. Read existing `state/digests/latest.md` if present — preserve current sections.
+2. Karpathy R4 — review/mark prior success criteria.
+3. Capture git state via Bash (`git rev-parse`, `git log -1`, `gh pr view`).
+4. Synthesize content; derive 1–3 testable `success_criteria` from Next action.
+5. Write to `state/digests/latest.md`. Set `trigger: digest-skill` + `last_model_update`.
+6. `rm -f state/digests/.activity-counter` to reset the staleness nudge.
+7. Validate: `pwsh -NoProfile -File .claude/hooks/digest-validate.ps1`. Non-zero = fix.
+8. Report: `Digest updated: <branch>@<sha> · next: <one-line> · criteria: <N>`.
+
+## Anti-patterns
+
+- Transcript capture — git log is the transcript.
+- Empty digest — if nothing changed, prior digest still applies.
+- Forgetting "Do NOT carry forward".
+
+## Related
+
+- `/learnings` — captures surprises into `docs/solutions/`.
+- `/correct` — captures user corrections as permanent `CLAUDE.md` rules.
+- `.claude/hooks/{precompact,sessionstart}-digest.ps1` — auto-fallback + read-back.
+- `state/digests/README.md` — directory layout.

--- a/.github/workflows/karpathy-cherny-discipline.yml
+++ b/.github/workflows/karpathy-cherny-discipline.yml
@@ -1,0 +1,103 @@
+name: Karpathy/Cherny Discipline Check
+
+on:
+  pull_request:
+    paths:
+      - 'docs/contracts/digest-schema.json'
+      - 'state/digests/**'
+      - '.claude/settings.json'
+      - '.claude/skills/digest/**'
+      - '.claude/skills/correct/**'
+      - '.claude/hooks/digest-*'
+      - '.claude/hooks/precompact-digest*'
+      - '.claude/hooks/sessionstart-digest*'
+      - 'CLAUDE.md'
+      - '.github/workflows/karpathy-cherny-discipline.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install validators
+        run: pip install jsonschema pyyaml
+
+      - name: Verify digest schema is well-formed JSON
+        run: python -c "import json; json.load(open('docs/contracts/digest-schema.json'))"
+
+      - name: Verify CLAUDE.md contains Karpathy 4 Rules section
+        run: |
+          if ! grep -q "Karpathy 4 Rules" CLAUDE.md; then
+            echo "::error file=CLAUDE.md::CLAUDE.md must contain a 'Karpathy 4 Rules' section."
+            exit 1
+          fi
+
+      - name: Verify required hook scripts exist
+        shell: bash
+        run: |
+          missing=0
+          for f in \
+            ".claude/hooks/precompact-digest.ps1" \
+            ".claude/hooks/sessionstart-digest.ps1" \
+            ".claude/hooks/digest-validate.ps1" \
+            ".claude/hooks/digest-staleness-nudge.ps1" \
+            ".claude/hooks/digest-activity-tracker.ps1" \
+            ".claude/hooks/digest-stop-finalize.ps1"; do
+            if [ ! -f "$f" ]; then
+              echo "::error file=$f::Required Karpathy/Cherny hook script missing: $f"
+              missing=1
+            fi
+          done
+          exit $missing
+
+      - name: Verify .claude/settings.json is valid JSON
+        run: python -c "import json; json.load(open('.claude/settings.json'))"
+
+      - name: Verify required skills exist
+        shell: bash
+        run: |
+          missing=0
+          for f in ".claude/skills/digest/SKILL.md" ".claude/skills/correct/SKILL.md"; do
+            if [ ! -f "$f" ]; then
+              echo "::error file=$f::Required skill missing: $f"
+              missing=1
+            fi
+          done
+          exit $missing
+
+      - name: Validate any committed digest archives against schema
+        run: |
+          python <<'PYEOF'
+          import json, glob, re, sys, os
+          import yaml
+          from jsonschema import validate, ValidationError
+
+          if not os.path.exists('docs/contracts/digest-schema.json'):
+              sys.exit(0)
+          with open('docs/contracts/digest-schema.json') as f:
+              schema = json.load(f)
+          errors = []
+          for path in glob.glob('state/digests/archive/*.md'):
+              with open(path) as f:
+                  content = f.read()
+              m = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+              if not m: continue
+              try:
+                  fm = yaml.safe_load(m.group(1))
+                  validate(instance=fm, schema=schema)
+              except (ValidationError, yaml.YAMLError) as e:
+                  errors.append(f"{path}: {e}")
+          if errors:
+              print('\n'.join(errors))
+              sys.exit(1)
+          print('All committed digests valid (or none committed).')
+          PYEOF

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 # Local settings with secrets/tokens
 .claude/settings.local.json
+
+# Session digests — per-session cursor state captured by the /digest skill
+# and the PreCompact/Stop hook fallbacks. README is tracked; contents are
+# session-specific and may include in-flight model context.
+state/digests/*
+!state/digests/README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ These rules apply to every Claude proposal that touches code:
 1. **Think before coding.** State your interpretation of the request + assumptions; ask one clarifying question if anything is ambiguous; wait for confirmation before writing code.
 2. **Simplicity first.** Write minimum code that solves the exact problem. No speculative features, no future-proofing.
 3. **Surgical changes only.** Only modify code directly related to the request. Don't refactor adjacent code, don't fix unrelated style issues.
-4. **Goal-driven execution.** Transform every task into verifiable success criteria. Loop until each is demonstrably met. "Task completed" ≠ "goal achieved."
+4. **Goal-driven execution.** Transform every task into verifiable success criteria. Loop until each is demonstrably met. "Task completed" ≠ "goal achieved." Use native `/goal <condition>` (Claude Code v2.1.139+) to mechanize this — Claude keeps working across turns until an evaluator confirms the condition holds. `/digest`'s `success_criteria` field is the **declared** form; `/goal` is the **operational** driver.
 
 Self-improvement reflex: when the user corrects you, invoke `/correct` so the rule lands in this file's **Session-learned rules** section — Cherny's "most important loop" from the 2026 Sequoia talk.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,28 @@ Demerzel orchestrates cycles across sibling repos via JSON-on-disk contracts (th
 - **tars** (`../tars/`, F# grammar + metacognition): cross-model theory validator.
 
 Locked-field changes need cross-repo coordination; the Galactic Protocol and `governance/demerzel/schemas/capability-registry.json` are Demerzel's own equivalents. The `links.supersedes` pattern in `optick-sae-artifact` is how to introduce a non-breaking baseline shift without freezing a schema. Contracts marked v0.1.x in their headers remain drafts until their Phase 4 freeze milestones.
+
+## Karpathy 4 Rules — AI coding discipline
+
+These rules apply to every Claude proposal that touches code:
+
+1. **Think before coding.** State your interpretation of the request + assumptions; ask one clarifying question if anything is ambiguous; wait for confirmation before writing code.
+2. **Simplicity first.** Write minimum code that solves the exact problem. No speculative features, no future-proofing.
+3. **Surgical changes only.** Only modify code directly related to the request. Don't refactor adjacent code, don't fix unrelated style issues.
+4. **Goal-driven execution.** Transform every task into verifiable success criteria. Loop until each is demonstrably met. "Task completed" ≠ "goal achieved."
+
+Self-improvement reflex: when the user corrects you, invoke `/correct` so the rule lands in this file's **Session-learned rules** section — Cherny's "most important loop" from the 2026 Sequoia talk.
+
+## Session continuity (Cherny pattern)
+
+- `/digest` — captures meaningful session state (cursor, in-flight, hypotheses, success criteria) to `state/digests/latest.md`. Auto-fallback via `.claude/hooks/precompact-digest.ps1`; auto-injected on next session via `.claude/hooks/sessionstart-digest.ps1`. See `.claude/skills/digest/SKILL.md`.
+- `/learnings` — captures surprises (non-obvious facts worth grep-finding later) into `docs/solutions/<category>/<date>-<topic>.md`.
+- `/correct` — turns user corrections into permanent rules in this CLAUDE.md.
+
+The hooks are validated in CI by `.github/workflows/karpathy-cherny-discipline.yml`.
+
+## Session-learned rules
+
+_Appended by `/correct` when the user corrects an approach. Persists across sessions._
+
+(none yet)

--- a/docs/contracts/digest-schema.json
+++ b/docs/contracts/digest-schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://guitar-alchemist/contracts/session-digest-v1.json",
+  "title": "Session Digest",
+  "description": "Frontmatter schema for state/digests/latest.md. The markdown body follows the section structure documented in .claude/skills/digest/SKILL.md. Karpathy R11: every AI step declares an output schema; runtime rejects mismatches.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "session_id", "written_at", "trigger", "branch", "head_sha", "head_subject"],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "session_id": { "type": "string", "minLength": 1 },
+    "written_at": { "type": "string", "format": "date-time" },
+    "trigger": {
+      "type": "string",
+      "enum": ["digest-skill", "precompact-hook-fallback", "stop-hook-finalize", "auto-write-routine"]
+    },
+    "branch": { "type": "string" },
+    "head_sha": { "type": "string" },
+    "head_subject": { "type": "string" },
+    "open_pr": { "type": ["string", "null"] },
+    "last_model_update": { "type": ["string", "null"], "format": "date-time" },
+    "success_criteria": {
+      "type": "array",
+      "description": "Karpathy R4: every Next action declares testable criteria. The next /digest invocation marks each as achieved / in-progress / abandoned.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["criterion", "status"],
+        "properties": {
+          "criterion": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["pending", "in-progress", "achieved", "abandoned"] },
+          "evidence": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}

--- a/state/digests/README.md
+++ b/state/digests/README.md
@@ -1,0 +1,40 @@
+# state/digests/
+
+Session-digest artifacts. Captures the **meaningful state of a session**
+(current cursor, in-flight work, live hypotheses, open questions,
+do-NOT-carry-forward, success criteria) so the next session can re-enter
+without re-discovering context cold.
+
+## Structure
+
+```
+state/digests/
+├── README.md           — this file (tracked)
+├── latest.md           — current digest (gitignored, single-slot)
+├── .activity-counter   — mutation counter for staleness nudge (gitignored)
+└── archive/            — historical digests (gitignored)
+    └── <ts>-<sessionId>.md
+```
+
+## Who writes
+
+| Writer | Trigger | Content |
+|---|---|---|
+| `/digest` skill | Model-invoked at breakpoints | Rich — all sections populated |
+| `.claude/hooks/precompact-digest.ps1` (PreCompact hook) | Auto on compaction | Metadata only (fallback if /digest didn't run) |
+| `.claude/hooks/digest-stop-finalize.ps1` (Stop hook) | Auto on session end | Metadata only (if /digest didn't run in last 10 min) |
+
+## Who reads
+
+- **`.claude/hooks/sessionstart-digest.ps1`** (SessionStart hook) — emits
+  `latest.md` to stdout; Claude Code injects it as `additionalContext`
+  for the model on session start.
+
+## Distinctions from adjacent artifacts
+
+| Artifact | Captures | Lifetime |
+|---|---|---|
+| `state/digests/latest.md` | **state** — current cursor, in-flight, hypotheses | per session, gitignored |
+| `CLAUDE.md` § Session-learned rules | **behavioural rules** appended by `/correct` | permanent, tracked |
+
+See `.claude/skills/digest/SKILL.md` for the schema + invocation rules.


### PR DESCRIPTION
## Summary

Propagates the full Karpathy 4 Rules + Cherny session-digest discipline pattern from GA (PR [GuitarAlchemist/ga#210](https://github.com/GuitarAlchemist/ga/pull/210)) — companion to [tars#20](https://github.com/GuitarAlchemist/tars/pull/20). 14 artifacts under `.claude/hooks/`, `.claude/skills/`, `docs/contracts/`, `state/digests/`, plus CI discipline check.

## What ships

**Hooks (`.claude/hooks/*.ps1`):** PreCompact + SessionStart + UserPromptSubmit + PostToolUse + Stop. See commit body for details.

**Skills:**
- `/digest` — model-driven session-state writer with testable `success_criteria` (Karpathy R4: *task complete ≠ goal achieved*)
- `/correct` — self-improvement reflex: user correction → permanent rule in `CLAUDE.md` (Cherny's *most important loop* from the 2026 Sequoia talk)

**Schema + CLAUDE.md addendum:** Karpathy 4 Rules section + Session continuity pointers + Session-learned rules section appended by `/correct`.

**CI discipline:** `.github/workflows/karpathy-cherny-discipline.yml` validates on PR — schema well-formed, CLAUDE.md addendum present, all 6 hooks exist, settings.json valid, both skills present, committed digest archives conform.

## Test plan

- [ ] `karpathy-cherny-discipline.yml` passes on this PR
- [ ] Manual `/digest` invocation writes a schema-valid `state/digests/latest.md`
- [ ] `/correct` appends a rule to `CLAUDE.md § Session-learned rules`
- [ ] PreCompact hook fires and writes valid digest on next auto-compaction

## Reference

- GA PR [#210](https://github.com/GuitarAlchemist/ga/pull/210)
- tars PR [#20](https://github.com/GuitarAlchemist/tars/pull/20)
- Plan: `ga/docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md`
- Cherny 2026 Sequoia talk: "Why Coding Is Solved, and What Comes Next" (YouTube `SlGRN8jh2RI`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)