### PR TITLE
feat(governance): single-source confidence thresholds via ref:confidence tokens

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,10 +59,14 @@ fact lives in one place and is read out, never restated.
   counts and the constitutional-precedence prose are populated from it. Replaced the
   hand-maintained `context-map.yaml` (removed 2026-06-21).
 - **Canonical reference syntax** — every cross-artifact citation is a parseable token
-  (`<constitution>#<article>`, `policy:<name>`, `persona:<name>`) followed by a prose gloss
-  after `—`. Lives in YAML fields (`constitutional_basis`, `references`) and in a new
-  `validates:` frontmatter block on behavioral tests (making persona↔test bidirectional,
-  not filename-only). The manifest harvests these into resolvable edges; dangling ones fail CI.
+  (`<constitution>#<article>`, `policy:<name>`, `persona:<name>`, and `ref:confidence#<key>`
+  for the confidence ladder — added 2026-06-21, Candidate 6) followed by a prose gloss
+  after `—`. Lives in YAML fields (`constitutional_basis`, `references`, threshold values)
+  and in a new `validates:` frontmatter block on behavioral tests (making persona↔test
+  bidirectional, not filename-only). The manifest harvests these into resolvable edges;
+  dangling ones fail CI. The confidence rungs are single-sourced in
+  `logic/confidence-thresholds.yaml`; policies reference a rung
+  (`proceed_autonomously: ref:confidence#autonomous`) instead of restating `0.9`.
 - **Schema-as-single-source validation** — structural rules live once in `*.schema.json`,
   read by two thin adapters: `jsonschema` (Python) and `Test-Json -Schema` (PowerShell).
   Kills the halt-marker and digest duplication; `persona.schema.json` finally gets used.

