### PR TITLE
fix(halt): jsonschema-with-stdlib-fallback validation parity (ADR-0003)

### DIFF
--- a/docs/adr/0003-schema-single-source-validation.md
+++ b/docs/adr/0003-schema-single-source-validation.md
@@ -61,3 +61,17 @@ follow-on), not by the schema.
 - **Keep per-language hand-coded validators, accept the duplication.** Rejected: the halt
   marker is the proof the duplication drifts; the schema is readable by both runtimes, so the
   shared seam costs little.
+
+## Update (2026-06-21)
+
+The original `demerzel_halt.py` adapter was deliberately **stdlib-only** and re-implemented
+the field checks in Python (harvesting only the enum/length values from the schema). That
+left it a *looser* subset than the PowerShell `Test-Json` adapter — no `pattern`,
+`additionalProperties`, or `required`-list enforcement — so the two adapters could still
+diverge. We now validate with **`jsonschema` when it is importable** (full parity with
+`Test-Json`) and fall back to a **stdlib generic schema-subset check** only when the package
+is absent. The fallback is retained because the halt tool is the cross-repo emergency brake
+and must run on a bare-Python machine without `pip install`. `scripts/requirements-halt.txt`
+declares `jsonschema` so CI always takes the strong path. This refines — does not reverse —
+the "schema is the single source" decision: the rules still live only in the schema; both
+runtimes now enforce all of them.

--- a/scripts/demerzel_halt.py
+++ b/scripts/demerzel_halt.py
@@ -50,6 +50,7 @@ import argparse
 import getpass
 import json
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -58,10 +59,13 @@ from typing import Any
 SCHEMA_VERSION = 1
 DEFAULT_SCOPE = "loops-only"
 
