### PR TITLE
feat: vendor qa-verdict.schema.json from ga + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# CODEOWNERS — required reviewer rules
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Rules below are *additive* to branch protection. GitHub requires a CODEOWNERS
+# reviewer on PRs touching listed paths when branch protection enables it.
+#
+# Maintainer: @spareilleux.
+
+# ============================================================================
+# Vendored cross-repo schemas — canonical source lives in ga/docs/contracts/
+# ============================================================================
+# These are copies of ga/docs/contracts/*.schema.json. The vendored copy
+# MUST NOT drift from canonical; CODEOWNERS enforces human review on every
+# update so a malicious schema widening upstream can't auto-propagate.
+# See `_vendored.drift_policy` field in each schema file for the bump rule.
+
+/schemas/contracts/                                @spareilleux
+/schemas/contracts/qa-verdict.schema.json          @spareilleux
+
+# ============================================================================
+# Demerzel-canonical governance schemas
+# ============================================================================
+# These are schemas Demerzel OWNS (consumed by ga / ix / tars but not
+# vendored from anywhere). Bumping them is a cross-repo coordination event;
+# require human review.
+/schemas/persona.schema.json                       @spareilleux
+/schemas/capability-registry.json                  @spareilleux
+/constitutions/                                    @spareilleux
+/policies/                                         @spareilleux
+
+# ============================================================================
+# IXQL pipelines — load-bearing for the QA Architect Tribunal
+# ============================================================================
+/pipelines/qa-architect-cycle.ixql                 @spareilleux

