### PR TITLE
chore(aihero): discipline + /teach skill

### DIFF
--- a/.claude/skills/teach/SKILL.md
+++ b/.claude/skills/teach/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: teach
+description: Personalized AI tutor — turns any topic into a customized, progress-tracked learning course. Use when the user wants to LEARN a concept, skill, language, tool, or domain. Creates a MISSION, curated RESOURCES, iterative lessons with self-checks, and learning-records that persist across sessions. NOT for interrogating the user about their own design (use brainstorming/IDSD for that).
+---
+
+# /teach — personalized learning tutor
+
+Adapted from aihero.dev (`learn-anything-with-my-teach-skill`). Turns the agent
+into a tutor that builds a personalized course for whatever the user wants to learn,
+adapted to their goal and proficiency, with progress tracked across sessions.
+
+## When to use
+The user wants to **learn** something. NOT for the agent interrogating the user
+about *their* design/plan — that's `brainstorming` / the IDSD intent gate.
+
+## Workflow
+
+### 1. Assess before teaching (ask one concise batch)
+- **Motivation** — why learn this, and what will they do with it?
+- **Current level** — none / some exposure / intermediate / advanced?
+- **Success criteria** — what does "done" look like concretely?
+- **Modality** — worked examples, theory-first, exercises, analogies, projects?
+
+> "The more detail you give, the better your personalized lessons will be."
+
+### 2. Set up the course under `./learning/<topic>/`
+- `MISSION.md` — goals, current level, success criteria (from step 1).
+- `RESOURCES.md` — curated materials. **Ground every entry in a real, verified
+  source — never fabricate links or citations** (fetch/verify before listing).
+- `reference/glossary.md` — key terms, grown as the course proceeds.
+- `lessons/` — one file per lesson (Markdown by default; HTML if embedded
+  quizzes/audio are wanted — optional, heavier).
+- `learning-records/` — what was covered, what landed, what didn't.
+
+### 3. Deliver lessons iteratively
+- One lesson at a time, scoped to the assessed level — short and concrete,
+  prefer worked examples over walls of theory.
+- End each lesson with a brief self-check (a few questions + answers).
+- Stop and wait for the learner to report how it went.
+
+### 4. Adapt
+- After each lesson, update `learning-records/` and `reference/glossary.md`.
+- Generate the next lesson based on what landed and what was missed.
+
+## Guardrails
+- Resources must be real and verified — no invented citations (ecosystem rule).
+- Keep lessons tight; one concept at a time; check understanding before advancing.
+- Persist progress so a later session can resume from `learning-records/`.

--- a/.claude/skills/teach/SKILL.md
+++ b/.claude/skills/teach/SKILL.md
@@ -46,3 +46,6 @@ about *their* design/plan — that's `brainstorming` / the IDSD intent gate.
 - Resources must be real and verified — no invented citations (ecosystem rule).
 - Keep lessons tight; one concept at a time; check understanding before advancing.
 - Persist progress so a later session can resume from `learning-records/`.
+
+## Output hygiene
+Generated course state under `./learning/` is personal and regenerable — it is gitignored and must NOT be committed (add `learning/` to .gitignore on first use).

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 # session-specific and may include in-flight model context.
 state/digests/*
 !state/digests/README.md
+
+# /teach generated courses (personal, regenerable)
+learning/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,22 @@ Spawn 4 teammates (Seldon, Auditor, Architect, Integrator).
 Use Sonnet for Seldon/Integrator, Opus for Architect/Auditor.
 Require plan approval for Architect before implementation.
 ```
+
+## Tracer-bullets + vertical slices (aihero delta, 2026-06-14)
+
+Adopted ecosystem-wide from aihero.dev. Counters AI's "build the whole thing at
+once" failure mode:
+
+- **Tracer-bullet first.** For any non-trivial feature, build the smallest
+  **end-to-end** slice that touches *every* layer, test it, get feedback, then
+  expand — never build layers in isolation. "Context-window constraints make the
+  discipline non-negotiable."
+- **Vertical, not horizontal, decomposition.** Each task/PR is a thin slice
+  cutting through all integration layers (surfacing unknowns early), not a
+  horizontal layer.
+
+Prefer existing planning/review/quality tooling over adding new skills — aihero's
+`/grill-me`, `/to-prd`, `/to-issues`, `/tdd`, `/improve-codebase-architecture`
+are already covered by this ecosystem's brainstorming, planning-doc, test, and
+structural-quality machinery. (The `/teach` skill IS adopted — see
+`.claude/skills/teach`.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,22 @@ The hooks are validated in CI by `.github/workflows/karpathy-cherny-discipline.y
 _Appended by `/correct` when the user corrects an approach. Persists across sessions._
 
 (none yet)
+
+## Tracer-bullets + vertical slices (aihero delta, 2026-06-14)
+
+Adopted ecosystem-wide from aihero.dev. Counters AI's "build the whole thing at
+once" failure mode:
+
+- **Tracer-bullet first.** For any non-trivial feature, build the smallest
+  **end-to-end** slice that touches *every* layer, test it, get feedback, then
+  expand — never build layers in isolation. "Context-window constraints make the
+  discipline non-negotiable."
+- **Vertical, not horizontal, decomposition.** Each task/PR is a thin slice
+  cutting through all integration layers (surfacing unknowns early), not a
+  horizontal layer.
+
+Prefer existing planning/review/quality tooling over adding new skills — aihero's
+`/grill-me`, `/to-prd`, `/to-issues`, `/tdd`, `/improve-codebase-architecture`
+are already covered by this ecosystem's brainstorming, planning-doc, test, and
+structural-quality machinery. (The `/teach` skill IS adopted — see
+`.claude/skills/teach`.)


### PR DESCRIPTION
Ecosystem-wide adoption from aihero.dev:
- Tracer-bullets + vertical-slice discipline added to agent guidance.
- /teach personalized-tutor skill under .claude/skills/teach.
Other aihero skills (grill-me/to-prd/to-issues/tdd/improve-arch) already covered by existing tooling — not duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)