### PR TITLE
feat(hooks): periodic mid-session digest + auto /correct + PR rationale capture

### DIFF
--- a/.claude/hooks/correction-detector.ps1
+++ b/.claude/hooks/correction-detector.ps1
@@ -1,0 +1,57 @@
+# UserPromptSubmit hook — Enhancement 2 (Cherny auto /correct trigger).
+# If the user's prompt matches correction language, nudge Claude to invoke
+# /correct so the rule lands in CLAUDE.md. Throttled: fires once per N=5 prompts.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+$repoRoot = & git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) { exit 0 }
+
+$digestDir   = Join-Path $repoRoot 'state/digests'
+$counterPath = Join-Path $digestDir '.correction-counter'
+
+if (-not (Test-Path $digestDir)) {
+    New-Item -ItemType Directory -Path $digestDir -Force | Out-Null
+}
+
+# Read JSON payload from stdin (UserPromptSubmit format: {prompt, session_id, ...})
+$prompt = ''
+try {
+    $stdinRaw = [Console]::In.ReadToEnd()
+    if ($stdinRaw) {
+        $payload = $stdinRaw | ConvertFrom-Json
+        if ($payload.prompt)      { $prompt = $payload.prompt }
+        elseif ($payload.user_prompt) { $prompt = $payload.user_prompt }
+    }
+} catch {}
+
+if (-not $prompt) { exit 0 }
+
+# Match correction language (case-insensitive, anchored at start, word boundary)
+$first = $prompt.Substring(0, [Math]::Min(200, $prompt.Length)).ToLowerInvariant()
+if ($first -notmatch "^(no|don't|dont|stop|wait|actually|that's wrong|thats wrong|incorrect)\b") {
+    exit 0
+}
+
+# Throttle: increment counter, fire only on first or every Nth thereafter
+$throttle = 5
+if ($env:DEMERZEL_CORRECTION_THROTTLE -and $env:DEMERZEL_CORRECTION_THROTTLE -match '^\d+$') {
+    $throttle = [int]$env:DEMERZEL_CORRECTION_THROTTLE
+}
+
+$count = 0
+if (Test-Path $counterPath) {
+    $raw = (Get-Content $counterPath -Raw).Trim()
+    if ($raw -match '^\d+$') { $count = [int]$raw }
+}
+$count++
+Set-Content -Path $counterPath -Value $count -Encoding UTF8
+
+if ($count -ne 1 -and ($count % $throttle) -ne 0) { exit 0 }
+
+$msg = 'Detected correction language. Consider invoking /correct to formalize this into CLAUDE.md so the rule persists across sessions (Cherny self-improvement loop).'
+
+# UserPromptSubmit JSON output uses additionalContext to inject a system reminder.
+$obj = [PSCustomObject]@{ additionalContext = "[correction-nudge] $msg" }
+$obj | ConvertTo-Json -Compress
+exit 0

--- a/.claude/hooks/digest-activity-tracker.ps1
+++ b/.claude/hooks/digest-activity-tracker.ps1
@@ -1,24 +1,99 @@
 # PostToolUse hook (matcher: Edit|Write|Bash) — increments mutation counter.
 # /digest skill resets the counter on invocation. Karpathy R4.
+#
+# Enhancement 1 (Cherny periodic mid-session digest): when activity threshold OR
+# time threshold is hit, write a mid-session metadata digest so we survive
+# crashes/network drops without waiting for Stop or PreCompact.
 
 $ErrorActionPreference = 'SilentlyContinue'
 
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
 
-$digestDir   = Join-Path $repoRoot 'state/digests'
-$counterPath = Join-Path $digestDir '.activity-counter'
+$digestDir      = Join-Path $repoRoot 'state/digests'
+$archDir        = Join-Path $digestDir 'archive'
+$counterPath    = Join-Path $digestDir '.activity-counter'
+$midCounterPath = Join-Path $digestDir '.activity-count'
+$latest         = Join-Path $digestDir 'latest.md'
 
-if (-not (Test-Path $digestDir)) {
-    New-Item -ItemType Directory -Path $digestDir -Force | Out-Null
-}
+if (-not (Test-Path $digestDir)) { New-Item -ItemType Directory -Path $digestDir -Force | Out-Null }
+if (-not (Test-Path $archDir))   { New-Item -ItemType Directory -Path $archDir -Force | Out-Null }
 