--- a/docs/adr/0004-confidence-threshold-tokens.md
+++ b/docs/adr/0004-confidence-threshold-tokens.md
@@ -1,0 +1,58 @@
+# 4. Single-sourced confidence thresholds via ref:confidence tokens
+
+- Status: Accepted
+- Date: 2026-06-21
+- Deciders: Stephane Pareilleux
+- Source: `/improve-codebase-architecture` review + `/grilling` session (2026-06-21), Candidate 6
+
+## Context
+
+The confidence ladder — `≥0.9 autonomous · ≥0.7 with-note · ≥0.5 ask-confirmation ·
+≥0.3 escalate · <0.3 do-not-act` (stated in `CLAUDE.md`) — was restated across 8+
+policies. `auto-remediation-policy.yaml` even carried `reference: "alignment-policy.yaml
+confidence_thresholds"` beside its own copy of `0.9 / 0.7 / 0.5`. Retuning a rung meant a
+multi-file hunt, and the copies could drift.
+
+This is the same disease as ADR-0002 (harvest, don't declare), one tier down: a value
+**declared** in many places instead of read from one home.
+
+## Decision
+
+Author the ladder once in `logic/confidence-thresholds.yaml` (`thresholds.<key>` →
+`{value, operator, meaning}`), and introduce a new **canonical citation token**,
+`ref:confidence#<key>`, alongside the existing `<constitution>#<article>` / `policy:<name>`
+/ `persona:<name>` syntax. Policies reference a rung instead of restating the number:
+
+```yaml
+confidence_thresholds:
+  proceed_autonomously: ref:confidence#autonomous
+```
+
+`scripts/build_manifest.py` (`check_confidence_refs`) harvests every token, emits a
+`confidence_ref` edge, and **fails CI on a dangling key** — the same gate `precedence.yaml`
+and the canonical reference syntax already use. The values live only in the canonical file.
+
+Only genuine **ladder** restatements are migrated. Thresholds that merely share a number
+but mean something policy-specific (e.g. `autonomous-loop-policy.yaml`'s single-model
+self-merge cap at `0.8`, its bump/halt triggers) stay where they are — they are not the
+ladder. Prose that *describes* the ladder ("confidence below 0.5 → ask") stays prose.
+
+## Consequences
+
+- **Locality**: retune a rung in one file; every referencing policy follows.
+- **Leverage**: dangling references fail CI, so a renamed/removed rung can't rot silently.
+- **Trade-off (accepted)**: the consumer of a policy here is an LLM reading the YAML, and
+  it now sees `ref:confidence#autonomous` instead of the literal `0.9` — an indirection it
+  must dereference. We accept this for the single-source guarantee; the canonical file is
+  small and self-describing. (The alternative — keep the inline number and only *assert*
+  agreement, the precedence.yaml pattern — was considered and not chosen here.)
+- A new token kind joins the canonical reference syntax; future schemes resolve it.
+
+## Alternatives considered
+
+- **Keep inline values, assert agreement in the manifest** (the `precedence.yaml` pattern:
+  values stay readable, CI fails on divergence). Rejected in favour of true single-sourcing
+  with reference tokens — though it remains the better fit if the LLM-reader indirection
+  proves costly, and this ADR is the place to revisit that.
+- **Leave the restatement, document it as accepted.** Rejected: the drift risk is real
+  (`auto-remediation` already carried a hand-synced copy with a "reference" note).

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -2465,6 +2465,24 @@
       "to": "confidence:with_note",
       "kind": "confidence_ref",
       "resolved": true
+    },
+    {
+      "from": "policies/auto-remediation-policy.yaml",
+      "to": "confidence:ask_confirmation",
+      "kind": "confidence_ref",
+      "resolved": true
+    },
+    {
+      "from": "policies/auto-remediation-policy.yaml",
+      "to": "confidence:autonomous",
+      "kind": "confidence_ref",
+      "resolved": true
+    },
+    {
+      "from": "policies/auto-remediation-policy.yaml",
+      "to": "confidence:with_note",
+      "kind": "confidence_ref",
+      "resolved": true
     }
   ],
   "precedence": [

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -2441,6 +2441,30 @@
       "to": "policy:weakness-prober-policy",
       "kind": "validates",
       "resolved": true
+    },
+    {
+      "from": "policies/alignment-policy.yaml",
+      "to": "confidence:ask_confirmation",
+      "kind": "confidence_ref",
+      "resolved": true
+    },
+    {
+      "from": "policies/alignment-policy.yaml",
+      "to": "confidence:autonomous",
+      "kind": "confidence_ref",
+      "resolved": true
+    },
+    {
+      "from": "policies/alignment-policy.yaml",
+      "to": "confidence:escalate",
+      "kind": "confidence_ref",
+      "resolved": true
+    },
+    {
+      "from": "policies/alignment-policy.yaml",
+      "to": "confidence:with_note",
+      "kind": "confidence_ref",
+      "resolved": true
     }
   ],
   "precedence": [

--- a/logic/confidence-thresholds.yaml
+++ b/logic/confidence-thresholds.yaml
@@ -1,0 +1,35 @@
+# Canonical confidence thresholds — the SINGLE source for the confidence ladder
+# that was restated across 8+ policies (the `≥0.9 autonomous · ≥0.7 with note ·
+# ≥0.5 ask · ≥0.3 escalate · <0.3 do-not-act` ladder in CLAUDE.md).
+#
+# Policies reference a rung by token instead of restating the number:
+#
+#     proceed_autonomously: ref:confidence#autonomous
+#
+# scripts/build_manifest.py resolves every `ref:confidence#<key>` token against
+# the `thresholds` keys below and FAILS CI on a dangling key (Candidate 6 of the
+# 2026-06-21 architecture review; the precedent is precedence.yaml + the canonical
+# reference syntax). Retuning a rung is a one-line edit here.
+schema_version: 1
+
+thresholds:
+  autonomous:
+    value: 0.9
+    operator: ">="
+    meaning: "Proceed autonomously."
+  with_note:
+    value: 0.7
+    operator: ">="
+    meaning: "Proceed, but leave a note."
+  ask_confirmation:
+    value: 0.5
+    operator: ">="
+    meaning: "Ask for confirmation before acting."
+  escalate:
+    value: 0.3
+    operator: ">="
+    meaning: "Escalate to a human."
+  do_not_act:
+    value: 0.3
+    operator: "<"
+    meaning: "Below 0.3 — do not act."

--- a/policies/alignment-policy.yaml
+++ b/policies/alignment-policy.yaml
@@ -27,11 +27,13 @@ verification_methods:
     - Report any deviations from the original plan
     - Log the action with rationale
 
+# Values single-sourced in logic/confidence-thresholds.yaml; build_manifest
+# resolves these ref:confidence#<key> tokens and fails CI on a dangling key.
 confidence_thresholds:
-  proceed_autonomously: 0.9
-  proceed_with_note: 0.7
-  ask_for_confirmation: 0.5
-  escalate_to_human: 0.3
+  proceed_autonomously: ref:confidence#autonomous
+  proceed_with_note: ref:confidence#with_note
+  ask_for_confirmation: ref:confidence#ask_confirmation
+  escalate_to_human: ref:confidence#escalate
 
 escalation_triggers:
   - Confidence below escalation threshold

--- a/policies/auto-remediation-policy.yaml
+++ b/policies/auto-remediation-policy.yaml
@@ -163,21 +163,22 @@ auto_remediation_actions:
 confidence_gating:
   description: "Align auto-remediation decisions with alignment-policy.yaml thresholds"
   reference: "alignment-policy.yaml confidence_thresholds"
+  # Values single-sourced in logic/confidence-thresholds.yaml via ref:confidence#<key>.
   thresholds:
     silent_auto_remediate:
-      minimum: 0.9
+      minimum: ref:confidence#autonomous
       behavior: "Auto-remediate without notification"
       applies_to: [low]
     notified_auto_remediate:
-      minimum: 0.7
+      minimum: ref:confidence#with_note
       behavior: "Auto-remediate and post notification via GitHub Discussion"
       applies_to: [low, medium]
     propose_and_wait:
-      minimum: 0.5
+      minimum: ref:confidence#ask_confirmation
       behavior: "Propose remediation in GitHub Issue, wait for human confirmation before acting"
       applies_to: [low, medium, high]
     escalate_no_action:
-      below: 0.5
+      below: ref:confidence#ask_confirmation
       behavior: "Escalate to human via GitHub Issue; do not take any remediation action"
       applies_to: [low, medium, high]
 

--- a/scripts/build_manifest.py
+++ b/scripts/build_manifest.py
@@ -38,7 +38,10 @@ import yaml
 REPO = Path(__file__).resolve().parent.parent
 MANIFEST = REPO / "governance-manifest.json"
 HEALTH = REPO / "governance-health.json"
+CONFIDENCE = REPO / "logic" / "confidence-thresholds.yaml"
 SCHEMA_VERSION = 1
+
+_CONFIDENCE_REF = re.compile(r"ref:confidence#([\w-]+)")
 
 if hasattr(sys.stdout, "reconfigure"):  # Windows consoles default to cp1252.
     sys.stdout.reconfigure(encoding="utf-8")
@@ -399,6 +402,29 @@ def check_precedence(inv: dict[str, list[dict[str, Any]]]) -> tuple[dict[str, An
     return prec, violations
 
 
+def check_confidence_refs(inv: dict[str, list[dict[str, Any]]]) -> tuple[list[dict[str, Any]], list[str]]:
+    """Resolve every `ref:confidence#<key>` token against the canonical thresholds
+    (logic/confidence-thresholds.yaml). Returns (edges, violations); a token that
+    names no such rung is a hard violation. ADR-0002 / Candidate 6 — the values
+    are single-sourced; policies reference a rung instead of restating the number."""
+    edges: list[dict[str, Any]] = []
+    violations: list[str] = []
+    if not CONFIDENCE.exists():
+        return edges, ["confidence: logic/confidence-thresholds.yaml is missing"]
+    thresholds = (yaml.safe_load(CONFIDENCE.read_text(encoding="utf-8")) or {}).get("thresholds", {})
+    valid = set(thresholds)
+    for art in inv.get("policy", []):
+        text = (REPO / art["path"]).read_text(encoding="utf-8")
+        for key in sorted(set(_CONFIDENCE_REF.findall(text))):
+            ok = key in valid
+            edges.append({"from": art["path"], "to": f"confidence:{key}", "kind": "confidence_ref", "resolved": ok})
+            if not ok:
+                violations.append(
+                    f"dangling confidence ref: {art['path']} -> ref:confidence#{key} (valid: {sorted(valid)})"
+                )
+    return edges, violations
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -414,6 +440,10 @@ def build() -> tuple[dict[str, Any], list[str], list[str]]:
     hard += check_readme_counts(counts)
     precedence, prec_violations = check_precedence(inv)
     hard += prec_violations
+
+    conf_edges, conf_violations = check_confidence_refs(inv)
+    edges += conf_edges
+    hard += conf_violations
 
     manifest = {
         "schema_version": SCHEMA_VERSION,


### PR DESCRIPTION
Candidate 6 of the 2026-06-21 architecture review.

The confidence ladder (`≥0.9 autonomous / ≥0.7 with-note / ≥0.5 ask / ≥0.3 escalate / <0.3 do-not-act`) was restated across 8+ policies.

- `logic/confidence-thresholds.yaml`: canonical rungs (value/operator/meaning).
- New canonical citation-token kind `ref:confidence#<key>`. `build_manifest.py` gains `check_confidence_refs()`: resolves every token, emits `confidence_ref` edges, and **fails CI on a dangling key** (precedent: precedence.yaml + canonical reference syntax).
- `alignment-policy.yaml` migrated as the reference consumer.
- CONTEXT.md records the new token kind + single source.

**Verified:** manifest green when valid; a bogus key fails with exit 1.

Per the design discussion, the LLM-reader indirection (token vs inline `0.9`) is the accepted trade. Remaining policies follow the same pattern (mechanical follow-up; coordinate with #351). Worth an ADR-0004 for the new token kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)