--- a/schemas/contracts/qa-verdict.schema.json
+++ b/schemas/contracts/qa-verdict.schema.json
@@ -1,0 +1,435 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://guitar-alchemist/contracts/qa-verdict-v1.json",
+  "title": "QA Verdict",
+  "description": "Cross-repo QA verdict shape v0.1.0. Source: docs/contracts/2026-05-02-qa-verdict.contract.md.",
+  "_vendored": {
+    "canonical_source": "https://github.com/GuitarAlchemist/ga/blob/main/docs/contracts/qa-verdict.schema.json",
+    "schema_source_commit_sha": "9c368eeeb56a81b9f156387e8e825e053c78f3ad",
+    "vendored_at": "2026-05-15",
+    "vendored_by": "Phase 0 deliverable #2 of ga/docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md",
+    "drift_policy": "This vendored copy MUST NOT diverge from the canonical. Any GA-side change requires a coordinated PR in this repo to update BOTH schema_source_commit_sha + the schema content. CODEOWNERS in .github/CODEOWNERS enforces human review.",
+    "drift_check": "Future CI step in karpathy-cherny-discipline.yml should diff against the canonical at schema_source_commit_sha via gh api repos/GuitarAlchemist/ga/contents/docs/contracts/qa-verdict.schema.json?ref=<sha> and fail PR on mismatch."
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "verdict_id",
+    "produced_at",
+    "producer",
+    "producer_version",
+    "target",
+    "risk_tier",
+    "verdict",
+    "blast_radius",
+    "evidence",
+    "followups",
+    "reviewer_chain",
+    "narrative"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "verdict_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable, sortable. Pattern: <iso8601>-<target_kind>-<short_id>-<producer>."
+    },
+    "produced_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "producer": {
+      "type": "string",
+      "enum": [
+        "qa-architect-cycle",
+        "qa-architect-agent",
+        "ix-adversarial-runner",
+        "tars-test-designer",
+        "ce-code-review",
+        "manual"
+      ]
+    },
+    "producer_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[A-Za-z0-9.-]+)?$"
+    },
+    "target": {
+      "$ref": "#/$defs/target"
+    },
+    "risk_tier": {
+      "type": "string",
+      "enum": [
+        "P0",
+        "P1",
+        "P2",
+        "P3"
+      ]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "block",
+        "merge_with_followups",
+        "pass",
+        "informational"
+      ]
+    },
+    "blast_radius": {
+      "$ref": "#/$defs/blast_radius"
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/evidence"
+      }
+    },
+    "followups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/followup"
+      }
+    },
+    "reviewer_chain": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/reviewer_entry"
+      }
+    },
+    "narrative": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "properties": {
+        "pr": {
+          "type": "string"
+        },
+        "plan": {
+          "type": "string"
+        },
+        "knowledge_graph_node": {
+          "type": "string"
+        },
+        "supersedes": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "verdict=block requires risk_tier=P0",
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "block"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "risk_tier": {
+            "const": "P0"
+          }
+        }
+      }
+    },
+    {
+      "$comment": "verdict=informational requires risk_tier=P3",
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "informational"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "risk_tier": {
+            "const": "P3"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "repo",
+        "ref"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "pull_request",
+            "commit",
+            "branch",
+            "release",
+            "quality_snapshot",
+            "scheduled_sweep"
+          ]
+        },
+        "repo": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "ref": {
+          "type": "string"
+        },
+        "sha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "base_sha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "blast_radius": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "layers_touched",
+        "one_way_doors_crossed",
+        "invariants_at_risk",
+        "components_reached",
+        "estimated_blast_score"
+      ],
+      "properties": {
+        "layers_touched": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "core",
+              "domain",
+              "analysis",
+              "ai_ml",
+              "orchestration",
+              "apps",
+              "frontend",
+              "infra",
+              "docs"
+            ]
+          }
+        },
+        "one_way_doors_crossed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "invariants_at_risk": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "components_reached": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "estimated_blast_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "test_run",
+            "semantic_basin",
+            "quality_snapshot",
+            "adversarial_replay",
+            "static_analysis",
+            "screenshot_diff",
+            "mutation_test",
+            "contract_check",
+            "manual_note"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "outcome": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "pass",
+            "fail",
+            "flaky",
+            "skipped",
+            "n/a",
+            null
+          ]
+        },
+        "score": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "baseline": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "guardrail_min": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "guardrail_max": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "delta_from_baseline": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "drift_summary": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "followup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "severity",
+        "title",
+        "rationale",
+        "blocks_merge"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "must_fix",
+            "should_fix",
+            "nice_to_have",
+            "info"
+          ]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1
+        },
+        "location": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposed_test": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "blocks_merge": {
+          "type": "boolean"
+        }
+      }
+    },
+    "reviewer_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "agent",
+        "role"
+      ],
+      "properties": {
+        "agent": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "blast_radius",
+            "semantic_judge",
+            "regression_replay",
+            "gap_analysis",
+            "contract_audit",
+            "accessibility",
+            "performance",
+            "security",
+            "architecture",
+            "human"
+          ]
+        },
+        "score": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "notes": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 0 deliverable #2 of [ga v2 plan](https://github.com/GuitarAlchemist/ga/blob/main/docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md). Companion PR [ga#215](https://github.com/GuitarAlchemist/ga/pull/215) adds CODEOWNERS on the canonical source.

## What ships

1. **`schemas/contracts/qa-verdict.schema.json`** — vendored copy of ga's canonical, with a `_vendored` metadata block recording:
   - `canonical_source`: GitHub URL of ga's master copy
   - `schema_source_commit_sha`: `9c368eeeb56a81b9f156387e8e825e053c78f3ad` (ga main HEAD 2026-05-15)
   - `drift_policy`: any GA-side change requires a coordinated PR here
   - `drift_check`: future CI step should `gh api repos/GuitarAlchemist/ga/contents/...?ref=<sha>` and diff
2. **`.github/CODEOWNERS`** — covers `/schemas/contracts/` + Demerzel-canonical governance + tribunal pipelines

## Why

2026-05-15 octo security review HIGH finding: auto-propagation of GA schema changes to vendored copies could silently inherit a malicious schema widening (e.g. permissive `producer` enum value). CODEOWNERS on both sides + drift-check CI = belt and suspenders.

## When it activates

CODEOWNERS becomes enforcing once branch protection enables required review on `master` (admin action, Phase 3). Until then, it's documentation + a guide for reviewers.

## Companion PRs

- [ga#215](https://github.com/GuitarAlchemist/ga/pull/215) — CODEOWNERS on canonical schema source

🤖 Generated with [Claude Code](https://claude.com/claude-code)