### PR TITLE
feat(hooks): DigestState deep module behind the session-digest hooks

### DIFF
--- a/.claude/hooks/DigestState.psm1
+++ b/.claude/hooks/DigestState.psm1
@@ -174,8 +174,16 @@ function Test-SchemaObject {
     }
     $json = $Fields | ConvertTo-Json -Depth 6
     try {
-        $null = Test-Json -Json $json -SchemaFile $schemaFile -ErrorAction Stop
-        [pscustomobject]@{ Valid = $true; Errors = $null }
+        # Test-Json signals schema failure two ways: a $false return AND/OR a
+        # non-terminating error. -ErrorAction Stop promotes the error to a throw,
+        # but some mismatches only flip the boolean — so honor BOTH. The discarded
+        # boolean was reporting bad digests as Valid=$true (octo review finding).
+        $ok = Test-Json -Json $json -SchemaFile $schemaFile -ErrorAction Stop
+        if ($ok) {
+            [pscustomobject]@{ Valid = $true; Errors = $null }
+        } else {
+            [pscustomobject]@{ Valid = $false; Errors = 'schema validation failed (Test-Json returned $false)' }
+        }
     } catch {
         [pscustomobject]@{ Valid = $false; Errors = $_.Exception.Message }
     }
@@ -243,7 +251,16 @@ function Write-Digest {
     New-Item -ItemType Directory -Path $paths.DigestDir, $paths.ArchiveDir -Force | Out-Null
 
     if (-not $RepoFacts) { $RepoFacts = Get-RepoFacts -RepoRoot $root }
-    if ($BodyFile -and (Test-Path $BodyFile)) { $Body = Get-Content $BodyFile -Raw }
+    if ($BodyFile) {
+        # A caller that passed -BodyFile but whose path does not resolve (e.g. a
+        # relative path from a non-root working dir) must fail loudly — silently
+        # proceeding would overwrite the digest with an empty body. Fail-open
+        # covers validation quirks, NOT a missing input file (octo review finding).
+        if (-not (Test-Path $BodyFile)) {
+            throw "BodyFile not found: $BodyFile (cwd: $((Get-Location).Path)). Refusing to write a digest with an empty body."
+        }
+        $Body = Get-Content $BodyFile -Raw
+    }
 
     $tsIso  = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
     $tsFile = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
@@ -261,7 +278,11 @@ function Write-Digest {
         if ($LastModelUpdate) { $fields['last_model_update'] = $LastModelUpdate }
         if ($null -ne $MutationsSinceLast) { $fields['mutations_since_last'] = [int]$MutationsSinceLast }
         if ($SuccessCriteriaJson) {
-            try { $fields['success_criteria'] = @($SuccessCriteriaJson | ConvertFrom-Json) } catch {}
+            # Surface parse failures instead of swallowing them — an empty catch
+            # silently dropped the whole success_criteria block on any quoting slip
+            # (octo review finding). Fail-open: warn but still write the digest.
+            try { $fields['success_criteria'] = @($SuccessCriteriaJson | ConvertFrom-Json) }
+            catch { Write-Warning "success_criteria JSON invalid — block dropped: $($_.Exception.Message)" }
         }
         $target = $paths.Latest
         if (Test-Path $target) {

--- a/.claude/hooks/DigestState.psm1
+++ b/.claude/hooks/DigestState.psm1
@@ -1,0 +1,307 @@
+# DigestState.psm1 — the deep module behind the session-digest hooks
+# (Candidate 1, /improve-codebase-architecture 2026-06-21).
+#
+# Mirrors scripts/DomainGate.psm1 (#352): the eight digest hooks used to each
+# re-derive the same primitives — the state/digests path, YAML escaping, git
+# facts, counter I/O, and a late-bound validation call. Those all live here now,
+# once. Hooks become thin DECIDERS ("is it stale?  then call Write-Digest").
+#
+# Interface (small): Get-DigestPaths / Format-Yaml / Format-YamlId /
+# Get-RepoFacts / Get-Counter / Step-Counter / Reset-Counter / Test-Digest /
+# Write-Digest. Everything else is implementation.
+#
+# Validation seam (ADR-0003): Write-Digest validates the OBJECT it constructs
+# (hashtable -> ConvertTo-Json -> Test-Json -SchemaFile) so the rules come from
+# the schema, not hand-coded here. Test-Digest does the same for an existing
+# file's top-level scalars. Pure PowerShell has no YAML parser, so deep nested
+# validation (success_criteria items) stays in the CI Python gate; the write
+# path validates the full object because we build it typed in memory.
+
+Set-StrictMode -Off
+
+# Counter logical-name -> on-disk filename. Names kept for back-compat so an
+# in-flight session's existing counters are not orphaned.
+$script:CounterFiles = @{
+    activity   = '.activity-counter'   # staleness nudge
+    mid        = '.activity-count'     # mid-session auto-digest gate
+    correction = '.correction-counter' # /correct throttle
+}
+
+# Kind -> schema file (relative to repo root).
+$script:SchemaFiles = @{
+    digest    = 'docs/contracts/digest-schema.json'
+    rationale = 'docs/contracts/pr-rationale-schema.json'
+}
+
+function Resolve-RepoRoot {
+    param([string]$RepoRoot)
+    if ($RepoRoot) { return $RepoRoot }
+    $top = & git rev-parse --show-toplevel 2>$null
+    if ($top) { return $top }
+    # Fallback: module lives in <root>/.claude/hooks
+    Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+}
+
+function Get-DigestPaths {
+    # The single home for every session-digest path. Callers ask here instead of
+    # joining 'state/digests' themselves.
+    param([string]$RepoRoot)
+    $root = Resolve-RepoRoot $RepoRoot
+    $dir  = Join-Path $root 'state/digests'
+    [pscustomobject]@{
+        RepoRoot          = $root
+        DigestDir         = $dir
+        ArchiveDir        = Join-Path $dir 'archive'
+        Latest            = Join-Path $dir 'latest.md'
+        ActivityCounter   = Join-Path $dir $script:CounterFiles.activity
+        MidCounter        = Join-Path $dir $script:CounterFiles.mid
+        CorrectionCounter = Join-Path $dir $script:CounterFiles.correction
+    }
+}
+
+function Format-Yaml {
+    # Single-line, length-capped, single-quote-escaped YAML scalar (was the
+    # copy-pasted Get-SafeYaml). Returns the literal 'null' for empty input.
+    param([string]$Value, [int]$MaxLen = 200)
+    if ($null -eq $Value -or $Value -eq '') { return 'null' }
+    $cleaned = ($Value -replace '[\r\n]', ' ')
+    if ($cleaned.Length -gt $MaxLen) { $cleaned = $cleaned.Substring(0, $MaxLen) + '...' }
+    "'$($cleaned -replace "'", "''")'"
+}
+
+function Format-YamlId {
+    # Filename-safe identifier (was the copy-pasted Get-SafeId).
+    param([string]$Value, [string]$Fallback = 'unknown', [int]$MaxLen = 64)
+    if (-not $Value) { return $Fallback }
+    $cleaned = $Value -replace '[\r\n\t]', ''
+    if ($cleaned.Length -gt $MaxLen) { $cleaned = $cleaned.Substring(0, $MaxLen) }
+    if ($cleaned -match '^[A-Za-z0-9._\-]+$') { return $cleaned }
+    $Fallback
+}
+
+function Get-RepoFacts {
+    # The git/gh facts every writer needs, fetched once. Tests inject these
+    # instead (Write-Digest -RepoFacts @{...}) so they never shell out.
+    param([string]$RepoRoot)
+    $root = Resolve-RepoRoot $RepoRoot
+    $openPr = $null
+    if (Get-Command gh -ErrorAction SilentlyContinue) {
+        $prJson = & gh pr view --json number 2>$null
+        if ($prJson) { try { $openPr = "#$(($prJson | ConvertFrom-Json).number)" } catch {} }
+    }
+    [pscustomobject]@{
+        Branch      = (& git -C $root rev-parse --abbrev-ref HEAD 2>$null)
+        HeadSha     = (& git -C $root rev-parse --short HEAD 2>$null)
+        HeadSubject = (& git -C $root log -1 --format='%s' 2>$null)
+        OpenPr      = $openPr
+    }
+}
+
+function Resolve-CounterPath {
+    param([Parameter(Mandatory)][string]$Name, [string]$RepoRoot)
+    if (-not $script:CounterFiles.ContainsKey($Name)) {
+        throw "Unknown counter '$Name' (expected: $($script:CounterFiles.Keys -join ', '))"
+    }
+    Join-Path (Get-DigestPaths -RepoRoot $RepoRoot).DigestDir $script:CounterFiles[$Name]
+}
+
+function Get-Counter {
+    param([Parameter(Mandatory)][string]$Name, [string]$RepoRoot)
+    $path = Resolve-CounterPath -Name $Name -RepoRoot $RepoRoot
+    if (Test-Path $path) {
+        $raw = (Get-Content $path -Raw).Trim()
+        if ($raw -match '^\d+$') { return [int]$raw }
+    }
+    0
+}
+
+function Step-Counter {
+    # Increment, persist, return the new value.
+    param([Parameter(Mandatory)][string]$Name, [string]$RepoRoot)
+    $path = Resolve-CounterPath -Name $Name -RepoRoot $RepoRoot
+    New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
+    $next = (Get-Counter -Name $Name -RepoRoot $RepoRoot) + 1
+    Set-Content -Path $path -Value $next -Encoding UTF8
+    $next
+}
+
+function Reset-Counter {
+    param([Parameter(Mandatory)][string]$Name, [string]$RepoRoot)
+    $path = Resolve-CounterPath -Name $Name -RepoRoot $RepoRoot
+    if (Test-Path $path) { Set-Content -Path $path -Value 0 -Encoding UTF8 }
+}
+
+function ConvertTo-FrontmatterYaml {
+    # Render an [ordered] field map to YAML frontmatter lines. Handles the only
+    # nested shape we emit: success_criteria (array of {criterion,status,evidence}).
+    param([Parameter(Mandatory)][System.Collections.Specialized.OrderedDictionary]$Fields)
+    $lines = @('---')
+    foreach ($entry in $Fields.GetEnumerator()) {
+        $k = $entry.Key; $v = $entry.Value
+        if ($k -eq 'success_criteria') {
+            $lines += 'success_criteria:'
+            foreach ($c in $v) {
+                $lines += "  - criterion: $(Format-Yaml ([string]$c.criterion) 300)"
+                $lines += "    status: $([string]$c.status)"
+                $ev = if ($null -ne $c.evidence) { Format-Yaml ([string]$c.evidence) 300 } else { 'null' }
+                $lines += "    evidence: $ev"
+            }
+            continue
+        }
+        if ($null -eq $v) { $lines += "${k}: null"; continue }
+        if ($v -is [int]) { $lines += "${k}: $v"; continue }
+        $s = [string]$v
+        # Distinguish an empty string (valid string scalar) from $null above —
+        # Format-Yaml maps '' to the literal null, which would re-parse as null.
+        if ($s -eq '') { $lines += "${k}: ''"; continue }
+        $lines += "${k}: $(Format-Yaml $s)"
+    }
+    $lines += '---'
+    $lines -join "`n"
+}
+
+function Test-SchemaObject {
+    # Validate an in-memory field map against a Kind's schema. Returns
+    # {Valid,Errors}. The rules live in the schema (ADR-0003), not here.
+    param(
+        [Parameter(Mandatory)]$Fields,
+        [Parameter(Mandatory)][string]$Kind,
+        [Parameter(Mandatory)][string]$RepoRoot
+    )
+    $schemaFile = Join-Path $RepoRoot $script:SchemaFiles[$Kind]
+    if (-not (Test-Path $schemaFile)) {
+        return [pscustomobject]@{ Valid = $false; Errors = "schema not found: $schemaFile" }
+    }
+    $json = $Fields | ConvertTo-Json -Depth 6
+    try {
+        $null = Test-Json -Json $json -SchemaFile $schemaFile -ErrorAction Stop
+        [pscustomobject]@{ Valid = $true; Errors = $null }
+    } catch {
+        [pscustomobject]@{ Valid = $false; Errors = $_.Exception.Message }
+    }
+}
+
+function Test-Digest {
+    # Validate an existing digest/rationale file's top-level scalars against its
+    # schema. Replaces digest-validate.ps1's hand-coded rules (Candidate 4 digest
+    # half). Deep nested fields (success_criteria items) are validated by CI.
+    param([Parameter(Mandatory)][string]$Path, [string]$RepoRoot, [string]$Kind)
+    $root = Resolve-RepoRoot $RepoRoot
+    if (-not (Test-Path $Path)) {
+        return [pscustomobject]@{ Valid = $false; Errors = "file not found: $Path" }
+    }
+    if (-not $Kind) {
+        $Kind = if ((Split-Path -Leaf $Path) -like 'pr-*') { 'rationale' } else { 'digest' }
+    }
+    $content = Get-Content $Path -Raw
+    if ($content -notmatch '(?s)^---\r?\n(.*?)\r?\n---') {
+        return [pscustomobject]@{ Valid = $false; Errors = "missing or malformed YAML frontmatter in $Path" }
+    }
+    $fields = [ordered]@{}
+    foreach ($line in ($matches[1] -split "`r?`n")) {
+        # Top-level, non-empty scalars only (leading-space/container lines skipped).
+        if ($line -match '^([\w_]+):[ \t]+(\S.*?)[ \t]*$') {
+            $key = $matches[1]; $val = $matches[2]
+            if ($val -match "^'(.*)'$") { $val = ($matches[1] -replace "''", "'") }
+            if ($val -eq 'null') { $fields[$key] = $null }
+            elseif ($key -in @('schema_version', 'mutations_since_last') -and $val -match '^\d+$') { $fields[$key] = [int]$val }
+            else { $fields[$key] = $val }
+        }
+    }
+    Test-SchemaObject -Fields $fields -Kind $Kind -RepoRoot $root
+}
+
+function Write-Digest {
+    # The composite verb. Resolves paths, fetches repo facts (or takes injected
+    # ones), escapes values, rotates latest->archive (digest kind), validates the
+    # constructed object against the schema, writes, and auto-resets counters by
+    # trigger. Fail-open: the file is always written (session continuity beats a
+    # validation quirk); the returned result carries Valid/Errors.
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateSet('digest', 'rationale')][string]$Kind,
+        [string]$RepoRoot,
+        $RepoFacts,
+        [string]$Body,
+        [string]$BodyFile,
+        # digest kind
+        [string]$Trigger = 'auto-write-routine',
+        [string]$SessionId,
+        [string]$OpenPr,
+        [Nullable[int]]$MutationsSinceLast,
+        [string]$LastModelUpdate,
+        [string]$SuccessCriteriaJson,
+        [string]$ArchiveLabel,
+        # rationale kind
+        [string]$PrNumber,
+        [string]$Title,
+        [string]$DiffShortstat
+    )
+
+    $paths = Get-DigestPaths -RepoRoot $RepoRoot
+    $root  = $paths.RepoRoot
+    New-Item -ItemType Directory -Path $paths.DigestDir, $paths.ArchiveDir -Force | Out-Null
+
+    if (-not $RepoFacts) { $RepoFacts = Get-RepoFacts -RepoRoot $root }
+    if ($BodyFile -and (Test-Path $BodyFile)) { $Body = Get-Content $BodyFile -Raw }
+
+    $tsIso  = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $tsFile = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
+
+    $fields = [ordered]@{}
+    if ($Kind -eq 'digest') {
+        $fields['schema_version'] = 1
+        $fields['session_id']     = if ($SessionId) { $SessionId } else { 'unknown' }
+        $fields['written_at']     = $tsIso
+        $fields['trigger']        = $Trigger
+        $fields['branch']         = [string]$RepoFacts.Branch
+        $fields['head_sha']       = [string]$RepoFacts.HeadSha
+        $fields['head_subject']   = [string]$RepoFacts.HeadSubject
+        if ($OpenPr) { $fields['open_pr'] = $OpenPr } elseif ($RepoFacts.OpenPr) { $fields['open_pr'] = [string]$RepoFacts.OpenPr } else { $fields['open_pr'] = $null }
+        if ($LastModelUpdate) { $fields['last_model_update'] = $LastModelUpdate }
+        if ($null -ne $MutationsSinceLast) { $fields['mutations_since_last'] = [int]$MutationsSinceLast }
+        if ($SuccessCriteriaJson) {
+            try { $fields['success_criteria'] = @($SuccessCriteriaJson | ConvertFrom-Json) } catch {}
+        }
+        $target = $paths.Latest
+        if (Test-Path $target) {
+            $label = if ($ArchiveLabel) { Format-YamlId $ArchiveLabel } else { Format-YamlId $Trigger }
+            Copy-Item $target (Join-Path $paths.ArchiveDir "$tsFile-$label.md") -Force
+        }
+    }
+    else {
+        $slug = ($Title.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-')
+        if ($slug.Length -gt 40) { $slug = $slug.Substring(0, 40).Trim('-') }
+        if (-not $slug) { $slug = 'untitled' }
+        $fields['schema_version'] = 1
+        $fields['trigger']        = 'pr-rationale-capture'
+        $fields['captured_at']    = $tsIso
+        $fields['branch']         = [string]$RepoFacts.Branch
+        $fields['pr_number']      = if ($PrNumber) { [string]$PrNumber } else { 'unknown' }
+        $fields['diff_shortstat'] = [string]$DiffShortstat
+        $target = Join-Path $paths.DigestDir "pr-$($fields['pr_number'])-$slug.md"
+    }
+
+    $check = Test-SchemaObject -Fields $fields -Kind $Kind -RepoRoot $root
+
+    $frontmatter = ConvertTo-FrontmatterYaml -Fields $fields
+    $bodyText = if ($Body) { $Body.TrimStart("`r", "`n") } else { '' }
+    Set-Content -Path $target -Value "$frontmatter`n`n$bodyText" -Encoding UTF8
+
+    if (-not $check.Valid) {
+        Write-Warning "Write-Digest: schema validation failed for $target — $($check.Errors)"
+    }
+
+    # Auto-reset counters by trigger (digest kind only).
+    if ($Kind -eq 'digest') {
+        switch ($Trigger) {
+            'digest-skill'                 { Reset-Counter -Name activity -RepoRoot $root; Reset-Counter -Name mid -RepoRoot $root }
+            'activity-tracker-mid-session' { Reset-Counter -Name mid -RepoRoot $root }
+        }
+    }
+
+    [pscustomobject]@{ Path = $target; Valid = $check.Valid; Errors = $check.Errors; Written = $true }
+}
+
+Export-ModuleMember -Function Get-DigestPaths, Format-Yaml, Format-YamlId, Get-RepoFacts,
+    Get-Counter, Step-Counter, Reset-Counter, Test-Digest, Write-Digest

--- a/.claude/hooks/correction-detector.ps1
+++ b/.claude/hooks/correction-detector.ps1
@@ -1,18 +1,14 @@
 # UserPromptSubmit hook — Enhancement 2 (Cherny auto /correct trigger).
 # If the user's prompt matches correction language, nudge Claude to invoke
 # /correct so the rule lands in CLAUDE.md. Throttled: fires once per N=5 prompts.
+# Thin decider over DigestState.psm1 (correction counter).
 
 $ErrorActionPreference = 'SilentlyContinue'
 
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
 
-$digestDir   = Join-Path $repoRoot 'state/digests'
-$counterPath = Join-Path $digestDir '.correction-counter'
-
-if (-not (Test-Path $digestDir)) {
-    New-Item -ItemType Directory -Path $digestDir -Force | Out-Null
-}
+Import-Module (Join-Path $PSScriptRoot 'DigestState.psm1') -Force
 
 # Read JSON payload from stdin (UserPromptSubmit format: {prompt, session_id, ...})
 $prompt = ''
@@ -39,14 +35,7 @@ if ($env:DEMERZEL_CORRECTION_THROTTLE -and $env:DEMERZEL_CORRECTION_THROTTLE -ma
     $throttle = [int]$env:DEMERZEL_CORRECTION_THROTTLE
 }
 
-$count = 0
-if (Test-Path $counterPath) {
-    $raw = (Get-Content $counterPath -Raw).Trim()
-    if ($raw -match '^\d+$') { $count = [int]$raw }
-}
-$count++
-Set-Content -Path $counterPath -Value $count -Encoding UTF8
-
+$count = Step-Counter -Name correction -RepoRoot $repoRoot
 if ($count -ne 1 -and ($count % $throttle) -ne 0) { exit 0 }
 
 $msg = 'Detected correction language. Consider invoking /correct to formalize this into CLAUDE.md so the rule persists across sessions (Cherny self-improvement loop).'

--- a/.claude/hooks/digest-activity-tracker.ps1
+++ b/.claude/hooks/digest-activity-tracker.ps1
@@ -1,90 +1,35 @@
-# PostToolUse hook (matcher: Edit|Write|Bash) — increments mutation counter.
-# /digest skill resets the counter on invocation. Karpathy R4.
-#
-# Enhancement 1 (Cherny periodic mid-session digest): when activity threshold OR
-# time threshold is hit, write a mid-session metadata digest so we survive
-# crashes/network drops without waiting for Stop or PreCompact.
+# PostToolUse hook (matcher: Edit|Write|Bash) — increments mutation counters and
+# writes a mid-session digest when an activity/time threshold is hit, so we
+# survive crashes/network drops without waiting for Stop or PreCompact (Cherny).
+# Thin decider over DigestState.psm1 (counters, git facts, validated write, and
+# the mid-counter reset all live in the module).
 
 $ErrorActionPreference = 'SilentlyContinue'
 
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
 
-$digestDir      = Join-Path $repoRoot 'state/digests'
-$archDir        = Join-Path $digestDir 'archive'
-$counterPath    = Join-Path $digestDir '.activity-counter'
-$midCounterPath = Join-Path $digestDir '.activity-count'
-$latest         = Join-Path $digestDir 'latest.md'
+Import-Module (Join-Path $PSScriptRoot 'DigestState.psm1') -Force
 
-if (-not (Test-Path $digestDir)) { New-Item -ItemType Directory -Path $digestDir -Force | Out-Null }
-if (-not (Test-Path $archDir))   { New-Item -ItemType Directory -Path $archDir -Force | Out-Null }
+# Staleness-nudge counter (reset only by a real /digest) + mid-session gate counter.
+$null     = Step-Counter -Name activity -RepoRoot $repoRoot
+$midCount = Step-Counter -Name mid -RepoRoot $repoRoot
 
-# Existing mutation counter (drives staleness nudge)
-$count = 0
-if (Test-Path $counterPath) {
-    $raw = (Get-Content $counterPath -Raw).Trim()
-    if ($raw -match '^\d+$') { $count = [int]$raw }
-}
-$count++
-Set-Content -Path $counterPath -Value $count -Encoding UTF8
-
-# Enhancement 1: independent counter for mid-session digest gating
-$midCount = 0
-if (Test-Path $midCounterPath) {
-    $raw = (Get-Content $midCounterPath -Raw).Trim()
-    if ($raw -match '^\d+$') { $midCount = [int]$raw }
-}
-$midCount++
-Set-Content -Path $midCounterPath -Value $midCount -Encoding UTF8
-
-# Thresholds: N=20 mutations OR M=30 minutes since last digest
+# Thresholds: N=20 mutations OR M=30 minutes since last digest (with >=3 mutations).
 $thresholdCount = 20
 $thresholdMin   = 30
 if ($env:DEMERZEL_DIGEST_MID_COUNT -and $env:DEMERZEL_DIGEST_MID_COUNT -match '^\d+$') { $thresholdCount = [int]$env:DEMERZEL_DIGEST_MID_COUNT }
 if ($env:DEMERZEL_DIGEST_MID_MIN   -and $env:DEMERZEL_DIGEST_MID_MIN   -match '^\d+$') { $thresholdMin   = [int]$env:DEMERZEL_DIGEST_MID_MIN }
 
+$latest = (Get-DigestPaths -RepoRoot $repoRoot).Latest
 $ageMin = 99999
-if (Test-Path $latest) {
-    $ageMin = [int]((Get-Date) - (Get-Item $latest).LastWriteTime).TotalMinutes
-}
+if (Test-Path $latest) { $ageMin = [int]((Get-Date) - (Get-Item $latest).LastWriteTime).TotalMinutes }
 
-$shouldWrite = $false
-if ($midCount -ge $thresholdCount) { $shouldWrite = $true }
-elseif ($ageMin -ge $thresholdMin -and $midCount -ge 3) { $shouldWrite = $true }
-
+$shouldWrite = ($midCount -ge $thresholdCount) -or ($ageMin -ge $thresholdMin -and $midCount -ge 3)
 if (-not $shouldWrite) { exit 0 }
 
-# Reset mid-session counter
-Set-Content -Path $midCounterPath -Value 0 -Encoding UTF8
-
-$tsIso  = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-$tsFile = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
-
-$branch   = & git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null
-$headSha  = & git -C $repoRoot rev-parse --short HEAD 2>$null
-$headSubj = & git -C $repoRoot log -1 --format='%s' 2>$null
-
-# Rotate existing latest into archive
-if (Test-Path $latest) {
-    Copy-Item $latest (Join-Path $archDir "$tsFile-pre-mid.md") -Force
-}
-
-$midPath = Join-Path $digestDir "mid-$tsFile.md"
-$md = @"
----
-schema_version: 1
-session_id: mid-session-auto
-written_at: $tsIso
-trigger: activity-tracker-mid-session
-branch: $branch
-head_sha: $headSha
-head_subject: $headSubj
-mutations_since_last: $midCount
----
-
+$body = @"
 # Session digest (mid-session auto — activity threshold reached)
-
-**Branch:** $branch @ $headSha — $headSubj
 
 ## Model-driven sections
 
@@ -94,6 +39,8 @@ Invoke ``/digest`` at your next natural breakpoint to populate **Next action**,
 and **Success criteria**._
 "@
 
-Set-Content -Path $midPath -Value $md -Encoding UTF8
-Copy-Item $midPath $latest -Force
+# Write-Digest rotates the prior latest and resets the mid counter on this trigger.
+$null = Write-Digest -Kind digest -RepoRoot $repoRoot `
+    -Trigger 'activity-tracker-mid-session' -SessionId 'mid-session-auto' `
+    -MutationsSinceLast $midCount -ArchiveLabel 'pre-mid' -Body $body
 exit 0

--- a/.claude/hooks/digest-staleness-nudge.ps1
+++ b/.claude/hooks/digest-staleness-nudge.ps1
@@ -1,24 +1,22 @@
 # UserPromptSubmit hook — emits an additionalContext nudge when state has drifted
 # from the last /digest. Karpathy R1+R4. Silent when digest is fresh.
+# Thin decider over DigestState.psm1 (latest path + activity counter).
 
 $ErrorActionPreference = 'SilentlyContinue'
 
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
 
-$latest  = Join-Path $repoRoot 'state/digests/latest.md'
-$counter = Join-Path $repoRoot 'state/digests/.activity-counter'
+Import-Module (Join-Path $PSScriptRoot 'DigestState.psm1') -Force
+
+$latest = (Get-DigestPaths -RepoRoot $repoRoot).Latest
 
 $digestAgeMin = $null
 if (Test-Path $latest) {
     $digestAgeMin = [int]((Get-Date) - (Get-Item $latest).LastWriteTime).TotalMinutes
 }
 
-$mutationCount = 0
-if (Test-Path $counter) {
-    $raw = (Get-Content $counter -Raw).Trim()
-    if ($raw -match '^\d+$') { $mutationCount = [int]$raw }
-}
+$mutationCount = Get-Counter -Name activity -RepoRoot $repoRoot
 
 $shouldNudge = $false
 $reason = ''

--- a/.claude/hooks/digest-stop-finalize.ps1
+++ b/.claude/hooks/digest-stop-finalize.ps1
@@ -1,66 +1,27 @@
 # Stop hook — writes a finalize digest if /digest hasn't run in the last 10 min.
 # Karpathy R4: every session boundary is a goal-driven checkpoint.
+# Thin decider over DigestState.psm1.
 
 $ErrorActionPreference = 'SilentlyContinue'
-
-function Get-SafeYaml {
-    param([string]$Value, [int]$MaxLen = 200)
-    if ($null -eq $Value -or $Value -eq '') { return 'null' }
-    $cleaned = ($Value -replace '[\r\n]', ' ')
-    if ($cleaned.Length -gt $MaxLen) { $cleaned = $cleaned.Substring(0, $MaxLen) + '...' }
-    $escaped = $cleaned -replace "'", "''"
-    return "'$escaped'"
-}
 
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
 
-$digestDir = Join-Path $repoRoot 'state/digests'
-$archDir   = Join-Path $digestDir 'archive'
-$latest    = Join-Path $digestDir 'latest.md'
+Import-Module (Join-Path $PSScriptRoot 'DigestState.psm1') -Force
 
+$latest = (Get-DigestPaths -RepoRoot $repoRoot).Latest
 if (Test-Path $latest) {
     $age = (Get-Date) - (Get-Item $latest).LastWriteTime
     if ($age.TotalMinutes -lt 10) { exit 0 }
 }
 
-New-Item -ItemType Directory -Path $digestDir, $archDir -Force | Out-Null
+$facts = Get-RepoFacts -RepoRoot $repoRoot
+$prLine = if ($facts.OpenPr) { "**Open PR:** $($facts.OpenPr)`n" } else { '' }
 
-$tsFile = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
-$tsIso  = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-
-if (Test-Path $latest) {
-    Copy-Item $latest (Join-Path $archDir "$tsFile-stop.md") -Force
-}
-
-$branch   = & git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null
-$headSha  = & git -C $repoRoot rev-parse --short HEAD 2>$null
-$headSubj = & git -C $repoRoot log -1 --format='%s' 2>$null
-
-$openPr = $null
-if (Get-Command gh -ErrorAction SilentlyContinue) {
-    $prJson = & gh pr view --json number 2>$null
-    if ($prJson) {
-        try { $openPr = "#$(($prJson | ConvertFrom-Json).number)" } catch {}
-    }
-}
-$prLine = if ($openPr) { "**Open PR:** $openPr`n" } else { '' }
-
-$digest = @"
----
-schema_version: 1
-session_id: stop-finalize
-written_at: $tsIso
-trigger: stop-hook-finalize
-branch: $(Get-SafeYaml $branch)
-head_sha: $(Get-SafeYaml $headSha)
-head_subject: $(Get-SafeYaml $headSubj)
-open_pr: $(Get-SafeYaml $openPr)
----
-
+$body = @"
 # Session digest (Stop-hook finalize — /digest not invoked in last 10 min)
 
-**Branch:** $branch @ $headSha — $headSubj
+**Branch:** $($facts.Branch) @ $($facts.HeadSha) — $($facts.HeadSubject)
 $prLine
 ## Model-driven sections
 
@@ -68,6 +29,6 @@ _Session ended without a recent ``/digest``. Next session: re-orient from
 ``git log`` + open PR. Prior digests (if any) are in ``state/digests/archive/``._
 "@
 
-Set-Content -Path $latest -Value $digest -Encoding UTF8
-& (Join-Path $repoRoot '.claude/hooks/digest-validate.ps1') -DigestPath $latest 2>$null
+$null = Write-Digest -Kind digest -RepoRoot $repoRoot -RepoFacts $facts `
+    -Trigger 'stop-hook-finalize' -SessionId 'stop-finalize' -ArchiveLabel 'stop' -Body $body
 exit 0

--- a/.claude/hooks/digest-validate.ps1
+++ b/.claude/hooks/digest-validate.ps1
@@ -1,5 +1,7 @@
-# Validates state/digests/latest.md frontmatter against docs/contracts/digest-schema.json.
-# Karpathy R11: every AI step declares an output schema; runtime rejects mismatches.
+# Validates a digest/rationale file's frontmatter against its schema.
+# Thin wrapper over DigestState's Test-Digest — the rules (required fields,
+# trigger enum, types) come from docs/contracts/*-schema.json, not hand-coded
+# here (ADR-0003: schema is the single source of structural validation).
 
 param([string]$DigestPath)
 
@@ -8,45 +10,16 @@ $ErrorActionPreference = 'SilentlyContinue'
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
 
+Import-Module (Join-Path $PSScriptRoot 'DigestState.psm1') -Force
+
 if (-not $DigestPath) {
-    $DigestPath = Join-Path $repoRoot 'state/digests/latest.md'
+    $DigestPath = (Get-DigestPaths -RepoRoot $repoRoot).Latest
 }
 if (-not (Test-Path $DigestPath)) { exit 0 }
 
-$content = Get-Content $DigestPath -Raw
-if ($content -notmatch '(?s)^---\r?\n(.*?)\r?\n---') {
-    Write-Error "digest-validate: missing or malformed YAML frontmatter in $DigestPath"
+$result = Test-Digest -Path $DigestPath -RepoRoot $repoRoot
+if (-not $result.Valid) {
+    Write-Error "digest-validate: $($result.Errors)"
     exit 1
 }
-
-$fmRaw = $matches[1]
-$fm = @{}
-foreach ($line in ($fmRaw -split "`r?`n")) {
-    if ($line -match '^\s*([\w_]+)\s*:\s*(.*?)\s*$') {
-        $key = $matches[1]
-        $val = $matches[2]
-        if ($val -eq 'null' -or $val -eq '') { $val = $null }
-        $fm[$key] = $val
-    }
-}
-
-$required = @('schema_version', 'session_id', 'written_at', 'trigger', 'branch', 'head_sha', 'head_subject')
-foreach ($k in $required) {
-    if (-not $fm.ContainsKey($k) -or $null -eq $fm[$k]) {
-        Write-Error "digest-validate: required field '$k' missing or null"
-        exit 1
-    }
-}
-
-if ($fm['schema_version'] -ne '1') {
-    Write-Error "digest-validate: schema_version must be 1 (got '$($fm['schema_version'])')"
-    exit 1
-}
-
-$validTriggers = @('digest-skill', 'precompact-hook-fallback', 'stop-hook-finalize', 'auto-write-routine')
-if ($fm['trigger'] -notin $validTriggers) {
-    Write-Error "digest-validate: trigger '$($fm['trigger'])' not in $($validTriggers -join ', ')"
-    exit 1
-}
-
 exit 0

--- a/.claude/hooks/pr-rationale-capture.ps1
+++ b/.claude/hooks/pr-rationale-capture.ps1
@@ -1,11 +1,14 @@
 # PostToolUse(matcher=Bash) hook — Enhancement 3 (Cherny PR rationale capture).
 # When a Bash invocation runs `gh pr create`, snapshot the title + body + diff
 # stats to state/digests/pr-<num>-<slug>.md so the rationale survives later edits.
+# Extraction stays here (its real complexity); the write goes through DigestState.
 
 $ErrorActionPreference = 'SilentlyContinue'
 
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
+
+Import-Module (Join-Path $PSScriptRoot 'DigestState.psm1') -Force
 
 # Read PostToolUse JSON payload from stdin: {tool_input: {command}, tool_response: {output}}
 $cmd = ''
@@ -43,35 +46,11 @@ $prNum = 'unknown'
 $mPr = [regex]::Match($output, 'pull/(\d+)')
 if ($mPr.Success) { $prNum = $mPr.Groups[1].Value }
 
-# Slug from title
-$slug = ($title.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-')
-if ($slug.Length -gt 40) { $slug = $slug.Substring(0, 40).Trim('-') }
-if (-not $slug) { $slug = 'untitled' }
-
-$digestDir = Join-Path $repoRoot 'state/digests'
-if (-not (Test-Path $digestDir)) { New-Item -ItemType Directory -Path $digestDir -Force | Out-Null }
-$outPath = Join-Path $digestDir "pr-$prNum-$slug.md"
-
-$tsIso     = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-$branch    = & git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null
 $shortStat = & git -C $repoRoot diff --shortstat HEAD~1 2>$null
 if (-not $shortStat) { $shortStat = '' }
 
-$md = @"
----
-schema_version: 1
-trigger: pr-rationale-capture
-captured_at: $tsIso
-branch: $branch
-pr_number: $prNum
-diff_shortstat: $shortStat
----
-
+$mdBody = @"
 # PR #$prNum — $title
-
-**Branch:** $branch
-**Captured:** $tsIso
-**Diff:** $shortStat
 
 ## Title
 
@@ -82,5 +61,6 @@ $title
 $body
 "@
 
-Set-Content -Path $outPath -Value $md -Encoding UTF8
+$null = Write-Digest -Kind rationale -RepoRoot $repoRoot `
+    -PrNumber $prNum -Title $title -DiffShortstat $shortStat -Body $mdBody
 exit 0

--- a/.claude/hooks/precompact-digest.ps1
+++ b/.claude/hooks/precompact-digest.ps1
@@ -1,34 +1,17 @@
 # PreCompact hook — archives state/digests/latest.md and writes a metadata-only
 # fallback if /digest wasn't invoked before compaction.
+# Thin decider over DigestState.psm1 (path resolution, escaping, git facts,
+# archive rotation, schema-validated write all live in the module).
 
 $ErrorActionPreference = 'SilentlyContinue'
 $WarningPreference     = 'SilentlyContinue'
 
-function Get-SafeId {
-    param([string]$Value, [string]$Fallback = 'unknown', [int]$MaxLen = 64)
-    if (-not $Value) { return $Fallback }
-    $cleaned = $Value -replace '[\r\n\t]', ''
-    if ($cleaned.Length -gt $MaxLen) { $cleaned = $cleaned.Substring(0, $MaxLen) }
-    if ($cleaned -match '^[A-Za-z0-9._\-]+$') { return $cleaned }
-    return $Fallback
-}
-function Get-SafeYaml {
-    param([string]$Value, [int]$MaxLen = 200)
-    if ($null -eq $Value -or $Value -eq '') { return 'null' }
-    $cleaned = ($Value -replace '[\r\n]', ' ')
-    if ($cleaned.Length -gt $MaxLen) { $cleaned = $cleaned.Substring(0, $MaxLen) + '...' }
-    $escaped = $cleaned -replace "'", "''"
-    return "'$escaped'"
-}
-
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
 
-$digestDir = Join-Path $repoRoot 'state/digests'
-$archDir   = Join-Path $digestDir 'archive'
-$latest    = Join-Path $digestDir 'latest.md'
-New-Item -ItemType Directory -Path $digestDir, $archDir -Force | Out-Null
+Import-Module (Join-Path $PSScriptRoot 'DigestState.psm1') -Force
 
+# Session id from the PreCompact stdin payload (this hook's own concern).
 $sessionId = 'unknown'
 try {
     $stdinRaw = [Console]::In.ReadToEnd()
@@ -37,46 +20,25 @@ try {
         if ($payload.session_id) { $sessionId = $payload.session_id }
     }
 } catch {}
+$safeSession = Format-YamlId $sessionId
 
-$ts     = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-$tsFile = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
+$paths = Get-DigestPaths -RepoRoot $repoRoot
 
-$safeSession = Get-SafeId $sessionId
-if (Test-Path $latest) {
-    Copy-Item $latest (Join-Path $archDir "$tsFile-$safeSession.md") -Force
-    $age = (Get-Date) - (Get-Item $latest).LastWriteTime
-    if ($age.TotalMinutes -lt 30) { exit 0 }
-}
-
-$branch   = & git -C $repoRoot rev-parse --abbrev-ref HEAD 2>$null
-$headSha  = & git -C $repoRoot rev-parse --short HEAD 2>$null
-$headSubj = & git -C $repoRoot log -1 --format='%s' 2>$null
-
-$openPr = $null
-if (Get-Command gh -ErrorAction SilentlyContinue) {
-    $prJson = & gh pr view --json number 2>$null
-    if ($prJson) {
-        try { $openPr = "#$(($prJson | ConvertFrom-Json).number)" } catch {}
+# If a real /digest ran recently, snapshot it and keep it — do not overwrite.
+# (On the stale path below, Write-Digest rotates the prior latest itself.)
+if (Test-Path $paths.Latest) {
+    $age = (Get-Date) - (Get-Item $paths.Latest).LastWriteTime
+    if ($age.TotalMinutes -lt 30) {
+        New-Item -ItemType Directory -Path $paths.ArchiveDir -Force | Out-Null
+        $tsFile = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH-mm-ssZ')
+        Copy-Item $paths.Latest (Join-Path $paths.ArchiveDir "$tsFile-$safeSession.md") -Force
+        exit 0
     }
 }
-$prLine = if ($openPr) { "**Open PR:** $openPr`n" } else { '' }
 
-$digest = @"
----
-schema_version: 1
-session_id: $(Get-SafeYaml $sessionId)
-written_at: $ts
-trigger: precompact-hook-fallback
-branch: $(Get-SafeYaml $branch)
-head_sha: $(Get-SafeYaml $headSha)
-head_subject: $(Get-SafeYaml $headSubj)
-open_pr: $(Get-SafeYaml $openPr)
----
-
+$body = @"
 # Session digest (fallback — /digest was not invoked before compaction)
 
-**Branch:** $branch @ $headSha — $headSubj
-$prLine
 ## Model-driven sections
 
 _No ``/digest`` invocation was captured before this compaction. Re-orient from
@@ -85,5 +47,6 @@ _No ``/digest`` invocation was captured before this compaction. Re-orient from
 **Do NOT carry forward** sections before the next compaction event._
 "@
 
-Set-Content -Path $latest -Value $digest -Encoding UTF8
+$null = Write-Digest -Kind digest -RepoRoot $repoRoot `
+    -Trigger 'precompact-hook-fallback' -SessionId $sessionId -ArchiveLabel $safeSession -Body $body
 exit 0

--- a/.claude/hooks/sessionstart-digest.ps1
+++ b/.claude/hooks/sessionstart-digest.ps1
@@ -1,12 +1,14 @@
 # SessionStart hook — emits state/digests/latest.md to stdout for additionalContext
-# injection. Skips silently if missing or >24h stale.
+# injection. Skips silently if missing or >24h stale. Thin reader over DigestState.
 
 $ErrorActionPreference = 'SilentlyContinue'
 
 $repoRoot = & git rev-parse --show-toplevel 2>$null
 if (-not $repoRoot) { exit 0 }
 
-$latest = Join-Path $repoRoot 'state/digests/latest.md'
+Import-Module (Join-Path $PSScriptRoot 'DigestState.psm1') -Force
+
+$latest = (Get-DigestPaths -RepoRoot $repoRoot).Latest
 if (-not (Test-Path $latest)) { exit 0 }
 
 $age = (Get-Date) - (Get-Item $latest).LastWriteTime

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -75,14 +75,32 @@ When a prior digest exists, this section reports the status delta:
 
 ## How to run
 
+The frontmatter is **generated** by `DigestState`'s `Write-Digest` (paths, git
+facts, escaping, schema validation, and counter reset all live there). You author
+only the **body** sections and the `success_criteria` — do not hand-write the
+`---` frontmatter block.
+
 1. Read existing `state/digests/latest.md` if present — preserve current sections.
 2. Karpathy R4 — review/mark prior success criteria.
-3. Capture git state via Bash (`git rev-parse`, `git log -1`, `gh pr view`).
-4. Synthesize content; derive 1–3 testable `success_criteria` from Next action.
-5. Write to `state/digests/latest.md`. Set `trigger: digest-skill` + `last_model_update`.
-6. `rm -f state/digests/.activity-counter` to reset the staleness nudge.
-7. Validate: `pwsh -NoProfile -File .claude/hooks/digest-validate.ps1`. Non-zero = fix.
-8. Report: `Digest updated: <branch>@<sha> · next: <one-line> · criteria: <N>`.
+3. Synthesize the body (the `#`/`##` sections below) and write it to a temp file,
+   e.g. `state/digests/.body.tmp.md`.
+4. Derive 1–3 testable `success_criteria` from the Next action as a JSON array:
+   `[{"criterion":"…","status":"pending","evidence":null}]`.
+5. Route through the module (it sets `trigger: digest-skill`, validates against
+   `docs/contracts/digest-schema.json`, writes `latest.md`, and resets the
+   staleness + mid counters):
+
+   ```pwsh
+   pwsh -NoProfile -Command "Import-Module .claude/hooks/DigestState.psm1 -Force; \
+     Write-Digest -Kind digest -Trigger digest-skill \
+       -BodyFile state/digests/.body.tmp.md \
+       -SuccessCriteriaJson '<json array>' \
+       -LastModelUpdate (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')"
+   ```
+
+   A non-`Valid` result prints a warning naming the schema error — fix and re-run.
+6. `rm -f state/digests/.body.tmp.md`.
+7. Report: `Digest updated: <branch>@<sha> · next: <one-line> · criteria: <N>`.
 
 ## Driving criteria autonomously with `/goal`
 

--- a/.github/workflows/karpathy-cherny-discipline.yml
+++ b/.github/workflows/karpathy-cherny-discipline.yml
@@ -4,13 +4,18 @@ on:
   pull_request:
     paths:
       - 'docs/contracts/digest-schema.json'
+      - 'docs/contracts/pr-rationale-schema.json'
       - 'state/digests/**'
       - '.claude/settings.json'
       - '.claude/skills/digest/**'
       - '.claude/skills/correct/**'
       - '.claude/hooks/digest-*'
+      - '.claude/hooks/DigestState.psm1'
       - '.claude/hooks/precompact-digest*'
       - '.claude/hooks/sessionstart-digest*'
+      - '.claude/hooks/pr-rationale-capture*'
+      - '.claude/hooks/correction-detector*'
+      - 'tests/powershell/**'
       - 'CLAUDE.md'
       - '.github/workflows/karpathy-cherny-discipline.yml'
 
@@ -46,6 +51,7 @@ jobs:
         run: |
           missing=0
           for f in \
+            ".claude/hooks/DigestState.psm1" \
             ".claude/hooks/precompact-digest.ps1" \
             ".claude/hooks/sessionstart-digest.ps1" \
             ".claude/hooks/digest-validate.ps1" \
@@ -101,3 +107,19 @@ jobs:
               sys.exit(1)
           print('All committed digests valid (or none committed).')
           PYEOF
+
+  pester:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run DigestState Pester tests
+        shell: pwsh
+        run: |
+          Install-Module Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          Import-Module Pester -MinimumVersion 5.0.0 -Force
+          $cfg = New-PesterConfiguration
+          $cfg.Run.Path = 'tests/powershell'
+          $cfg.Run.Exit = $true
+          $cfg.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $cfg

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,6 +77,21 @@ fact lives in one place and is read out, never restated.
   *agrees* with it. Makes the append-only + precedence [Architecture invariant](#architecture-invariant)
   machine-checkable without generating the headers' human rationale.
 
+## Architecture seams (designed + built 2026-06-21, Candidate 1)
+
+- **`DigestState`** — `.claude/hooks/DigestState.psm1`, a dot-sourced PowerShell deep
+  module mirroring [`Get-DomainGateState`](#architecture-seams-designed-2026-06-20-via-improve-codebase-architecture-built-2026-06-21-pr-357).
+  The eight session-digest hooks were each re-deriving the same primitives — the
+  `state/digests` path, YAML escaping, git facts, counter I/O, and a late-bound
+  validation call. Those now live here once, behind a small interface
+  (`Write-Digest`/`Get-DigestPaths`/`Format-Yaml`/`Get-RepoFacts`/`{Get,Step,Reset}-Counter`/`Test-Digest`);
+  the hooks became thin *deciders*. `Write-Digest -Kind digest|rationale` resolves
+  paths, fetches/accepts repo facts, rotates `latest`→`archive`, **validates the
+  constructed object against the schema** (`docs/contracts/{digest,pr-rationale}-schema.json`),
+  writes, and auto-resets counters by trigger. `Test-Digest` replaced
+  `digest-validate.ps1`'s hand-coded rules with a schema read (ADR-0003). First
+  unit-testable seam in the hook layer (`tests/powershell/DigestState.Tests.ps1`, Pester).
+
 ## Conventions
 
 See `CLAUDE.md` / `AGENTS.md` for authoritative validation rules, the constitutional

--- a/docs/contracts/digest-schema.json
+++ b/docs/contracts/digest-schema.json
@@ -12,12 +12,13 @@
     "written_at": { "type": "string", "format": "date-time" },
     "trigger": {
       "type": "string",
-      "enum": ["digest-skill", "precompact-hook-fallback", "stop-hook-finalize", "auto-write-routine"]
+      "enum": ["digest-skill", "precompact-hook-fallback", "stop-hook-finalize", "auto-write-routine", "activity-tracker-mid-session"]
     },
     "branch": { "type": "string" },
     "head_sha": { "type": "string" },
     "head_subject": { "type": "string" },
     "open_pr": { "type": ["string", "null"] },
+    "mutations_since_last": { "type": "integer", "minimum": 0, "description": "Mutations counted since the last digest; emitted by the activity-tracker mid-session auto-write." },
     "last_model_update": { "type": ["string", "null"], "format": "date-time" },
     "success_criteria": {
       "type": "array",

--- a/docs/contracts/pr-rationale-schema.json
+++ b/docs/contracts/pr-rationale-schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://guitar-alchemist/contracts/pr-rationale-v1.json",
+  "title": "PR Rationale Snapshot",
+  "description": "Frontmatter schema for state/digests/pr-<num>-<slug>.md, written by .claude/hooks/pr-rationale-capture.ps1 via DigestState's Write-Digest -Kind rationale. Snapshots a PR's title/body/diff stats so the rationale survives later edits. Distinct from the session-digest schema (docs/contracts/digest-schema.json).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "trigger", "captured_at", "branch", "pr_number"],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "trigger": { "type": "string", "const": "pr-rationale-capture" },
+    "captured_at": { "type": "string", "format": "date-time" },
+    "branch": { "type": "string" },
+    "pr_number": { "type": "string", "description": "PR number as a string, or 'unknown' when not parseable from the gh output." },
+    "diff_shortstat": { "type": "string", "description": "Output of git diff --shortstat, or empty." }
+  }
+}

--- a/tests/powershell/DigestState.Tests.ps1
+++ b/tests/powershell/DigestState.Tests.ps1
@@ -1,0 +1,118 @@
+# Pester tests for .claude/hooks/DigestState.psm1 — the first unit-testable seam
+# in the hook layer. Exercises Write-Digest through its interface against an
+# isolated $TestDrive RepoRoot with injected -RepoFacts (no git, no network).
+
+BeforeAll {
+    $repoRoot   = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $modulePath = Join-Path $repoRoot '.claude/hooks/DigestState.psm1'
+    Import-Module $modulePath -Force
+
+    # Build an isolated repo root that contains the schemas the module reads.
+    $script:Root = "$TestDrive/repo"
+    New-Item -ItemType Directory -Path "$script:Root/docs/contracts" -Force | Out-Null
+    Copy-Item (Join-Path $repoRoot 'docs/contracts/digest-schema.json')       "$script:Root/docs/contracts/" -Force
+    Copy-Item (Join-Path $repoRoot 'docs/contracts/pr-rationale-schema.json') "$script:Root/docs/contracts/" -Force
+
+    $script:Facts = [pscustomobject]@{ Branch = 'main'; HeadSha = 'abc1234'; HeadSubject = 'test commit'; OpenPr = $null }
+}
+
+Describe 'Format-Yaml' {
+    It 'returns null for empty input' { Format-Yaml '' | Should -Be 'null' }
+    It 'single-quotes and escapes embedded quotes' { Format-Yaml "it's" | Should -Be "'it''s'" }
+    It 'collapses newlines and caps length' {
+        (Format-Yaml ("a`nb")) | Should -Be "'a b'"
+        (Format-Yaml ('x' * 300) 10) | Should -Match "^'x{10}\.\.\.'$"
+    }
+}
+
+Describe 'Counters' {
+    It 'steps, reads, and resets' {
+        Get-Counter -Name activity -RepoRoot $script:Root | Should -Be 0
+        Step-Counter -Name activity -RepoRoot $script:Root | Should -Be 1
+        Step-Counter -Name activity -RepoRoot $script:Root | Should -Be 2
+        Get-Counter -Name activity -RepoRoot $script:Root | Should -Be 2
+        Reset-Counter -Name activity -RepoRoot $script:Root
+        Get-Counter -Name activity -RepoRoot $script:Root | Should -Be 0
+    }
+    It 'rejects an unknown counter name' {
+        { Step-Counter -Name bogus -RepoRoot $script:Root } | Should -Throw
+    }
+}
+
+Describe 'Write-Digest -Kind digest' {
+    It 'writes a schema-valid digest to latest.md' {
+        $r = Write-Digest -Kind digest -RepoRoot $script:Root -RepoFacts $script:Facts `
+            -Trigger 'precompact-hook-fallback' -SessionId 'sess-1' -Body '# hello'
+        $r.Valid | Should -BeTrue
+        $r.Path  | Should -Be (Join-Path $script:Root 'state/digests/latest.md')
+        Test-Path $r.Path | Should -BeTrue
+        (Get-Content $r.Path -Raw) | Should -Match "trigger: 'precompact-hook-fallback'"
+    }
+
+    It 'fails validation on a bad trigger but still writes (fail-open)' {
+        $r = Write-Digest -Kind digest -RepoRoot $script:Root -RepoFacts $script:Facts `
+            -Trigger 'not-a-real-trigger' -SessionId 'sess-2' -Body 'x' -WarningAction SilentlyContinue
+        $r.Valid   | Should -BeFalse
+        $r.Written | Should -BeTrue
+        Test-Path $r.Path | Should -BeTrue
+    }
+
+    It 'accepts mutations_since_last and success_criteria' {
+        $sc = '[{"criterion":"build green","status":"pending","evidence":null}]'
+        $r = Write-Digest -Kind digest -RepoRoot $script:Root -RepoFacts $script:Facts `
+            -Trigger 'activity-tracker-mid-session' -SessionId 'mid' -MutationsSinceLast 7 `
+            -SuccessCriteriaJson $sc -Body 'b'
+        $r.Valid | Should -BeTrue
+        (Get-Content $r.Path -Raw) | Should -Match 'mutations_since_last: 7'
+        (Get-Content $r.Path -Raw) | Should -Match 'criterion:'
+    }
+
+    It 'rotates the prior latest into archive on overwrite' {
+        Write-Digest -Kind digest -RepoRoot $script:Root -RepoFacts $script:Facts -Trigger 'digest-skill' -Body 'first' | Out-Null
+        Write-Digest -Kind digest -RepoRoot $script:Root -RepoFacts $script:Facts -Trigger 'digest-skill' -Body 'second' | Out-Null
+        (Get-ChildItem "$script:Root/state/digests/archive" -Filter '*.md').Count | Should -BeGreaterThan 0
+    }
+}
+
+Describe 'Write-Digest counter auto-reset by trigger' {
+    It 'digest-skill resets both activity and mid' {
+        Step-Counter -Name activity -RepoRoot $script:Root | Out-Null
+        Step-Counter -Name mid -RepoRoot $script:Root | Out-Null
+        Write-Digest -Kind digest -RepoRoot $script:Root -RepoFacts $script:Facts -Trigger 'digest-skill' -Body 'x' | Out-Null
+        Get-Counter -Name activity -RepoRoot $script:Root | Should -Be 0
+        Get-Counter -Name mid -RepoRoot $script:Root | Should -Be 0
+    }
+    It 'activity-tracker-mid-session resets mid only, leaves activity' {
+        Step-Counter -Name activity -RepoRoot $script:Root | Out-Null
+        Step-Counter -Name mid -RepoRoot $script:Root | Out-Null
+        Write-Digest -Kind digest -RepoRoot $script:Root -RepoFacts $script:Facts -Trigger 'activity-tracker-mid-session' -Body 'x' | Out-Null
+        Get-Counter -Name mid -RepoRoot $script:Root | Should -Be 0
+        Get-Counter -Name activity -RepoRoot $script:Root | Should -BeGreaterThan 0
+    }
+}
+
+Describe 'Write-Digest -Kind rationale' {
+    It 'writes a schema-valid pr-<num>-<slug>.md' {
+        $r = Write-Digest -Kind rationale -RepoRoot $script:Root -RepoFacts $script:Facts `
+            -PrNumber '123' -Title 'Fix the thing' -DiffShortstat ' 2 files changed' -Body 'rationale'
+        $r.Valid | Should -BeTrue
+        $r.Path  | Should -Match 'pr-123-fix-the-thing\.md$'
+        (Get-Content $r.Path -Raw) | Should -Match "trigger: 'pr-rationale-capture'"
+    }
+}
+
+Describe 'Test-Digest' {
+    It 'validates a freshly written digest' {
+        $w = Write-Digest -Kind digest -RepoRoot $script:Root -RepoFacts $script:Facts -Trigger 'digest-skill' -Body 'x'
+        (Test-Digest -Path $w.Path -RepoRoot $script:Root).Valid | Should -BeTrue
+    }
+    It 'rejects a file with no frontmatter' {
+        $bad = "$script:Root/state/digests/nofm.md"
+        Set-Content -Path $bad -Value 'just a body' -Encoding UTF8
+        (Test-Digest -Path $bad -RepoRoot $script:Root).Valid | Should -BeFalse
+    }
+    It 'infers rationale kind from the pr- filename' {
+        $w = Write-Digest -Kind rationale -RepoRoot $script:Root -RepoFacts $script:Facts -PrNumber '9' -Title 'x' -Body 'b'
+        (Test-Digest -Path $w.Path -RepoRoot $script:Root).Valid | Should -BeTrue
+    }
+}


### PR DESCRIPTION
Candidate 1 of the 2026-06-21 `/improve-codebase-architecture` review. **Also lands Candidate 4's digest half.**

The 8 session-digest hooks each re-derived the same primitives (the `state/digests` path ×7, `Get-SafeYaml` ×2, git facts, counter I/O ×3, a late-bound validation call). Collapsed into `.claude/hooks/DigestState.psm1`, mirroring the accepted `DomainGate.psm1` pattern (#352, ADR-0003).

- Composite `Write-Digest -Kind digest|rationale` (schema chosen internally; `-RepoRoot`/`-RepoFacts` injection; rotate→validate→write; auto-resets counters by trigger) + leaf verbs.
- Broadened `digest-schema.json`; authored `pr-rationale-schema.json`.
- `Test-Digest` replaces `digest-validate.ps1`'s hand-coded rules with a schema read (Candidate 4 digest half).
- First unit-testable seam in the hook layer: `tests/powershell/DigestState.Tests.ps1` (Pester), wired into `karpathy-cherny-discipline.yml`.

**Verified:** 15/15 Pester green · 9/9 hooks parse clean · end-to-end hook run in a temp repo emits a schema-valid digest · actionlint clean · no manifest drift. Net −131 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)