### PR TITLE
fix(seldon-plan): loud failure replaces dead-green agent invocation

### DIFF
--- a/.github/workflows/seldon-plan.yml
+++ b/.github/workflows/seldon-plan.yml
@@ -120,12 +120,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SELDON_FORCE_DEPARTMENT: ${{ github.event.inputs.department }}
         run: |
-          echo "Starting Seldon Plan research cycle"
-          echo "Department override: ${SELDON_FORCE_DEPARTMENT:-auto}"
-          # Invoke Claude Code with the seldon-plan skill
-          # claude -p "/seldon plan${SELDON_FORCE_DEPARTMENT:+ $SELDON_FORCE_DEPARTMENT}" --output-format json
-          # Note: actual invocation depends on Claude Code CLI availability in CI
-          echo "Cycle invocation placeholder — see policies/seldon-plan-policy.yaml for full spec"
+          if [ "${SELDON_PLANNER_INTENTIONALLY_DISABLED:-false}" = "true" ]; then
+            echo "::notice::Seldon Plan intentionally disabled via SELDON_PLANNER_INTENTIONALLY_DISABLED=true"
+            echo "Skipping the planner this run by explicit opt-out."
+            exit 0
+          fi
+          echo "::error::Seldon Plan agent invocation is disabled (commented out)." >&2
+          echo "::error::This scheduled workflow was producing ~150 dead-green runs/month." >&2
+          echo "::error::Per ix#63 workflows audit (2026-05-24), green CI on placeholder work is worse than red." >&2
+          echo "::error::" >&2
+          echo "::error::To fix:" >&2
+          echo "::error::  (a) Restore the 'claude --plan ...' invocation in this step, OR" >&2
+          echo "::error::  (b) Delete this workflow if Seldon Plan is no longer needed, OR" >&2
+          echo "::error::  (c) Set SELDON_PLANNER_INTENTIONALLY_DISABLED=true in the workflow env to pause" >&2
+          echo "::error::      explicitly (this still requires re-evaluation before re-enabling)." >&2
+          exit 1
 
       - name: Commit and push state
         if: |


### PR DESCRIPTION
## Summary
The `Run Seldon Plan cycle` step in `.github/workflows/seldon-plan.yml` had its `claude --plan ...` invocation commented out and replaced with `echo` placeholders. Cron fires 5x/day → ~150 dead-green runs/month. Per ga's `feedback_green_but_dead` memory (recorded 2026-05-24 after the same pattern produced 50 days of green Seldon runs at zero output), this is exactly the anti-pattern to surface as loud red.

## Behavior

| Before | After |
|---|---|
| `echo "skipped" && exit 0` | `echo "::error::Seldon Plan agent invocation is disabled..." && exit 1` |
| Cron runs report success indefinitely | Cron runs report failure until a human decides |
| No way to pause intentionally — only by editing the workflow | Set `SELDON_PLANNER_INTENTIONALLY_DISABLED=true` to pause explicitly |

## Three options a reviewer should pick from
1. **Restore the `claude --plan ...` invocation** if Seldon Plan is still needed.
2. **Delete this workflow** if Seldon Plan has been superseded.
3. **Set `SELDON_PLANNER_INTENTIONALLY_DISABLED=true`** in the workflow env to pause explicitly. This still requires the workflow author to re-evaluate before re-enabling (the env var is a tripwire, not a permanent off-switch).

## What this does NOT do
- Does not restore the agent invocation (would need budget + provider config decision).
- Does not delete the workflow (reversible decision, defer to human).
- Does not touch other workflows.

## Companion to
- ix#63 (workflows green-but-dead audit) — this is the action item it surfaced.

## Test plan
- [ ] `yaml.safe_load` parses the modified workflow.
- [ ] Next scheduled run fails red with the diagnostic message visible in PR checks UI.
- [ ] Setting `SELDON_PLANNER_INTENTIONALLY_DISABLED=true` makes the run pass with a `::notice::`.

Generated with [Claude Code](https://claude.com/claude-code)