+# Existing mutation counter (drives staleness nudge)
 $count = 0
 if (Test-Path $counterPath) {
     $raw = (Get-Content $counterPath -Raw).Trim()
     if ($raw -match '^\d+$') { $count = [int]$raw }
 }
 $count++
-
 Set-Content -Path $counterPath -Value $count -Encoding UTF8
+
+# Enhancement 1: independent counter for mid-session digest gating
+$midCount = 0
+if (Test-Path $midCounterPath) {
+    $raw = (Get-Content $midCounterPath -Raw).Trim()
+    if ($raw -match '^\d+$') { $midCount = [int]$raw }
+}
+$midCount++
+Set-Content -Path $midCounterPath -Value $midCount -Encoding UTF8
+
+# Thresholds: N=20 mutations OR M=30 minutes since last digest
+$thresholdCount = 20
+$thresholdMin   = 30
+if ($env:DEMERZEL_DIGEST_MID_COUNT -and $env:DEMERZEL_DIGEST_MID_COUNT -match '^\d+$') { $thresholdCount = [int]$env:DEMERZEL_DIGEST_MID_COUNT }
+if ($env:DEMERZEL_DIGEST_MID_MIN   -and $env:DEMERZEL_DIGEST_MID_MIN   -match '^\d+$') { $thresholdMin   = [int]$env:DEMERZEL_DIGEST_MID_MIN }
+
+$ageMin = 99999
+if (Test-Path $latest) {
+    $ageMin = [int]((Get-Date) - (Get-Item $latest).LastWriteTime).TotalMinutes
+}
+
+$shouldWrite = $false
+if ($midCount -ge $thresholdCount) { $shouldWrite = $true }
+elseif ($ageMin -ge $thresholdMin -and $midCount -ge 3) { $shouldWrite = $true }
+
+if (-not $shouldWrite) { exit 0 }
+
+# Reset mid-session counter
+Set-Content -Path $midCounterPath -Value 0 -Encoding UTF8
+
+$tsIso  = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+$tsFile = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
+
+$branch   = & git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null
+$headSha  = & git -C $repoRoot rev-parse --short HEAD 2>$null
+$headSubj = & git -C $repoRoot log -1 --format='%s' 2>$null
+
+# Rotate existing latest into archive
+if (Test-Path $latest) {
+    Copy-Item $latest (Join-Path $archDir "$tsFile-pre-mid.md") -Force
+}
+
+$midPath = Join-Path $digestDir "mid-$tsFile.md"
+$md = @"
+---
+schema_version: 1
+session_id: mid-session-auto
+written_at: $tsIso
+trigger: activity-tracker-mid-session
+branch: $branch
+head_sha: $headSha
+head_subject: $headSubj
+mutations_since_last: $midCount
+---
+
+# Session digest (mid-session auto — activity threshold reached)
+
+**Branch:** $branch @ $headSha — $headSubj
+
+## Model-driven sections
+
+_Auto-written by digest-activity-tracker after $midCount mutations / ${ageMin}m since last digest.
+Invoke ``/digest`` at your next natural breakpoint to populate **Next action**,
+**In-flight**, **Live hypotheses**, **Open questions**, **Do NOT carry forward**,
+and **Success criteria**._
+"@
+
+Set-Content -Path $midPath -Value $md -Encoding UTF8
+Copy-Item $midPath $latest -Force
 exit 0

