### PR TITLE
feat(quality): schema-pin sidecar for state/quality-trend/** (canonical coordinator)

### DIFF
--- a/state/quality-trend/_schema.json
+++ b/state/quality-trend/_schema.json
@@ -1,0 +1,18 @@
+{
+  "$comment": "Schema pin declaration for state/quality-trend/** and state/pdca/**-quality-trend.pdca.json artifacts in Demerzel. Phase 0 deliverable #5 of ga/docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md.",
+  "schema_version": 1,
+  "applies_to_path": "state/quality-trend/** + state/pdca/*quality-trend*",
+  "pins": {
+    "OPTIC-K": "v1.8",
+    "qa_verdict_schema": "ga/docs/contracts/qa-verdict.schema.json (vendored upstream — Demerzel is the canonical consumer / aggregator)",
+    "ix_optick_sae_artifact_schema": "ga/docs/contracts/optick-sae-artifact.schema.json (vendored upstream)",
+    "demerzel_constitution": "constitutions/asimov.constitution.yaml",
+    "demerzel_capability_registry": "schemas/capability-registry.json"
+  },
+  "policy": {
+    "scope": "Quality-trend JSONL entries appended AFTER this file's git introduction are considered pinned to these versions. Pre-existing entries in 2026-05.jsonl are implicitly draft/v0.",
+    "bump_rule": "Demerzel is the cross-repo coordinator. On OPTIC-K or qa_verdict_schema bump, this file MUST be updated FIRST (before ga / ix / tars sidecars) so the tribunal can refuse to aggregate verdicts that reference outdated pins.",
+    "jsonl_note": "Optional: appending a header line {\"_schema\":{...}} to 2026-05.jsonl is permitted (v2 plan literal text) but not required — consumers reading the JSONL should fall back to this sidecar for the canonical pin set.",
+    "owner": "Demerzel maintainer (cross-repo coordinator role)"
+  }
+}


### PR DESCRIPTION
## Summary

Phase 0 deliverable #5 of [ga v2 plan](https://github.com/GuitarAlchemist/ga/blob/main/docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md). **Demerzel is the cross-repo coordinator role** — this sidecar is *upstream* of the ga / ix / tars sidecars: on any OPTIC-K or qa_verdict_schema bump, this file MUST be updated FIRST so the tribunal can refuse to aggregate verdicts referencing outdated pins.

## What ships

One file: `state/quality-trend/_schema.json` pinning:

| Pin | Value |
|---|---|
| OPTIC-K | v1.8 |
| qa_verdict_schema | ga/docs/contracts/qa-verdict.schema.json (Demerzel = canonical consumer / aggregator) |
| ix_optick_sae_artifact_schema | ga/docs/contracts/optick-sae-artifact.schema.json |
| demerzel_constitution | constitutions/asimov.constitution.yaml |
| demerzel_capability_registry | schemas/capability-registry.json |

## Why sidecar (not JSONL header)

The v2 plan literal text says "JSONL files get a leading `{\"_schema\":...}` header line." For `state/quality-trend/2026-05.jsonl`, that's brittle — line-by-line consumers might parse the header as a malformed data record. Sidecar is less brittle. The sidecar text explicitly permits appending a header line if a downstream tool prefers it.

## Companion PRs

- [ga#212](https://github.com/GuitarAlchemist/ga/pull/212), [ix#TBD](https://github.com/GuitarAlchemist/ix/pulls), tars — all add the same sidecar shape with repo-specific pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)