### PR TITLE
ci: pin agent blackbox beta release

### DIFF
--- a/.github/workflows/agent-blackbox.yml
+++ b/.github/workflows/agent-blackbox.yml
@@ -11,6 +11,7 @@ permissions:
   checks: write
 
 env:
+  AGENT_BLACKBOX_REF: "v0.1.0-beta.1"
   VERIFY_COMMAND: "python scripts/validate_governance.py"
   IX_BLAST_RADIUS_BUILD_COMMAND: ""
   IX_BLAST_RADIUS_COMMAND: ""
@@ -33,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: GuitarAlchemist/agent-blackbox
+          ref: ${{ env.AGENT_BLACKBOX_REF }}
           path: .agent-blackbox
           token: ${{ secrets.AGENT_BLACKBOX_TOKEN || github.token }}
 


### PR DESCRIPTION
## Summary
- pin Agent Blackbox checkout to v0.1.0-beta.1
- keep governance verification behavior unchanged

## Verification
- git diff --check