--- a/.claude/hooks/pr-rationale-capture.ps1
+++ b/.claude/hooks/pr-rationale-capture.ps1
@@ -1,0 +1,86 @@
+# PostToolUse(matcher=Bash) hook — Enhancement 3 (Cherny PR rationale capture).
+# When a Bash invocation runs `gh pr create`, snapshot the title + body + diff
+# stats to state/digests/pr-<num>-<slug>.md so the rationale survives later edits.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+$repoRoot = & git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) { exit 0 }
+
+# Read PostToolUse JSON payload from stdin: {tool_input: {command}, tool_response: {output}}
+$cmd = ''
+$output = ''
+try {
+    $stdinRaw = [Console]::In.ReadToEnd()
+    if (-not $stdinRaw) { exit 0 }
+    $payload = $stdinRaw | ConvertFrom-Json
+    if ($payload.tool_input -and $payload.tool_input.command) { $cmd = $payload.tool_input.command }
+    if ($payload.tool_response) {
+        if ($payload.tool_response.output) { $output = $payload.tool_response.output }
+        elseif ($payload.tool_response -is [string]) { $output = $payload.tool_response }
+    }
+} catch { exit 0 }
+
+if (-not $cmd) { exit 0 }
+if ($cmd -notmatch 'gh\s+pr\s+create') { exit 0 }
+
+# Extract --title "..." or --title '...'
+$title = ''
+$mTitle = [regex]::Match($cmd, '--title\s+(?:"([^"]*)"|''([^'']*)'')')
+if ($mTitle.Success) {
+    $title = if ($mTitle.Groups[1].Value) { $mTitle.Groups[1].Value } else { $mTitle.Groups[2].Value }
+}
+
+# Extract --body "..." or --body '...' (best-effort — heredoc bodies show as $(cat ...))
+$body = ''
+$mBody = [regex]::Match($cmd, '--body\s+(?:"([\s\S]*?)"(?=\s|$)|''([\s\S]*?)''(?=\s|$))')
+if ($mBody.Success) {
+    $body = if ($mBody.Groups[1].Value) { $mBody.Groups[1].Value } else { $mBody.Groups[2].Value }
+}
+
+# Extract PR number from gh CLI output URL (https://github.com/x/y/pull/123)
+$prNum = 'unknown'
+$mPr = [regex]::Match($output, 'pull/(\d+)')
+if ($mPr.Success) { $prNum = $mPr.Groups[1].Value }
+
+# Slug from title
+$slug = ($title.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-')
+if ($slug.Length -gt 40) { $slug = $slug.Substring(0, 40).Trim('-') }
+if (-not $slug) { $slug = 'untitled' }
+
+$digestDir = Join-Path $repoRoot 'state/digests'
+if (-not (Test-Path $digestDir)) { New-Item -ItemType Directory -Path $digestDir -Force | Out-Null }
+$outPath = Join-Path $digestDir "pr-$prNum-$slug.md"
+
+$tsIso     = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+$branch    = & git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null
+$shortStat = & git -C $repoRoot diff --shortstat HEAD~1 2>$null
+if (-not $shortStat) { $shortStat = '' }
+
+$md = @"
+---
+schema_version: 1
+trigger: pr-rationale-capture
+captured_at: $tsIso
+branch: $branch
+pr_number: $prNum
+diff_shortstat: $shortStat
+---
+
+# PR #$prNum — $title
+
+**Branch:** $branch
+**Captured:** $tsIso
+**Diff:** $shortStat
+
+## Title
+
+$title
+
+## Body
+
+$body
+"@
+
+Set-Content -Path $outPath -Value $md -Encoding UTF8
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,6 +35,10 @@
           {
             "type": "command",
             "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/.claude/hooks/digest-staleness-nudge.ps1"
+          },
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/.claude/hooks/correction-detector.ps1"
           }
         ]
       }
@@ -46,6 +50,15 @@
           {
             "type": "command",
             "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/.claude/hooks/digest-activity-tracker.ps1"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh -NoProfile -File $CLAUDE_PROJECT_DIR/.claude/hooks/pr-rationale-capture.ps1"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Ports the three Cherny session-continuity hooks from ix PR #51 to Demerzel (PowerShell port of the bash originals). No governance/ files touched.

- **Mid-session digest** (`digest-activity-tracker.ps1`): on 20 mutations OR 30 min since last digest, write `state/digests/mid-<ISO>.md` + rotate `latest.md`. Survives crashes/network drops.
- **Correction detector** (`correction-detector.ps1`): UserPromptSubmit hook — detects `no|don't|stop|wait|actually|incorrect` and nudges `/correct`. Throttled 1-in-5.
- **PR rationale capture** (`pr-rationale-capture.ps1`): PostToolUse(Bash) — snapshots `gh pr create` title+body+diff to `state/digests/pr-<num>-<slug>.md`.

settings.json registers correction-detector under UserPromptSubmit and pr-rationale-capture under PostToolUse(Bash).

## Test plan

- [x] `correction-detector.ps1` returns `{"additionalContext":"..."}` on stdin `{"prompt":"stop that approach"}`
- [x] `pr-rationale-capture.ps1` writes `state/digests/pr-55-feat-x.md` given synthetic `gh pr create` payload
- [x] `digest-activity-tracker.ps1` still increments `.activity-counter` per invocation
- [ ] Mid-session digest fires once threshold is reached in a real session

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>