-# Single source of the structural constraints (ADR-0003): the scope enum and the
-# reason length live in schemas/halt-all.schema.json, not hardcoded here. This
-# Python adapter stays stdlib-only (the halt tool must not depend on jsonschema);
-# the PowerShell adapter validates the full schema via Test-Json -Schema.
+# Single source of the structural rules (ADR-0003): every constraint lives in
+# schemas/halt-all.schema.json. We validate with `jsonschema` when it can be
+# imported — full parity with the PowerShell adapter's `Test-Json -Schema` — and
+# otherwise fall back to a stdlib generic check that enforces the same constructs
+# read from the schema. The fallback exists because this is the cross-repo
+# EMERGENCY BRAKE: an operator must be able to halt on a bare-Python machine
+# without `pip install`, so a missing package must never block a halt.
 _SCHEMA = json.loads(
     (Path(__file__).resolve().parent.parent / "schemas" / "halt-all.schema.json").read_text(
         encoding="utf-8"
@@ -87,31 +91,69 @@ def now_rfc3339() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def validate(marker: dict[str, Any]) -> list[str]:
-    """Return a list of validation errors. Empty list means the marker is valid."""
+_TYPE_CHECKS = {
+    "object": lambda v: isinstance(v, dict),
+    "array": lambda v: isinstance(v, list),
+    "string": lambda v: isinstance(v, str),
+    "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
+    "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+    "boolean": lambda v: isinstance(v, bool),
+    "null": lambda v: v is None,
+}
+
+
+def _validate_stdlib(instance: Any, schema: dict[str, Any], path: str = "") -> list[str]:
+    """Stdlib JSON-Schema subset check (no third-party deps). Covers the
+    constructs the marker schema uses: type (incl. unions), required,
+    additionalProperties:false, const, enum, min/maxLength, pattern, items."""
     errors: list[str] = []
-    if marker.get("schema_version") != SCHEMA_VERSION:
-        errors.append(
-            f"schema_version must be {SCHEMA_VERSION}; got {marker.get('schema_version')!r}"
-        )
-    halted_at = marker.get("halted_at")
-    if not isinstance(halted_at, str) or "T" not in halted_at:
-        errors.append("halted_at must be an RFC3339 UTC timestamp string")
-    reason = marker.get("reason")
-    if not isinstance(reason, str) or not (1 <= len(reason) <= _REASON_MAX):
-        errors.append(f"reason must be a 1-{_REASON_MAX} character string")
-    scope = marker.get("scope", DEFAULT_SCOPE)
-    if scope not in VALID_SCOPES:
-        errors.append(f"scope must be one of {sorted(VALID_SCOPES)}; got {scope!r}")
-    expires_at = marker.get("expires_at")
-    if expires_at is not None and not isinstance(expires_at, str):
-        errors.append("expires_at must be null or an RFC3339 UTC timestamp string")
-    exempt = marker.get("exempt_agents")
-    if exempt is not None and not (
-        isinstance(exempt, list) and all(isinstance(a, str) for a in exempt)
-    ):
-        errors.append("exempt_agents must be null or a list of strings")
+    where = path.rstrip(".") or "value"
+    typ = schema.get("type")
+    if typ is not None:
+        types = typ if isinstance(typ, list) else [typ]
+        if not any(_TYPE_CHECKS.get(t, lambda _v: True)(instance) for t in types):
+            return [f"{where}: expected type {typ}, got {type(instance).__name__}"]
+    if "const" in schema and instance != schema["const"]:
+        errors.append(f"{where}: must equal {schema['const']!r}")
+    if "enum" in schema and instance not in schema["enum"]:
+        errors.append(f"{where}: must be one of {schema['enum']}")
+    if isinstance(instance, str):
+        if "minLength" in schema and len(instance) < schema["minLength"]:
+            errors.append(f"{where}: shorter than minLength {schema['minLength']}")
+        if "maxLength" in schema and len(instance) > schema["maxLength"]:
+            errors.append(f"{where}: longer than maxLength {schema['maxLength']}")
+        if "pattern" in schema and not re.search(schema["pattern"], instance):
+            errors.append(f"{where}: does not match pattern {schema['pattern']}")
+    if isinstance(instance, dict):
+        props = schema.get("properties", {})
+        for req in schema.get("required", []):
+            if req not in instance:
+                errors.append(f"{path}{req}: required field missing")
+        if schema.get("additionalProperties") is False:
+            for key in instance:
+                if key not in props:
+                    errors.append(f"{path}{key}: additional property not allowed")
+        for key, subschema in props.items():
+            if key in instance and instance[key] is not None:
+                errors.extend(_validate_stdlib(instance[key], subschema, f"{path}{key}."))
+    if isinstance(instance, list) and "items" in schema:
+        for i, item in enumerate(instance):
+            errors.extend(_validate_stdlib(item, schema["items"], f"{path}[{i}]."))
     return errors
+
+
+def validate(marker: dict[str, Any]) -> list[str]:
+    """Return a list of validation errors. Empty list means the marker is valid.
+
+    Uses jsonschema (full parity with the PowerShell Test-Json adapter) when it
+    is importable; falls back to the stdlib subset check so the emergency halt
+    never fails for a missing package."""
+    try:
+        import jsonschema  # noqa: PLC0415 — optional dependency, imported lazily by design
+    except ImportError:
+        return _validate_stdlib(marker, _SCHEMA)
+    validator = jsonschema.Draft202012Validator(_SCHEMA)
+    return [e.message for e in sorted(validator.iter_errors(marker), key=lambda e: list(e.path))]
 
 
 def atomic_write(path: Path, content: str) -> None:

--- a/scripts/requirements-halt.txt
+++ b/scripts/requirements-halt.txt
@@ -1,0 +1,10 @@
+# Optional dependency for scripts/demerzel_halt.py.
+#
+# The halt tool is the cross-repo EMERGENCY BRAKE and runs on stdlib alone — it
+# falls back to a built-in schema check if jsonschema is absent, so an operator
+# can always halt without `pip install`. Installing this gives the STRONG path:
+# full parity with the PowerShell Test-Json adapter (ADR-0003). CI installs it so
+# tests exercise the jsonschema path; operators may skip it.
+#
+# Pinned to match scripts/requirements-qa-tribunal.txt.
+jsonschema==4.21.1

--- a/tests/python/test_demerzel_halt_validate.py
+++ b/tests/python/test_demerzel_halt_validate.py
@@ -1,0 +1,74 @@
+"""Tests for scripts/demerzel_halt.py marker validation (Candidate 4).
+
+Verifies BOTH validation paths agree with the schema:
+  - validate()        — jsonschema when importable (full parity with Test-Json)
+  - _validate_stdlib() — the bare-Python fallback the emergency halt relies on
+
+Run: python tests/python/test_demerzel_halt_validate.py   (or via pytest)
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+import demerzel_halt as dh  # noqa: E402
+
+VALID = {"schema_version": 1, "halted_at": "2026-06-21T00:00:00Z", "reason": "investigating cost burn"}
+
+
+def _both(marker):
+    """(jsonschema-path errors, stdlib-path errors) for a marker."""
+    return dh.validate(marker), dh._validate_stdlib(marker, dh._SCHEMA)
+
+
+def test_valid_marker_passes_both_paths():
+    js, std = _both(VALID)
+    assert js == [], js
+    assert std == [], std
+
+
+def test_valid_with_optional_scope_and_expiry():
+    m = {**VALID, "scope": "global", "expires_at": "2026-06-22T00:00:00Z"}
+    js, std = _both(m)
+    assert js == [] and std == [], (js, std)
+
+
+def test_bad_scope_rejected_by_both():
+    js, std = _both({**VALID, "scope": "everything"})
+    assert js and std, (js, std)
+
+
+def test_missing_required_reason_rejected_by_both():
+    m = {"schema_version": 1, "halted_at": "2026-06-21T00:00:00Z"}
+    js, std = _both(m)
+    assert js and std, (js, std)
+
+
+def test_malformed_timestamp_rejected_by_both():
+    # Parity improvement: the old hand-rolled check only required a 'T'.
+    js, std = _both({**VALID, "halted_at": "yesterdayTmorning"})
+    assert js and std, (js, std)
+
+
+def test_additional_property_rejected_by_both():
+    # Parity improvement: additionalProperties:false now enforced in stdlib too.
+    js, std = _both({**VALID, "bogus_field": "x"})
+    assert js and std, (js, std)
+
+
+def test_overlong_reason_rejected_by_both():
+    js, std = _both({**VALID, "reason": "x" * 600})
+    assert js and std, (js, std)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"FAIL {name}: {e}")
+    print(f"\n{'OK' if not failures else str(failures) + ' FAILED'}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Candidate 4 (halt half) of the 2026-06-21 architecture review. The digest half shipped with Candidate 1 (DigestState).

`demerzel_halt.py` harvested the enum/length from the schema but its hand-rolled `validate()` enforced a **looser subset** than the PowerShell `Test-Json` adapter (no `pattern`, `additionalProperties`, or `required`-list check) — so the two adapters could diverge.

- `validate()` now uses `jsonschema` when importable (full parity with `Test-Json`), else a stdlib generic schema-subset check. The fallback is kept because the halt tool is the cross-repo **emergency brake** and must run on bare Python without `pip install`.
- `scripts/requirements-halt.txt` declares `jsonschema` (pinned) so CI takes the strong path.
- `tests/python/test_demerzel_halt_validate.py` proves both paths agree, incl. new parity catches (malformed timestamp, additional field).
- ADR-0003 amended (refines, does not reverse the stdlib-only stance).

**Verified:** 7/7 validate tests pass under both paths; CLI `status` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)