### PR TITLE
feat(ci): wire post_discussion.sh across all workflows (integrates #365 + #366)

### DIFF
--- a/.github/actions/ecosystem/action.yml
+++ b/.github/actions/ecosystem/action.yml
@@ -1,0 +1,84 @@
+name: 'Ecosystem facts'
+description: >
+  Single source of GuitarAlchemist ecosystem identity (repo node id, discussion
+  category ids, consumer repos) and governance counts. Reads them once from
+  schemas/capability-registry.json + governance-manifest.json and exposes them as
+  outputs, so no workflow restates a category id or re-runs `ls | wc -l`.
+  Requires the repo to be checked out first (actions/checkout).
+
+outputs:
+  repo_node_id:
+    description: 'GraphQL node id of the Demerzel repo'
+    value: ${{ steps.eco.outputs.repo_node_id }}
+  consumer_repos:
+    description: 'Space-separated consumer repo keys (ix tars ga), from .repos'
+    value: ${{ steps.eco.outputs.consumer_repos }}
+  cat_announcements:
+    description: 'Discussion category id: Announcements'
+    value: ${{ steps.eco.outputs.cat_announcements }}
+  cat_general:
+    description: 'Discussion category id: General'
+    value: ${{ steps.eco.outputs.cat_general }}
+  cat_ideas:
+    description: 'Discussion category id: Ideas'
+    value: ${{ steps.eco.outputs.cat_ideas }}
+  cat_polls:
+    description: 'Discussion category id: Polls'
+    value: ${{ steps.eco.outputs.cat_polls }}
+  cat_q_and_a:
+    description: 'Discussion category id: Q&A'
+    value: ${{ steps.eco.outputs.cat_q_and_a }}
+  cat_show_and_tell:
+    description: 'Discussion category id: Show and tell'
+    value: ${{ steps.eco.outputs.cat_show_and_tell }}
+  count_persona:
+    description: 'Number of personas'
+    value: ${{ steps.eco.outputs.count_persona }}
+  count_policy:
+    description: 'Number of policies'
+    value: ${{ steps.eco.outputs.count_policy }}
+  count_constitution:
+    description: 'Number of constitutions'
+    value: ${{ steps.eco.outputs.count_constitution }}
+  count_behavioral_test:
+    description: 'Number of behavioral tests'
+    value: ${{ steps.eco.outputs.count_behavioral_test }}
+  count_schema:
+    description: 'Number of schemas'
+    value: ${{ steps.eco.outputs.count_schema }}
+  count_workflow:
+    description: 'Number of workflows'
+    value: ${{ steps.eco.outputs.count_workflow }}
+  count_skill:
+    description: 'Number of skills'
+    value: ${{ steps.eco.outputs.count_skill }}
+  count_pipeline:
+    description: 'Number of pipelines'
+    value: ${{ steps.eco.outputs.count_pipeline }}
+  count_grammar:
+    description: 'Number of grammars'
+    value: ${{ steps.eco.outputs.count_grammar }}
+  count_contract_schema:
+    description: 'Number of contract schemas'
+    value: ${{ steps.eco.outputs.count_contract_schema }}
+
+runs:
+  using: composite
+  steps:
+    - id: eco
+      shell: bash
+      run: |
+        set -euo pipefail
+        reg=schemas/capability-registry.json
+        man=governance-manifest.json
+        {
+          echo "repo_node_id=$(jq -r '.github.repo_node_id' "$reg")"
+          echo "consumer_repos=$(jq -r '.repos | keys | join(" ")' "$reg")"
+          for c in announcements general ideas polls q-and-a show-and-tell; do
+            key=$(echo "$c" | tr '-' '_')
+            echo "cat_${key}=$(jq -r --arg c "$c" '.github.discussion_categories[$c]' "$reg")"
+          done
+          for k in persona policy constitution behavioral_test schema workflow skill pipeline grammar contract_schema; do
+            echo "count_${k}=$(jq -r --arg k "$k" '.counts[$k]' "$man")"
+          done
+        } >> "$GITHUB_OUTPUT"

--- a/.github/scripts/llm_call.sh
+++ b/.github/scripts/llm_call.sh
@@ -3,6 +3,8 @@
 #
 # Usage:   llm_call.sh <provider> <prompt> [max_tokens]
 #          provider ∈ claude | gemini | codex   (codex == openai)
+#          LLM_SYSTEM (env, optional) — system prompt, carried per-provider.
+#          LLM_<PROVIDER>_MODEL (env, optional) — override the default model.
 # Output:  the model's text on stdout.
 #
 # Collapses the curl + auth-header + payload-escaping + response-extraction that
@@ -33,8 +35,9 @@ _http_post() {
 
 _call_claude() {
   local prompt="$1" max="$2"
-  jq -n --arg m "$CLAUDE_MODEL" --argjson mx "$max" --arg p "$prompt" \
-      '{model:$m, max_tokens:$mx, messages:[{role:"user", content:$p}]}' \
+  jq -n --arg m "$CLAUDE_MODEL" --argjson mx "$max" --arg p "$prompt" --arg s "${LLM_SYSTEM:-}" \
+      '{model:$m, max_tokens:$mx, messages:[{role:"user", content:$p}]}
+       + (if $s == "" then {} else {system:$s} end)' \
     | _http_post "$CLAUDE_URL" \
         -H "x-api-key: ${ANTHROPIC_API_KEY:-}" \
         -H "anthropic-version: 2023-06-01" \
@@ -44,8 +47,9 @@ _call_claude() {
 
 _call_gemini() {
   local prompt="$1" max="$2"
-  jq -n --argjson mx "$max" --arg p "$prompt" \
-      '{contents:[{parts:[{text:$p}]}], generationConfig:{maxOutputTokens:$mx}}' \
+  jq -n --argjson mx "$max" --arg p "$prompt" --arg s "${LLM_SYSTEM:-}" \
+      '{contents:[{parts:[{text:$p}]}], generationConfig:{maxOutputTokens:$mx}}
+       + (if $s == "" then {} else {systemInstruction:{parts:[{text:$s}]}} end)' \
     | _http_post "${GEMINI_URL}/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY:-}" \
         -H "content-type: application/json" \
     | jq -r '.candidates[0].content.parts[0].text'
@@ -53,8 +57,9 @@ _call_gemini() {
 
 _call_openai() {
   local prompt="$1" max="$2"
-  jq -n --arg m "$OPENAI_MODEL" --argjson mx "$max" --arg p "$prompt" \
-      '{model:$m, max_completion_tokens:$mx, messages:[{role:"user", content:$p}]}' \
+  jq -n --arg m "$OPENAI_MODEL" --argjson mx "$max" --arg p "$prompt" --arg s "${LLM_SYSTEM:-}" \
+      '{model:$m, max_completion_tokens:$mx,
+        messages: ((if $s == "" then [] else [{role:"system", content:$s}] end) + [{role:"user", content:$p}])}' \
     | _http_post "$OPENAI_URL" \
         -H "authorization: Bearer ${OPENAI_API_KEY:-}" \
         -H "content-type: application/json" \

--- a/.github/scripts/llm_call.sh
+++ b/.github/scripts/llm_call.sh
@@ -5,18 +5,24 @@
 #          provider ∈ claude | gemini | codex   (codex == openai)
 #          LLM_SYSTEM (env, optional) — system prompt, carried per-provider.
 #          LLM_<PROVIDER>_MODEL (env, optional) — override the default model.
-# Output:  the model's text on stdout.
+#
+# Contract (so callers never parse the raw JSON themselves):
+#   stdout      — the model's text (only on success)
+#   stderr      — a human diagnostic (only on failure)
+#   exit code   — 0 ok · 2 usage · 3 API/transport error · 4 empty/blocked response
+#
+# Use the if-form, which is set -e safe (GitHub runs run: blocks with -eo pipefail):
+#   if TEXT=$(llm_call.sh claude "$p" 2>/tmp/err); then ... ; else <fallback>; fi
 #
 # Collapses the curl + auth-header + payload-escaping + response-extraction that
 # was re-typed across 8 workflows (and 3x in cross-model-review.yml). The
-# per-provider response shape (.content[0].text vs .candidates[].. vs
-# .choices[]..) is the only real difference and it lives here, once.
+# per-provider request/response shapes are the only real difference; they live
+# here, once.
 #
 # Testability (Candidate 3): the network call is the single function _http_post.
-# bats sources this file and overrides _http_post with a fixture, so the auth +
-# extraction logic is unit-tested without a live API. Endpoints + models are
-# env-overridable for the same reason. main() runs only when executed, not when
-# sourced.
+# bats sources this file and overrides _http_post with a fixture, so the auth,
+# extraction, AND error-classification logic are unit-tested without a live API.
+# Endpoints + models are env-overridable. main() runs only when executed.
 set -euo pipefail
 
 CLAUDE_URL="${LLM_CLAUDE_URL:-https://api.anthropic.com/v1/messages}"
@@ -33,37 +39,61 @@ _http_post() {
   curl -sS -X POST "$url" "$@" --data @-
 }
 
+# _emit <raw> <text_filter> <error_filter> — classify a raw response into the
+# contract. stdout+return 0 on success; stderr+return 3/4 on failure. All three
+# providers route through here so the error contract is identical.
+_emit() {
+  local raw="$1" text_filter="$2" error_filter="$3"
+  if [ -z "$raw" ]; then
+    echo "llm_call: transport failure (no response body)" >&2
+    return 3
+  fi
+  local apierr
+  apierr=$(printf '%s' "$raw" | jq -r "$error_filter" 2>/dev/null || true)
+  if [ -n "$apierr" ] && [ "$apierr" != "null" ]; then
+    echo "llm_call: API error: $apierr" >&2
+    return 3
+  fi
+  local text
+  text=$(printf '%s' "$raw" | jq -r "$text_filter" 2>/dev/null || true)
+  if [ -z "$text" ] || [ "$text" = "null" ]; then
+    echo "llm_call: no text in response: $(printf '%s' "$raw" | tr -d '\n' | head -c 300)" >&2
+    return 4
+  fi
+  printf '%s\n' "$text"
+}
+
 _call_claude() {
-  local prompt="$1" max="$2"
-  jq -n --arg m "$CLAUDE_MODEL" --argjson mx "$max" --arg p "$prompt" --arg s "${LLM_SYSTEM:-}" \
+  local prompt="$1" max="$2" raw
+  raw=$(jq -n --arg m "$CLAUDE_MODEL" --argjson mx "$max" --arg p "$prompt" --arg s "${LLM_SYSTEM:-}" \
       '{model:$m, max_tokens:$mx, messages:[{role:"user", content:$p}]}
        + (if $s == "" then {} else {system:$s} end)' \
     | _http_post "$CLAUDE_URL" \
         -H "x-api-key: ${ANTHROPIC_API_KEY:-}" \
         -H "anthropic-version: 2023-06-01" \
-        -H "content-type: application/json" \
-    | jq -r '.content[0].text'
+        -H "content-type: application/json") || true
+  _emit "$raw" '.content[0].text' '.error.message // empty'
 }
 
 _call_gemini() {
-  local prompt="$1" max="$2"
-  jq -n --argjson mx "$max" --arg p "$prompt" --arg s "${LLM_SYSTEM:-}" \
+  local prompt="$1" max="$2" raw
+  raw=$(jq -n --argjson mx "$max" --arg p "$prompt" --arg s "${LLM_SYSTEM:-}" \
       '{contents:[{parts:[{text:$p}]}], generationConfig:{maxOutputTokens:$mx}}
        + (if $s == "" then {} else {systemInstruction:{parts:[{text:$s}]}} end)' \
     | _http_post "${GEMINI_URL}/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY:-}" \
-        -H "content-type: application/json" \
-    | jq -r '.candidates[0].content.parts[0].text'
+        -H "content-type: application/json") || true
+  _emit "$raw" '.candidates[0].content.parts[0].text' '.error.message // empty'
 }
 
 _call_openai() {
-  local prompt="$1" max="$2"
-  jq -n --arg m "$OPENAI_MODEL" --argjson mx "$max" --arg p "$prompt" --arg s "${LLM_SYSTEM:-}" \
+  local prompt="$1" max="$2" raw
+  raw=$(jq -n --arg m "$OPENAI_MODEL" --argjson mx "$max" --arg p "$prompt" --arg s "${LLM_SYSTEM:-}" \
       '{model:$m, max_completion_tokens:$mx,
         messages: ((if $s == "" then [] else [{role:"system", content:$s}] end) + [{role:"user", content:$p}])}' \
     | _http_post "$OPENAI_URL" \
         -H "authorization: Bearer ${OPENAI_API_KEY:-}" \
-        -H "content-type: application/json" \
-    | jq -r '.choices[0].message.content'
+        -H "content-type: application/json") || true
+  _emit "$raw" '.choices[0].message.content' '.error.message // empty'
 }
 
 main() {

--- a/.github/scripts/llm_call.sh
+++ b/.github/scripts/llm_call.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# llm_call.sh — one place for "call an LLM and get its text back".
+#
+# Usage:   llm_call.sh <provider> <prompt> [max_tokens]
+#          provider ∈ claude | gemini | codex   (codex == openai)
+# Output:  the model's text on stdout.
+#
+# Collapses the curl + auth-header + payload-escaping + response-extraction that
+# was re-typed across 8 workflows (and 3x in cross-model-review.yml). The
+# per-provider response shape (.content[0].text vs .candidates[].. vs
+# .choices[]..) is the only real difference and it lives here, once.
+#
+# Testability (Candidate 3): the network call is the single function _http_post.
+# bats sources this file and overrides _http_post with a fixture, so the auth +
+# extraction logic is unit-tested without a live API. Endpoints + models are
+# env-overridable for the same reason. main() runs only when executed, not when
+# sourced.
+set -euo pipefail
+
+CLAUDE_URL="${LLM_CLAUDE_URL:-https://api.anthropic.com/v1/messages}"
+GEMINI_URL="${LLM_GEMINI_URL:-https://generativelanguage.googleapis.com/v1beta/models}"
+OPENAI_URL="${LLM_OPENAI_URL:-https://api.openai.com/v1/chat/completions}"
+CLAUDE_MODEL="${LLM_CLAUDE_MODEL:-claude-sonnet-4-20250514}"
+GEMINI_MODEL="${LLM_GEMINI_MODEL:-gemini-2.0-flash}"
+OPENAI_MODEL="${LLM_OPENAI_MODEL:-gpt-4o}"
+
+# _http_post <url> [curl-args...] — THE seam. Reads the request body on stdin,
+# prints the raw response on stdout. Overridden by tests.
+_http_post() {
+  local url="$1"; shift
+  curl -sS -X POST "$url" "$@" --data @-
+}
+
+_call_claude() {
+  local prompt="$1" max="$2"
+  jq -n --arg m "$CLAUDE_MODEL" --argjson mx "$max" --arg p "$prompt" \
+      '{model:$m, max_tokens:$mx, messages:[{role:"user", content:$p}]}' \
+    | _http_post "$CLAUDE_URL" \
+        -H "x-api-key: ${ANTHROPIC_API_KEY:-}" \
+        -H "anthropic-version: 2023-06-01" \
+        -H "content-type: application/json" \
+    | jq -r '.content[0].text'
+}
+
+_call_gemini() {
+  local prompt="$1" max="$2"
+  jq -n --argjson mx "$max" --arg p "$prompt" \
+      '{contents:[{parts:[{text:$p}]}], generationConfig:{maxOutputTokens:$mx}}' \
+    | _http_post "${GEMINI_URL}/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY:-}" \
+        -H "content-type: application/json" \
+    | jq -r '.candidates[0].content.parts[0].text'
+}
+
+_call_openai() {
+  local prompt="$1" max="$2"
+  jq -n --arg m "$OPENAI_MODEL" --argjson mx "$max" --arg p "$prompt" \
+      '{model:$m, max_completion_tokens:$mx, messages:[{role:"user", content:$p}]}' \
+    | _http_post "$OPENAI_URL" \
+        -H "authorization: Bearer ${OPENAI_API_KEY:-}" \
+        -H "content-type: application/json" \
+    | jq -r '.choices[0].message.content'
+}
+
+main() {
+  local provider="${1:?usage: llm_call.sh <provider> <prompt> [max_tokens]}"
+  local prompt="${2:?prompt required}"
+  local max="${3:-1024}"
+  case "$provider" in
+    claude)       _call_claude "$prompt" "$max" ;;
+    gemini)       _call_gemini "$prompt" "$max" ;;
+    codex|openai) _call_openai "$prompt" "$max" ;;
+    *) echo "llm_call: unknown provider '$provider' (claude|gemini|codex)" >&2; exit 2 ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.github/scripts/post_discussion.sh
+++ b/.github/scripts/post_discussion.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# post_discussion.sh — one place for "create a GitHub Discussion".
+#
+# Usage:   REPO_NODE_ID=<id> post_discussion.sh <category_id> <title> <body>
+# Output:  the new discussion URL on stdout.
+#
+# Collapses the createDiscussion GraphQL ceremony re-typed across 9 workflows.
+# Crucially it RAISES (non-zero exit) on failure instead of the `|| echo
+# "Failed"` swallow those workflows used — a failed post is now a failed step,
+# not a silent green. category_id is passed in (resolve it via the ecosystem
+# action's cat_* outputs — Candidate 2), so this script owns the call, not the ids.
+#
+# Testability (Candidate 3): the GraphQL call is the single function _graphql.
+# bats sources this file and overrides _graphql, so the build/validate/raise
+# logic is unit-tested without hitting GitHub. main() runs only when executed.
+set -euo pipefail
+
+# _graphql <query> <repo> <cat> <title> <body> — THE seam. Prints the created
+# discussion URL (or empty/"null" on failure). Overridden by tests.
+_graphql() {
+  gh api graphql \
+    -f query="$1" \
+    -f repo="$2" -f cat="$3" -f title="$4" -f body="$5" \
+    --jq '.data.createDiscussion.discussion.url'
+}
+
+main() {
+  local category_id="${1:?usage: post_discussion.sh <category_id> <title> <body>}"
+  local title="${2:?title required}"
+  local body="${3:?body required}"
+  local repo="${REPO_NODE_ID:?REPO_NODE_ID env required}"
+
+  # shellcheck disable=SC2016  # $repo/$cat/... are GraphQL variables, not shell — single quotes are intentional
+  local query='mutation($repo: ID!, $cat: ID!, $title: String!, $body: String!) {
+  createDiscussion(input: {repositoryId: $repo, categoryId: $cat, title: $title, body: $body}) {
+    discussion { url }
+  }
+}'
+
+  local url
+  url="$(_graphql "$query" "$repo" "$category_id" "$title" "$body")"
+  if [[ -z "$url" || "$url" == "null" ]]; then
+    echo "post_discussion: createDiscussion returned no URL (category=$category_id)" >&2
+    exit 1
+  fi
+  echo "$url"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.github/workflows/cross-model-review.yml
+++ b/.github/workflows/cross-model-review.yml
@@ -183,38 +183,18 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          PROMPT=$(cat /tmp/review_prompt.txt)
-          ESCAPED=$(echo "$PROMPT" | jq -Rs .)
-
-          RESPONSE=$(curl -s -X POST https://api.anthropic.com/v1/messages \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "content-type: application/json" \
-            -d "{
-              \"model\": \"claude-sonnet-4-20250514\",
-              \"max_tokens\": 2048,
-              \"messages\": [{\"role\": \"user\", \"content\": $ESCAPED}]
-            }")
-
-          echo "$RESPONSE" | jq -r '.content[0].text // "Review failed: no response"' > /tmp/review_result.txt
+          bash .github/scripts/llm_call.sh claude "$(cat /tmp/review_prompt.txt)" 2048 \
+            > /tmp/review_result.txt || echo "Review failed: no response" > /tmp/review_result.txt
 
       - name: Run Gemini review
         if: env.SKIP_REVIEW != 'true' && steps.reviewer.outputs.reviewer == 'gemini'
         id: gemini_review
         env:
-          GOOGLE_AI_KEY: ${{ secrets.GOOGLE_AI_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_AI_KEY }}
+          LLM_GEMINI_MODEL: gemini-2.5-flash
         run: |
-          PROMPT=$(cat /tmp/review_prompt.txt)
-          ESCAPED=$(echo "$PROMPT" | jq -Rs .)
-
-          RESPONSE=$(curl -s -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GOOGLE_AI_KEY" \
-            -H "content-type: application/json" \
-            -d "{
-              \"contents\": [{\"parts\": [{\"text\": $ESCAPED}]}],
-              \"generationConfig\": {\"maxOutputTokens\": 2048}
-            }")
-
-          echo "$RESPONSE" | jq -r '.candidates[0].content.parts[0].text // "Review failed: no response"' > /tmp/review_result.txt
+          bash .github/scripts/llm_call.sh gemini "$(cat /tmp/review_prompt.txt)" 2048 \
+            > /tmp/review_result.txt || echo "Review failed: no response" > /tmp/review_result.txt
 
       - name: Run Codex review
         if: env.SKIP_REVIEW != 'true' && steps.reviewer.outputs.reviewer == 'codex'
@@ -222,19 +202,8 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          PROMPT=$(cat /tmp/review_prompt.txt)
-          ESCAPED=$(echo "$PROMPT" | jq -Rs .)
-
-          RESPONSE=$(curl -s -X POST https://api.openai.com/v1/chat/completions \
-            -H "Authorization: Bearer $OPENAI_API_KEY" \
-            -H "content-type: application/json" \
-            -d "{
-              \"model\": \"gpt-4o\",
-              \"max_tokens\": 2048,
-              \"messages\": [{\"role\": \"user\", \"content\": $ESCAPED}]
-            }")
-
-          echo "$RESPONSE" | jq -r '.choices[0].message.content // "Review failed: no response"' > /tmp/review_result.txt
+          bash .github/scripts/llm_call.sh codex "$(cat /tmp/review_prompt.txt)" 2048 \
+            > /tmp/review_result.txt || echo "Review failed: no response" > /tmp/review_result.txt
 
       - name: Post review to PR
         if: env.SKIP_REVIEW != 'true'

--- a/.github/workflows/demerzel-autofix.yml
+++ b/.github/workflows/demerzel-autofix.yml
@@ -117,25 +117,15 @@ jobs:
           ISSUES=$(cat /tmp/issues.json)
           CONTEXT=$(cat /tmp/context.md)
 
-          # Call Claude API for intelligent triage
-          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "content-type: application/json" \
-            -d "$(jq -n \
-              --arg ctx "$CONTEXT" \
-              --arg issues "$ISSUES" \
-              '{
-                model: "claude-sonnet-4-20250514",
-                max_tokens: 4000,
-                messages: [{
-                  role: "user",
-                  content: ("You are Demerzel, an AI governance coordinator. Triage these open GitHub issues.\n\nGovernance context:\n" + $ctx + "\n\nOpen issues (JSON):\n" + $issues + "\n\nFor each issue, respond in this exact JSON format (array of objects):\n```json\n[\n  {\n    \"number\": 42,\n    \"title\": \"issue title\",\n    \"classification\": \"governance-gap | feature | bug | documentation | maintenance | research\",\n    \"priority\": \"P0 | P1 | P2 | P3\",\n    \"auto_fixable\": true or false,\n    \"fix_description\": \"what would fix this issue\",\n    \"evidence_of_completion\": [\"file or condition that proves completion\"],\n    \"is_complete\": true or false,\n    \"completion_evidence\": \"why you think it is complete, or null\",\n    \"blocked_by\": \"what blocks this, or null\",\n    \"recommended_action\": \"close | fix-now | needs-human | defer\"\n  }\n]\n```\n\nBe precise. Check if issues are already resolved by recent commits. Only mark as complete if you have concrete evidence.")
-                }]
-              }')" 2>/dev/null)
+          # Call Claude via the shared llm_call.sh seam (Candidate 3).
+          PROMPT=$(jq -rn \
+            --arg ctx "$CONTEXT" \
+            --arg issues "$ISSUES" \
+            '("You are Demerzel, an AI governance coordinator. Triage these open GitHub issues.\n\nGovernance context:\n" + $ctx + "\n\nOpen issues (JSON):\n" + $issues + "\n\nFor each issue, respond in this exact JSON format (array of objects):\n```json\n[\n  {\n    \"number\": 42,\n    \"title\": \"issue title\",\n    \"classification\": \"governance-gap | feature | bug | documentation | maintenance | research\",\n    \"priority\": \"P0 | P1 | P2 | P3\",\n    \"auto_fixable\": true or false,\n    \"fix_description\": \"what would fix this issue\",\n    \"evidence_of_completion\": [\"file or condition that proves completion\"],\n    \"is_complete\": true or false,\n    \"completion_evidence\": \"why you think it is complete, or null\",\n    \"blocked_by\": \"what blocks this, or null\",\n    \"recommended_action\": \"close | fix-now | needs-human | defer\"\n  }\n]\n```\n\nBe precise. Check if issues are already resolved by recent commits. Only mark as complete if you have concrete evidence.")')
+          RESPONSE=$(bash .github/scripts/llm_call.sh claude "$PROMPT" 4000)
 
           # Extract the JSON array from the response
-          TRIAGE=$(echo "$RESPONSE" | jq -r '.content[0].text' | sed -n '/```json/,/```/p' | sed '1d;$d')
+          TRIAGE=$(echo "$RESPONSE" | sed -n '/```json/,/```/p' | sed '1d;$d')
 
           if [ -z "$TRIAGE" ] || [ "$TRIAGE" = "null" ]; then
             echo "AI triage failed, falling back to basic scan"

--- a/.github/workflows/demerzel-autofix.yml
+++ b/.github/workflows/demerzel-autofix.yml
@@ -38,6 +38,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Ecosystem facts
+        id: eco
+        uses: ./.github/actions/ecosystem
+
       - name: Gather context
         id: context
         env:
@@ -65,11 +69,12 @@ jobs:
           COUNT=$(echo "$ISSUES" | jq 'length')
           echo "ISSUE_COUNT=$COUNT" >> $GITHUB_OUTPUT
 
-          # Inventory governance artifacts for context
-          PERSONA_COUNT=$(ls personas/*.persona.yaml 2>/dev/null | wc -l)
-          POLICY_COUNT=$(ls policies/*.yaml 2>/dev/null | wc -l)
-          TEST_COUNT=$(ls tests/behavioral/*.md 2>/dev/null | wc -l)
-          SCHEMA_COUNT=$(find schemas/ -name "*.json" 2>/dev/null | wc -l)
+          # Governance counts harvested from the manifest (ADR-0002); state
+          # counts below are runtime dirs the manifest does not track.
+          PERSONA_COUNT=${{ steps.eco.outputs.count_persona }}
+          POLICY_COUNT=${{ steps.eco.outputs.count_policy }}
+          TEST_COUNT=${{ steps.eco.outputs.count_behavioral_test }}
+          SCHEMA_COUNT=$(( ${{ steps.eco.outputs.count_schema }} + ${{ steps.eco.outputs.count_contract_schema }} ))
           BELIEF_COUNT=$(ls state/beliefs/*.json 2>/dev/null | wc -l)
           SIGNAL_COUNT=$(ls state/conscience/signals/*.json 2>/dev/null | wc -l)
           PATTERN_COUNT=$(ls state/conscience/patterns/*.json 2>/dev/null | wc -l)
@@ -238,8 +243,8 @@ jobs:
 
           URL=$(gh api graphql -f query="mutation {
             createDiscussion(input: {
-              repositoryId: \"R_kgDORnMyyQ\",
-              categoryId: \"DIC_kwDORnMyyc4C4eDT\",
+              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
+              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
               title: \"🔧 Auto-Remediation Scan — $DATE\",
               body: $BODY
             }) {

--- a/.github/workflows/demerzel-autofix.yml
+++ b/.github/workflows/demerzel-autofix.yml
@@ -233,16 +233,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           DATE="${{ steps.context.outputs.DATE }}"
-          BODY=$(cat remediation-report.md | jq -Rs .)
-
-          URL=$(gh api graphql -f query="mutation {
-            createDiscussion(input: {
-              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
-              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
-              title: \"🔧 Auto-Remediation Scan — $DATE\",
-              body: $BODY
-            }) {
-              discussion { url }
-            }
-          }" --jq '.data.createDiscussion.discussion.url' 2>/dev/null || echo "Failed to post")
+          URL=$(REPO_NODE_ID="${{ steps.eco.outputs.repo_node_id }}" \
+            bash .github/scripts/post_discussion.sh \
+              "${{ steps.eco.outputs.cat_general }}" "🔧 Auto-Remediation Scan — $DATE" "$(cat remediation-report.md)")
           echo "Remediation Discussion: $URL"

--- a/.github/workflows/demerzel-autofix.yml
+++ b/.github/workflows/demerzel-autofix.yml
@@ -122,10 +122,14 @@ jobs:
             --arg ctx "$CONTEXT" \
             --arg issues "$ISSUES" \
             '("You are Demerzel, an AI governance coordinator. Triage these open GitHub issues.\n\nGovernance context:\n" + $ctx + "\n\nOpen issues (JSON):\n" + $issues + "\n\nFor each issue, respond in this exact JSON format (array of objects):\n```json\n[\n  {\n    \"number\": 42,\n    \"title\": \"issue title\",\n    \"classification\": \"governance-gap | feature | bug | documentation | maintenance | research\",\n    \"priority\": \"P0 | P1 | P2 | P3\",\n    \"auto_fixable\": true or false,\n    \"fix_description\": \"what would fix this issue\",\n    \"evidence_of_completion\": [\"file or condition that proves completion\"],\n    \"is_complete\": true or false,\n    \"completion_evidence\": \"why you think it is complete, or null\",\n    \"blocked_by\": \"what blocks this, or null\",\n    \"recommended_action\": \"close | fix-now | needs-human | defer\"\n  }\n]\n```\n\nBe precise. Check if issues are already resolved by recent commits. Only mark as complete if you have concrete evidence.")')
-          RESPONSE=$(bash .github/scripts/llm_call.sh claude "$PROMPT" 4000)
-
-          # Extract the JSON array from the response
-          TRIAGE=$(echo "$RESPONSE" | sed -n '/```json/,/```/p' | sed '1d;$d')
+          # if-form: a non-zero llm_call (API/transport error) falls through to
+          # the basic-scan fallback instead of aborting the step under -e.
+          if RESPONSE=$(bash .github/scripts/llm_call.sh claude "$PROMPT" 4000 2>/tmp/llm_err); then
+            TRIAGE=$(echo "$RESPONSE" | sed -n '/```json/,/```/p' | sed '1d;$d')
+          else
+            echo "::warning::AI triage call failed: $(cat /tmp/llm_err)"
+            TRIAGE=""
+          fi
 
           if [ -z "$TRIAGE" ] || [ "$TRIAGE" = "null" ]; then
             echo "AI triage failed, falling back to basic scan"

--- a/.github/workflows/demerzel-capability-expansion.yml
+++ b/.github/workflows/demerzel-capability-expansion.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           DATE=$(date -u +%Y-%m-%d)
           ANALYSIS=$(cat /tmp/expansion-analysis.txt)
-          BODY=$(cat <<DISCEOF | jq -Rs .
+          BODY=$(cat <<DISCEOF
           ## 🚀 Capability Expansion Scan — ${DATE}
 
           Demerzel scanned the ecosystem for capability gaps and expansion opportunities.
@@ -174,14 +174,6 @@ jobs:
           *Demerzel knows what she doesn't know. This scan identifies gaps across ix, tars, ga, and the governance framework itself.*
           DISCEOF
           )
-
-          gh api graphql -f query="mutation {
-            createDiscussion(input: {
-              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
-              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
-              title: \"🚀 Capability Expansion — $DATE\",
-              body: $BODY
-            }) {
-              discussion { url }
-            }
-          }" --jq '.data.createDiscussion.discussion.url' 2>/dev/null || echo "Failed to post"
+          REPO_NODE_ID="${{ steps.eco.outputs.repo_node_id }}" \
+            bash .github/scripts/post_discussion.sh \
+              "${{ steps.eco.outputs.cat_general }}" "🚀 Capability Expansion — $DATE" "$BODY"

--- a/.github/workflows/demerzel-capability-expansion.yml
+++ b/.github/workflows/demerzel-capability-expansion.yml
@@ -102,22 +102,13 @@ jobs:
             exit 0
           fi
 
-          RESPONSE=$(curl -s --max-time 60 \
-            https://api.anthropic.com/v1/messages \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "content-type: application/json" \
-            -H "anthropic-version: 2025-01-01" \
-            -d "$(jq -n \
-              --arg caps "$CAPABILITIES" \
-              --arg focus "$FOCUS" \
-              '{
-                model: "claude-sonnet-4-20250514",
-                max_tokens: 2000,
-                system: "You are Demerzel, governance coordinator for the GuitarAlchemist AI ecosystem.\n\nYour ecosystem:\n- **Demerzel** (this repo): governance framework — constitutions, policies, personas, skills, workflows\n- **ix**: Rust ML forge — crates for ML algorithms, optimization, GPU compute, MCP servers\n- **tars**: F# cognition — WoT DSL, symbolic reasoning, agent reflection, explorations\n- **ga**: C# Guitar Alchemist — music theory domain, MCP server with 50+ tools, chatbot\n\nYour job: identify what the ecosystem CANNOT currently do but SHOULD be able to do. Think about:\n1. Missing MCP tools/servers that would add valuable capabilities\n2. Missing skills/hooks that would improve automation\n3. Cross-repo integrations that would create synergy\n4. Knowledge gaps where no repo has expertise\n5. New repos/teams that might be needed\n\nFor each gap, specify:\n- What is missing\n- Which repo should implement it (or if a new repo is needed)\n- Priority (CRITICAL/HIGH/MEDIUM/LOW)\n- Suggested directive (what to tell the implementing repo)\n\nFocus area: " + $focus + "\n\nBe concrete and actionable. No vague suggestions.",
-                messages: [{role: "user", content: "Current ecosystem capabilities:\n\n" + $caps + "\n\nIdentify capability gaps and expansion opportunities."}]
-              }')" 2>/dev/null)
-
-          echo "$RESPONSE" | jq -r '.content[0].text' 2>/dev/null > /tmp/expansion-analysis.txt
+          # Call Claude via the shared llm_call.sh seam (Candidate 3).
+          LLM_SYSTEM=$(jq -rn --arg focus "$FOCUS" \
+            '"You are Demerzel, governance coordinator for the GuitarAlchemist AI ecosystem.\n\nYour ecosystem:\n- **Demerzel** (this repo): governance framework — constitutions, policies, personas, skills, workflows\n- **ix**: Rust ML forge — crates for ML algorithms, optimization, GPU compute, MCP servers\n- **tars**: F# cognition — WoT DSL, symbolic reasoning, agent reflection, explorations\n- **ga**: C# Guitar Alchemist — music theory domain, MCP server with 50+ tools, chatbot\n\nYour job: identify what the ecosystem CANNOT currently do but SHOULD be able to do. Think about:\n1. Missing MCP tools/servers that would add valuable capabilities\n2. Missing skills/hooks that would improve automation\n3. Cross-repo integrations that would create synergy\n4. Knowledge gaps where no repo has expertise\n5. New repos/teams that might be needed\n\nFor each gap, specify:\n- What is missing\n- Which repo should implement it (or if a new repo is needed)\n- Priority (CRITICAL/HIGH/MEDIUM/LOW)\n- Suggested directive (what to tell the implementing repo)\n\nFocus area: " + $focus + "\n\nBe concrete and actionable. No vague suggestions."')
+          PROMPT=$(jq -rn --arg caps "$CAPABILITIES" \
+            '"Current ecosystem capabilities:\n\n" + $caps + "\n\nIdentify capability gaps and expansion opportunities."')
+          export LLM_SYSTEM
+          bash .github/scripts/llm_call.sh claude "$PROMPT" 2000 > /tmp/expansion-analysis.txt
 
           if [ -s /tmp/expansion-analysis.txt ]; then
             echo "ANALYSIS_READY=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/demerzel-capability-expansion.yml
+++ b/.github/workflows/demerzel-capability-expansion.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Checkout Demerzel
         uses: actions/checkout@v4
 
+      - name: Ecosystem facts
+        id: eco
+        uses: ./.github/actions/ecosystem
+
       - name: Inventory ecosystem capabilities
         id: capabilities
         run: |
@@ -181,8 +185,8 @@ jobs:
 
           gh api graphql -f query="mutation {
             createDiscussion(input: {
-              repositoryId: \"R_kgDORnMyyQ\",
-              categoryId: \"DIC_kwDORnMyyc4C4eDT\",
+              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
+              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
               title: \"🚀 Capability Expansion — $DATE\",
               body: $BODY
             }) {

--- a/.github/workflows/demerzel-capability-expansion.yml
+++ b/.github/workflows/demerzel-capability-expansion.yml
@@ -108,11 +108,12 @@ jobs:
           PROMPT=$(jq -rn --arg caps "$CAPABILITIES" \
             '"Current ecosystem capabilities:\n\n" + $caps + "\n\nIdentify capability gaps and expansion opportunities."')
           export LLM_SYSTEM
-          bash .github/scripts/llm_call.sh claude "$PROMPT" 2000 > /tmp/expansion-analysis.txt
-
-          if [ -s /tmp/expansion-analysis.txt ]; then
+          # if-form: the seam guarantees non-empty text on success (exit 0) or a
+          # non-zero exit + stderr diagnostic on failure — no -s check needed.
+          if bash .github/scripts/llm_call.sh claude "$PROMPT" 2000 > /tmp/expansion-analysis.txt 2>/tmp/llm_err; then
             echo "ANALYSIS_READY=true" >> $GITHUB_OUTPUT
           else
+            echo "::warning::Capability analysis call failed: $(cat /tmp/llm_err)"
             echo "ANALYSIS_READY=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/demerzel-cross-repo-issues.yml
+++ b/.github/workflows/demerzel-cross-repo-issues.yml
@@ -101,13 +101,15 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           COUNT="${{ steps.scan.outputs.ISSUES_CREATED }}"
 
-          gh api graphql -f query="mutation {
-            createDiscussion(input: {
-              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
-              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
-              title: \"🔍 Cross-Repo Governance Scan — $DATE\",
-              body: \"Demerzel scanned consumer repos and created **$COUNT** new governance issues.\n\nCheck:\n- [ix issues](https://github.com/GuitarAlchemist/ix/issues)\n- [tars issues](https://github.com/GuitarAlchemist/tars/issues)\n- [ga issues](https://github.com/GuitarAlchemist/ga/issues)\n\n*Governed by Demerzel under the [governance mandate](https://github.com/GuitarAlchemist/Demerzel/blob/master/constitutions/demerzel-mandate.md)*\"
-            }) {
-              discussion { url }
-            }
-          }" --jq '.data.createDiscussion.discussion.url' 2>/dev/null
+          BODY=$(printf '%s\n' \
+            "Demerzel scanned consumer repos and created **$COUNT** new governance issues." \
+            "" \
+            "Check:" \
+            "- [ix issues](https://github.com/GuitarAlchemist/ix/issues)" \
+            "- [tars issues](https://github.com/GuitarAlchemist/tars/issues)" \
+            "- [ga issues](https://github.com/GuitarAlchemist/ga/issues)" \
+            "" \
+            "*Governed by Demerzel under the [governance mandate](https://github.com/GuitarAlchemist/Demerzel/blob/master/constitutions/demerzel-mandate.md)*")
+          REPO_NODE_ID="${{ steps.eco.outputs.repo_node_id }}" \
+            bash .github/scripts/post_discussion.sh \
+              "${{ steps.eco.outputs.cat_general }}" "🔍 Cross-Repo Governance Scan — $DATE" "$BODY"

--- a/.github/workflows/demerzel-cross-repo-issues.yml
+++ b/.github/workflows/demerzel-cross-repo-issues.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Checkout Demerzel
         uses: actions/checkout@v4
 
+      - name: Ecosystem facts
+        id: eco
+        uses: ./.github/actions/ecosystem
+
       - name: Scan repos for governance gaps
         id: scan
         env:
@@ -99,8 +103,8 @@ jobs:
 
           gh api graphql -f query="mutation {
             createDiscussion(input: {
-              repositoryId: \"R_kgDORnMyyQ\",
-              categoryId: \"DIC_kwDORnMyyc4C4eDT\",
+              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
+              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
               title: \"🔍 Cross-Repo Governance Scan — $DATE\",
               body: \"Demerzel scanned consumer repos and created **$COUNT** new governance issues.\n\nCheck:\n- [ix issues](https://github.com/GuitarAlchemist/ix/issues)\n- [tars issues](https://github.com/GuitarAlchemist/tars/issues)\n- [ga issues](https://github.com/GuitarAlchemist/ga/issues)\n\n*Governed by Demerzel under the [governance mandate](https://github.com/GuitarAlchemist/Demerzel/blob/master/constitutions/demerzel-mandate.md)*\"
             }) {

--- a/.github/workflows/demerzel-discussion-lifecycle.yml
+++ b/.github/workflows/demerzel-discussion-lifecycle.yml
@@ -68,29 +68,24 @@ jobs:
 
           # Use Claude to assess if this discussion contains actionable work
           if [ -n "$ANTHROPIC_API_KEY" ]; then
-            ASSESSMENT=$(curl -s --max-time 30 \
-              https://api.anthropic.com/v1/messages \
-              -H "x-api-key: $ANTHROPIC_API_KEY" \
-              -H "content-type: application/json" \
-              -H "anthropic-version: 2025-01-01" \
-              -d "$(jq -n \
-                --arg title "$DISCUSSION_TITLE" \
-                --arg body "${DISCUSSION_BODY:0:3000}" \
-                --arg category "$DISCUSSION_CATEGORY" \
-                '{
-                  model: "claude-sonnet-4-20250514",
-                  max_tokens: 500,
-                  system: "You are Demerzel, a governance coordinator. Analyze this GitHub Discussion and determine:\n1. Does it contain actionable work that should become a GitHub Issue? (human directives, bug reports, feature requests, improvement suggestions)\n2. If yes, what should the issue title and body be?\n\nRespond in this exact JSON format:\n{\"needs_issue\": true/false, \"reason\": \"why\", \"issue_title\": \"title if needed\", \"issue_body\": \"body if needed\", \"labels\": [\"enhancement\" or \"bug\" or \"documentation\"]}",
-                  messages: [{role: "user", content: "Discussion #" + $title + " (category: " + $category + "):\n\n" + $body}]
-                }')" 2>/dev/null)
-
-            NEEDS_ISSUE=$(echo "$ASSESSMENT" | jq -r '.content[0].text' 2>/dev/null | jq -r '.needs_issue // false' 2>/dev/null)
-            ISSUE_TITLE=$(echo "$ASSESSMENT" | jq -r '.content[0].text' 2>/dev/null | jq -r '.issue_title // empty' 2>/dev/null)
-            ISSUE_BODY=$(echo "$ASSESSMENT" | jq -r '.content[0].text' 2>/dev/null | jq -r '.issue_body // empty' 2>/dev/null)
-            ISSUE_LABELS=$(echo "$ASSESSMENT" | jq -r '.content[0].text' 2>/dev/null | jq -r '.labels // ["enhancement"] | join(",")' 2>/dev/null)
-            REASON=$(echo "$ASSESSMENT" | jq -r '.content[0].text' 2>/dev/null | jq -r '.reason // empty' 2>/dev/null)
-
-            echo "Assessment: needs_issue=$NEEDS_ISSUE, reason=$REASON"
+            # Call Claude via the shared llm_call.sh seam (Candidate 3). ASSESSMENT
+            # is now the model's text directly (the seam extracted it), so it is
+            # parsed as JSON in one step. A non-zero seam exit -> safe NEEDS_ISSUE=false.
+            LLM_SYSTEM=$(jq -rn '"You are Demerzel, a governance coordinator. Analyze this GitHub Discussion and determine:\n1. Does it contain actionable work that should become a GitHub Issue? (human directives, bug reports, feature requests, improvement suggestions)\n2. If yes, what should the issue title and body be?\n\nRespond in this exact JSON format:\n{\"needs_issue\": true/false, \"reason\": \"why\", \"issue_title\": \"title if needed\", \"issue_body\": \"body if needed\", \"labels\": [\"enhancement\" or \"bug\" or \"documentation\"]}"')
+            PROMPT=$(jq -rn --arg title "$DISCUSSION_TITLE" --arg body "${DISCUSSION_BODY:0:3000}" --arg category "$DISCUSSION_CATEGORY" \
+              '"Discussion #" + $title + " (category: " + $category + "):\n\n" + $body')
+            export LLM_SYSTEM
+            if ASSESSMENT=$(bash .github/scripts/llm_call.sh claude "$PROMPT" 500 2>/tmp/llm_err); then
+              NEEDS_ISSUE=$(echo "$ASSESSMENT" | jq -r '.needs_issue // false' 2>/dev/null)
+              ISSUE_TITLE=$(echo "$ASSESSMENT" | jq -r '.issue_title // empty' 2>/dev/null)
+              ISSUE_BODY=$(echo "$ASSESSMENT" | jq -r '.issue_body // empty' 2>/dev/null)
+              ISSUE_LABELS=$(echo "$ASSESSMENT" | jq -r '.labels // ["enhancement"] | join(",")' 2>/dev/null)
+              REASON=$(echo "$ASSESSMENT" | jq -r '.reason // empty' 2>/dev/null)
+              echo "Assessment: needs_issue=$NEEDS_ISSUE, reason=$REASON"
+            else
+              echo "::warning::Discussion assessment failed: $(cat /tmp/llm_err)"
+              NEEDS_ISSUE="false"
+            fi
           else
             # Fallback: only promote Ideas category discussions
             if [ "$DISCUSSION_CATEGORY" = "Ideas" ]; then

--- a/.github/workflows/demerzel-discussion-responder.yml
+++ b/.github/workflows/demerzel-discussion-responder.yml
@@ -100,42 +100,18 @@ jobs:
           7. Use Demerzel's voice: authoritative but warm, precise but not pedantic, always deferential to human authority
           8. Format as GitHub-flavored markdown"
 
-          # Call Claude API
-          RESPONSE=$(curl -s --max-time 30 \
-            https://api.anthropic.com/v1/messages \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "content-type: application/json" \
-            -H "anthropic-version: 2025-01-01" \
-            -d "$(jq -n \
-              --arg model "$CLAUDE_MODEL" \
-              --argjson max_tokens "$CLAUDE_MAX_TOKENS" \
-              --arg system "$SYSTEM_PROMPT" \
-              --arg discussion_title "$DISCUSSION_TITLE" \
-              --arg discussion_body "${DISCUSSION_BODY:0:2000}" \
-              --arg comment "$COMMENT_BODY" \
-              --arg author "$COMMENT_AUTHOR" \
-              '{
-                model: $model,
-                max_tokens: $max_tokens,
-                system: $system,
-                messages: [{
-                  role: "user",
-                  content: "Discussion: \($discussion_title)\n\nOriginal post (truncated):\n\($discussion_body)\n\n---\n\nComment from \($author):\n\($comment)\n\nRespond as Demerzel."
-                }]
-              }')" 2>/dev/null)
-
-          if [ $? -ne 0 ] || [ -z "$RESPONSE" ]; then
+          # Call Claude via the shared llm_call.sh seam (Candidate 3). The seam's
+          # exit code + stderr replace the old $?/empty/no-text inspection.
+          PROMPT=$(jq -rn \
+            --arg discussion_title "$DISCUSSION_TITLE" \
+            --arg discussion_body "${DISCUSSION_BODY:0:2000}" \
+            --arg comment "$COMMENT_BODY" \
+            --arg author "$COMMENT_AUTHOR" \
+            '"Discussion: \($discussion_title)\n\nOriginal post (truncated):\n\($discussion_body)\n\n---\n\nComment from \($author):\n\($comment)\n\nRespond as Demerzel."')
+          export LLM_SYSTEM="$SYSTEM_PROMPT"
+          if ! ANSWER=$(LLM_CLAUDE_MODEL="$CLAUDE_MODEL" bash .github/scripts/llm_call.sh claude "$PROMPT" "$CLAUDE_MAX_TOKENS" 2>/tmp/llm_err); then
             echo "RESPONSE_READY=false" >> $GITHUB_OUTPUT
-            echo "Claude API call failed"
-            exit 0
-          fi
-
-          # Extract text
-          ANSWER=$(echo "$RESPONSE" | jq -r '[.content[] | select(.type == "text") | .text] | join("\n")' 2>/dev/null)
-
-          if [ -z "$ANSWER" ] || [ "$ANSWER" = "null" ]; then
-            echo "RESPONSE_READY=false" >> $GITHUB_OUTPUT
-            echo "No text in response"
+            echo "::warning::Claude API call failed: $(cat /tmp/llm_err)"
             exit 0
           fi
 

--- a/.github/workflows/demerzel-ideation.yml
+++ b/.github/workflows/demerzel-ideation.yml
@@ -201,18 +201,9 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           DATE="${{ steps.context.outputs.DATE }}"
-          BODY=$(cat ideation-report.md | jq -Rs .)
-
-          URL=$(gh api graphql -f query="mutation {
-            createDiscussion(input: {
-              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
-              categoryId: \"${{ steps.eco.outputs.cat_ideas }}\",
-              title: \"🧠 Demerzel Ideation — ${DATE}\",
-              body: $BODY
-            }) {
-              discussion { url }
-            }
-          }" --jq '.data.createDiscussion.discussion.url' 2>/dev/null || echo "Failed to post ideas")
+          URL=$(REPO_NODE_ID="${{ steps.eco.outputs.repo_node_id }}" \
+            bash .github/scripts/post_discussion.sh \
+              "${{ steps.eco.outputs.cat_ideas }}" "🧠 Demerzel Ideation — ${DATE}" "$(cat ideation-report.md)")
           echo "Ideas Discussion: $URL"
           echo "DISCUSSION_URL=$URL" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/demerzel-ideation.yml
+++ b/.github/workflows/demerzel-ideation.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           fetch-depth: 20
 
+      - name: Ecosystem facts
+        id: eco
+        uses: ./.github/actions/ecosystem
+
       - name: Check if ideation already posted today
         id: dedup
         env:
@@ -70,10 +74,11 @@ jobs:
           DATE="${{ steps.dedup.outputs.DATE }}"
           echo "DATE=$DATE" >> $GITHUB_OUTPUT
 
-          # Artifact inventory
-          PERSONA_COUNT=$(ls personas/*.persona.yaml 2>/dev/null | wc -l)
-          POLICY_COUNT=$(ls policies/*.yaml 2>/dev/null | wc -l)
-          TEST_COUNT=$(ls tests/behavioral/*.md 2>/dev/null | wc -l)
+          # Governance counts harvested from the manifest (ADR-0002); the state
+          # counts below are runtime dirs the manifest does not track.
+          PERSONA_COUNT=${{ steps.eco.outputs.count_persona }}
+          POLICY_COUNT=${{ steps.eco.outputs.count_policy }}
+          TEST_COUNT=${{ steps.eco.outputs.count_behavioral_test }}
           DEPT_COUNT=$(ls state/streeling/departments/*.department.json 2>/dev/null | wc -l)
           SIGNAL_COUNT=$(ls state/conscience/signals/*.json 2>/dev/null | wc -l)
           PATTERN_COUNT=$(ls state/conscience/patterns/*.json 2>/dev/null | wc -l)
@@ -221,8 +226,8 @@ jobs:
 
           URL=$(gh api graphql -f query="mutation {
             createDiscussion(input: {
-              repositoryId: \"R_kgDORnMyyQ\",
-              categoryId: \"DIC_kwDORnMyyc4C4eDV\",
+              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
+              categoryId: \"${{ steps.eco.outputs.cat_ideas }}\",
               title: \"🧠 Demerzel Ideation — ${DATE}\",
               body: $BODY
             }) {

--- a/.github/workflows/demerzel-ideation.yml
+++ b/.github/workflows/demerzel-ideation.yml
@@ -149,35 +149,14 @@ jobs:
         run: |
           CONTEXT=$(cat /tmp/ideation-context.md)
 
-          RESPONSE=$(curl -s --max-time 60 \
-            https://api.anthropic.com/v1/messages \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "content-type: application/json" \
-            -H "anthropic-version: 2023-06-01" \
-            -d "$(jq -n \
-              --arg ctx "$CONTEXT" \
-              '{
-                model: "claude-sonnet-4-6-20250514",
-                max_tokens: 3000,
-                system: "You are Demerzel and Seldon, governance coordinator and chancellor of Streeling University for the GuitarAlchemist AI ecosystem.\n\nGenerate 3-5 FRESH ideas based on the current ecosystem state. Ideas must be:\n1. Concrete and actionable (not vague aspirations)\n2. Grounded in what just changed (recent commits, open issues, conscience signals)\n3. Novel — do NOT repeat ideas that are already open issues\n4. Spanning different domains: governance, music theory, ML/AI, cross-repo integration, research\n\nFor each idea, output:\n- Title (concise, issue-ready)\n- Source (what triggered this idea — a commit, a gap, a pattern)\n- Problem (what is wrong or missing)\n- Proposal (specific action)\n- Priority (P0-P3)\n- Repos affected\n- Streeling department (which department should own this research)\n\nFormat as markdown with ### headers per idea. Be creative but practical.",
-                messages: [{role: "user", content: ("Generate fresh ideation based on current ecosystem state:\n\n" + $ctx)}]
-              }')" 2>/dev/null)
-
-          # Log API response status for debugging
-          RESP_TYPE=$(echo "$RESPONSE" | jq -r '.type // "no-response"' 2>/dev/null)
-          RESP_ERROR=$(echo "$RESPONSE" | jq -r '.error // empty' 2>/dev/null)
-          STOP_REASON=$(echo "$RESPONSE" | jq -r '.stop_reason // empty' 2>/dev/null)
-          echo "API response type: $RESP_TYPE"
-          echo "API stop_reason: $STOP_REASON"
-          if [ -n "$RESP_ERROR" ]; then
-            echo "::error::Anthropic API error: $RESP_ERROR"
-          fi
-
-          IDEAS=$(echo "$RESPONSE" | jq -r '.content[0].text' 2>/dev/null)
-
-          if [ -z "$IDEAS" ] || [ "$IDEAS" = "null" ]; then
-            echo "::warning::AI ideation failed — no content in API response"
-            echo "Raw response (first 500 chars): $(echo "$RESPONSE" | head -c 500)"
+          # Call Claude via the shared llm_call.sh seam (Candidate 3). The seam's
+          # exit code + stderr replace the old raw-response .type/.error/.stop_reason
+          # inspection; the if-form keeps the graceful skip under -e.
+          LLM_SYSTEM=$(jq -rn '"You are Demerzel and Seldon, governance coordinator and chancellor of Streeling University for the GuitarAlchemist AI ecosystem.\n\nGenerate 3-5 FRESH ideas based on the current ecosystem state. Ideas must be:\n1. Concrete and actionable (not vague aspirations)\n2. Grounded in what just changed (recent commits, open issues, conscience signals)\n3. Novel — do NOT repeat ideas that are already open issues\n4. Spanning different domains: governance, music theory, ML/AI, cross-repo integration, research\n\nFor each idea, output:\n- Title (concise, issue-ready)\n- Source (what triggered this idea — a commit, a gap, a pattern)\n- Problem (what is wrong or missing)\n- Proposal (specific action)\n- Priority (P0-P3)\n- Repos affected\n- Streeling department (which department should own this research)\n\nFormat as markdown with ### headers per idea. Be creative but practical."')
+          PROMPT=$(jq -rn --arg ctx "$CONTEXT" '("Generate fresh ideation based on current ecosystem state:\n\n" + $ctx)')
+          export LLM_SYSTEM
+          if ! IDEAS=$(LLM_CLAUDE_MODEL=claude-sonnet-4-6-20250514 bash .github/scripts/llm_call.sh claude "$PROMPT" 3000 2>/tmp/llm_err); then
+            echo "::warning::AI ideation failed: $(cat /tmp/llm_err)"
             echo "IDEA_COUNT=0" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -244,24 +223,12 @@ jobs:
           # Get existing open issue titles to prevent duplicates
           EXISTING_ISSUES=$(gh issue list --repo GuitarAlchemist/Demerzel --state open --json title --jq '.[].title' | jq -Rs .)
 
-          REVIEW=$(curl -s --max-time 45 \
-            https://api.anthropic.com/v1/messages \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "content-type: application/json" \
-            -H "anthropic-version: 2023-06-01" \
-            -d "$(jq -n \
-              --arg ideas "$IDEAS" \
-              --arg existing "$EXISTING_ISSUES" \
-              '{
-                model: "claude-sonnet-4-6-20250514",
-                max_tokens: 1500,
-                system: ("You are a critical reviewer. Review these ideas. REJECT any that duplicate existing issues.\n\nExisting open issues:\n" + $existing + "\n\nFor each idea respond as JSON array:\n[{\"idea_number\": 1, \"verdict\": \"APPROVE|MODIFY|REJECT\", \"rationale\": \"...\", \"issue_title\": \"...\", \"labels\": [\"enhancement\"]}]\n\nBe rigorous. Reject duplicates and vague ideas."),
-                messages: [{role: "user", content: $ideas}]
-              }')" 2>/dev/null)
-
-          REVIEW_TEXT=$(echo "$REVIEW" | jq -r '.content[0].text' 2>/dev/null)
-
-          if [ -z "$REVIEW_TEXT" ] || [ "$REVIEW_TEXT" = "null" ]; then
+          # Call Claude via the shared llm_call.sh seam (Candidate 3).
+          LLM_SYSTEM=$(jq -rn --arg existing "$EXISTING_ISSUES" \
+            '("You are a critical reviewer. Review these ideas. REJECT any that duplicate existing issues.\n\nExisting open issues:\n" + $existing + "\n\nFor each idea respond as JSON array:\n[{\"idea_number\": 1, \"verdict\": \"APPROVE|MODIFY|REJECT\", \"rationale\": \"...\", \"issue_title\": \"...\", \"labels\": [\"enhancement\"]}]\n\nBe rigorous. Reject duplicates and vague ideas.")')
+          export LLM_SYSTEM
+          if ! REVIEW_TEXT=$(LLM_CLAUDE_MODEL=claude-sonnet-4-6-20250514 bash .github/scripts/llm_call.sh claude "$IDEAS" 1500 2>/tmp/llm_err); then
+            echo "::warning::Idea review failed: $(cat /tmp/llm_err)"
             echo "REVIEW_READY=false" >> $GITHUB_OUTPUT
             exit 0
           fi

--- a/.github/workflows/demerzel-self-improvement.yml
+++ b/.github/workflows/demerzel-self-improvement.yml
@@ -169,22 +169,15 @@ jobs:
           INVENTORY=$(cat /tmp/inventory.json)
 
           if [ -n "$ANTHROPIC_API_KEY" ]; then
-            ANALYSIS=$(curl -s --max-time 30 \
-              https://api.anthropic.com/v1/messages \
-              -H "x-api-key: $ANTHROPIC_API_KEY" \
-              -H "content-type: application/json" \
-              -H "anthropic-version: 2025-01-01" \
-              -d "$(jq -n \
-                --arg gaps "$GAPS" \
-                --arg inventory "$INVENTORY" \
-                '{
-                  model: "claude-sonnet-4-20250514",
-                  max_tokens: 1000,
-                  system: "You are Demerzel, governance coordinator. Given detected gaps in the governance framework, prioritize them by impact and suggest concrete fixes. For each gap, classify as: CRITICAL (blocks governance), HIGH (reduces effectiveness), MEDIUM (quality gap), LOW (nice-to-have). Suggest which gaps should become GitHub Issues. Be concise — bullet points, not paragraphs.",
-                  messages: [{role: "user", content: "Inventory:\n" + $inventory + "\n\nDetected gaps:\n" + $gaps + "\n\nPrioritize these gaps and suggest which should become issues."}]
-                }')" 2>/dev/null)
-
-            echo "$ANALYSIS" | jq -r '.content[0].text' 2>/dev/null > /tmp/analysis.txt
+            # Call Claude via the shared llm_call.sh seam (Candidate 3); on a
+            # non-zero seam exit, fall back to the raw gaps instead of "null".
+            LLM_SYSTEM=$(jq -rn '"You are Demerzel, governance coordinator. Given detected gaps in the governance framework, prioritize them by impact and suggest concrete fixes. For each gap, classify as: CRITICAL (blocks governance), HIGH (reduces effectiveness), MEDIUM (quality gap), LOW (nice-to-have). Suggest which gaps should become GitHub Issues. Be concise — bullet points, not paragraphs."')
+            PROMPT=$(jq -rn --arg gaps "$GAPS" --arg inventory "$INVENTORY" '"Inventory:\n" + $inventory + "\n\nDetected gaps:\n" + $gaps + "\n\nPrioritize these gaps and suggest which should become issues."')
+            export LLM_SYSTEM
+            if ! bash .github/scripts/llm_call.sh claude "$PROMPT" 1000 > /tmp/analysis.txt 2>/tmp/llm_err; then
+              echo "::warning::Gap analysis call failed: $(cat /tmp/llm_err)"
+              echo "$GAPS" > /tmp/analysis.txt
+            fi
           else
             echo "$GAPS" > /tmp/analysis.txt
           fi

--- a/.github/workflows/demerzel-self-improvement.yml
+++ b/.github/workflows/demerzel-self-improvement.yml
@@ -224,7 +224,7 @@ jobs:
           ANALYSIS=$(cat /tmp/analysis.txt 2>/dev/null || echo "No AI analysis available")
           GAP_COUNT="${{ steps.gaps.outputs.GAP_COUNT }}"
 
-          BODY=$(cat <<DISCEOF | jq -Rs .
+          BODY=$(cat <<DISCEOF
           ## 🔍 Self-Improvement Scan — ${DATE}
 
           **Gaps detected:** ${GAP_COUNT}
@@ -239,14 +239,6 @@ jobs:
           *Demerzel Self-Improvement Scanner — detecting and addressing governance gaps automatically.*
           DISCEOF
           )
-
-          gh api graphql -f query="mutation {
-            createDiscussion(input: {
-              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
-              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
-              title: \"🔍 Self-Improvement Scan — $DATE\",
-              body: $BODY
-            }) {
-              discussion { url }
-            }
-          }" --jq '.data.createDiscussion.discussion.url' 2>/dev/null || echo "Failed to post"
+          REPO_NODE_ID="${{ steps.eco.outputs.repo_node_id }}" \
+            bash .github/scripts/post_discussion.sh \
+              "${{ steps.eco.outputs.cat_general }}" "🔍 Self-Improvement Scan — $DATE" "$BODY"

--- a/.github/workflows/demerzel-self-improvement.yml
+++ b/.github/workflows/demerzel-self-improvement.yml
@@ -29,38 +29,34 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Ecosystem facts (counts + ids, single source)
+        id: eco
+        uses: ./.github/actions/ecosystem
+
       - name: Inventory governance artifacts
         id: inventory
         run: |
-          # Personas
-          PERSONAS=$(ls personas/*.persona.yaml 2>/dev/null)
-          PERSONA_COUNT=$(echo "$PERSONAS" | wc -l)
-          PERSONA_NAMES=$(echo "$PERSONAS" | xargs -I{} basename {} .persona.yaml | tr '\n' ',')
+          # Counts + names are HARVESTED from governance-manifest.json (ADR-0002)
+          # via the ecosystem action, not re-derived with `ls | wc -l`.
+          PERSONA_COUNT=${{ steps.eco.outputs.count_persona }}
+          PERSONA_NAMES=$(jq -r '.inventory.persona[].name' governance-manifest.json | paste -sd, -)
 
-          # Policies
-          POLICIES=$(ls policies/*.yaml 2>/dev/null)
-          POLICY_COUNT=$(echo "$POLICIES" | wc -l)
-          POLICY_NAMES=$(echo "$POLICIES" | xargs -I{} basename {} .yaml | tr '\n' ',')
+          POLICY_COUNT=${{ steps.eco.outputs.count_policy }}
+          POLICY_NAMES=$(jq -r '.inventory.policy[].name' governance-manifest.json | paste -sd, -)
 
-          # Behavioral tests
-          TESTS=$(ls tests/behavioral/*.md 2>/dev/null)
-          TEST_COUNT=$(echo "$TESTS" | wc -l)
-          TEST_NAMES=$(echo "$TESTS" | xargs -I{} basename {} .md | tr '\n' ',')
+          TEST_COUNT=${{ steps.eco.outputs.count_behavioral_test }}
+          TEST_NAMES=$(jq -r '.inventory.behavioral_test[].name' governance-manifest.json | paste -sd, -)
 
-          # Skills
-          SKILLS=$(ls -d .claude/skills/*/ 2>/dev/null)
-          SKILL_COUNT=$(echo "$SKILLS" | wc -l)
-          SKILL_NAMES=$(echo "$SKILLS" | xargs -I{} basename {} | tr '\n' ',')
+          SKILL_COUNT=${{ steps.eco.outputs.count_skill }}
+          SKILL_NAMES=$(jq -r '.inventory.skill[].name' governance-manifest.json | paste -sd, -)
 
-          # Schemas
-          SCHEMA_COUNT=$(ls schemas/*.json schemas/contracts/*.json 2>/dev/null | wc -l)
+          # Schemas: the manifest splits plain schemas from contract schemas.
+          SCHEMA_COUNT=$(( ${{ steps.eco.outputs.count_schema }} + ${{ steps.eco.outputs.count_contract_schema }} ))
 
-          # Constitutions
-          CONST_COUNT=$(ls constitutions/*.md 2>/dev/null | wc -l)
+          CONST_COUNT=${{ steps.eco.outputs.count_constitution }}
 
-          # Workflows
-          WORKFLOW_COUNT=$(ls .github/workflows/*.yml 2>/dev/null | wc -l)
-          WORKFLOW_NAMES=$(ls .github/workflows/*.yml 2>/dev/null | xargs -I{} basename {} .yml | tr '\n' ',')
+          WORKFLOW_COUNT=${{ steps.eco.outputs.count_workflow }}
+          WORKFLOW_NAMES=$(jq -r '.inventory.workflow[].name' governance-manifest.json | paste -sd, -)
 
           # Open issues
           OPEN_ISSUES=$(gh issue list --repo GuitarAlchemist/Demerzel --state open --json number,title --jq '.[] | "#\(.number): \(.title)"' 2>/dev/null)
@@ -253,8 +249,8 @@ jobs:
 
           gh api graphql -f query="mutation {
             createDiscussion(input: {
-              repositoryId: \"R_kgDORnMyyQ\",
-              categoryId: \"DIC_kwDORnMyyc4C4eDT\",
+              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
+              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
               title: \"🔍 Self-Improvement Scan — $DATE\",
               body: $BODY
             }) {

--- a/.github/workflows/demerzel-showcase.yml
+++ b/.github/workflows/demerzel-showcase.yml
@@ -38,16 +38,8 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           TITLE="${{ steps.showcase.outputs.SHOWCASE_TITLE }}"
-          BODY=$(cat showcase.md | jq -Rs .)
-
-          URL=$(gh api graphql -f query="mutation {
-            createDiscussion(input: {
-              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
-              categoryId: \"${{ steps.eco.outputs.cat_show_and_tell }}\",
-              title: \"$TITLE\",
-              body: $BODY
-            }) {
-              discussion { url }
-            }
-          }" --jq '.data.createDiscussion.discussion.url' 2>/dev/null || echo "Failed to post showcase")
+          # post_discussion.sh raises on failure (no silent "Failed" swallow).
+          URL=$(REPO_NODE_ID="${{ steps.eco.outputs.repo_node_id }}" \
+            bash .github/scripts/post_discussion.sh \
+              "${{ steps.eco.outputs.cat_show_and_tell }}" "$TITLE" "$(cat showcase.md)")
           echo "Showcase: $URL"

--- a/.github/workflows/demerzel-showcase.yml
+++ b/.github/workflows/demerzel-showcase.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Checkout Demerzel
         uses: actions/checkout@v4
 
+      - name: Ecosystem facts
+        id: eco
+        uses: ./.github/actions/ecosystem
+
       - name: Generate showcase content
         id: showcase
         env:
@@ -38,8 +42,8 @@ jobs:
 
           URL=$(gh api graphql -f query="mutation {
             createDiscussion(input: {
-              repositoryId: \"R_kgDORnMyyQ\",
-              categoryId: \"DIC_kwDORnMyyc4C4eDW\",
+              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
+              categoryId: \"${{ steps.eco.outputs.cat_show_and_tell }}\",
               title: \"$TITLE\",
               body: $BODY
             }) {

--- a/.github/workflows/ga-chatbot-discussions.yml
+++ b/.github/workflows/ga-chatbot-discussions.yml
@@ -164,14 +164,15 @@ jobs:
 
           if [ "$TOPIC_COUNT" -ge 3 ]; then
             echo "PATTERN DETECTED: ${TOPIC} asked 3+ times — promotion candidate for dedicated resource"
-            gh api graphql -f query="mutation {
-              createDiscussion(input: {
-                repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
-                categoryId: \"${{ steps.eco.outputs.cat_general }}\",
-                title: \"🔄 Compounding: '${TOPIC}' topic trending in Q&A\",
-                body: \"Seldon has answered **${TOPIC_COUNT}** questions about **${TOPIC}** in the Q&A channel.\n\nPer the governance promotion protocol, frequently-asked topics (3+) are candidates for dedicated teaching resources.\n\n**Proposed action:** Create a pinned discussion or guide for '${TOPIC}' to reduce repetitive Q&A and improve self-service learning.\n\n*Detected by Demerzel meta-compounding cycle from Q&A interaction data.*\"
-              }) {
-                discussion { url }
-              }
-            }" --jq '.data.createDiscussion.discussion.url' 2>/dev/null
+            BODY=$(printf '%s\n' \
+              "Seldon has answered **${TOPIC_COUNT}** questions about **${TOPIC}** in the Q&A channel." \
+              "" \
+              "Per the governance promotion protocol, frequently-asked topics (3+) are candidates for dedicated teaching resources." \
+              "" \
+              "**Proposed action:** Create a pinned discussion or guide for '${TOPIC}' to reduce repetitive Q&A and improve self-service learning." \
+              "" \
+              "*Detected by Demerzel meta-compounding cycle from Q&A interaction data.*")
+            REPO_NODE_ID="${{ steps.eco.outputs.repo_node_id }}" \
+              bash .github/scripts/post_discussion.sh \
+                "${{ steps.eco.outputs.cat_general }}" "🔄 Compounding: '${TOPIC}' topic trending in Q&A" "$BODY"
           fi

--- a/.github/workflows/ga-chatbot-discussions.yml
+++ b/.github/workflows/ga-chatbot-discussions.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Checkout Demerzel
         uses: actions/checkout@v4
 
+      - name: Ecosystem facts
+        id: eco
+        uses: ./.github/actions/ecosystem
+
       - name: Process music theory question
         id: answer
         env:
@@ -150,7 +154,7 @@ jobs:
           # Post compounding note as a smaller discussion (only if interesting pattern detected)
           TOPIC_COUNT=$(gh api graphql -f query='query {
             repository(owner:"GuitarAlchemist", name:"Demerzel") {
-              discussions(last: 50, categoryId:"DIC_kwDORnMyyc4C4eDU") {
+              discussions(last: 50, categoryId:"${{ steps.eco.outputs.cat_q_and_a }}") {
                 nodes { title }
               }
             }
@@ -162,8 +166,8 @@ jobs:
             echo "PATTERN DETECTED: ${TOPIC} asked 3+ times — promotion candidate for dedicated resource"
             gh api graphql -f query="mutation {
               createDiscussion(input: {
-                repositoryId: \"R_kgDORnMyyQ\",
-                categoryId: \"DIC_kwDORnMyyc4C4eDT\",
+                repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
+                categoryId: \"${{ steps.eco.outputs.cat_general }}\",
                 title: \"🔄 Compounding: '${TOPIC}' topic trending in Q&A\",
                 body: \"Seldon has answered **${TOPIC_COUNT}** questions about **${TOPIC}** in the Q&A channel.\n\nPer the governance promotion protocol, frequently-asked topics (3+) are candidates for dedicated teaching resources.\n\n**Proposed action:** Create a pinned discussion or guide for '${TOPIC}' to reduce repetitive Q&A and improve self-service learning.\n\n*Detected by Demerzel meta-compounding cycle from Q&A interaction data.*\"
               }) {

--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -1,0 +1,28 @@
+name: Script Tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/**'
+      - 'tests/bats/**'
+      - '.github/workflows/script-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bats + shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats shellcheck
+
+      - name: Shellcheck the extracted scripts
+        run: shellcheck .github/scripts/llm_call.sh .github/scripts/post_discussion.sh
+
+      - name: Run bats tests
+        run: bats tests/bats

--- a/.github/workflows/streeling-daily.yml
+++ b/.github/workflows/streeling-daily.yml
@@ -162,18 +162,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           DATE=$(date -u +%Y-%m-%d)
-          BODY=$(cat harvest-report.md | jq -Rs .)
-
-          URL=$(gh api graphql -f query="mutation {
-            createDiscussion(input: {
-              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
-              categoryId: \"${{ steps.eco.outputs.cat_announcements }}\",
-              title: \"🤖 Demerzel Governance Report — $DATE\",
-              body: $BODY
-            }) {
-              discussion { url }
-            }
-          }" --jq '.data.createDiscussion.discussion.url' 2>/dev/null || echo "Failed to post to Demerzel Discussions")
+          URL=$(REPO_NODE_ID="${{ steps.eco.outputs.repo_node_id }}" \
+            bash .github/scripts/post_discussion.sh \
+              "${{ steps.eco.outputs.cat_announcements }}" "🤖 Demerzel Governance Report — $DATE" "$(cat harvest-report.md)")
           echo "Demerzel Discussion: $URL"
 
       - name: Generate Seldon academic digest (Fridays only)
@@ -244,18 +235,9 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           DATE=$(date -u +%Y-%m-%d)
-          BODY=$(cat seldon-digest.md | jq -Rs .)
-
-          URL=$(gh api graphql -f query="mutation {
-            createDiscussion(input: {
-              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
-              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
-              title: \"📚 Seldon Knowledge Digest — $DATE\",
-              body: $BODY
-            }) {
-              discussion { url }
-            }
-          }" --jq '.data.createDiscussion.discussion.url' 2>/dev/null || echo "Failed to post Seldon digest")
+          URL=$(REPO_NODE_ID="${{ steps.eco.outputs.repo_node_id }}" \
+            bash .github/scripts/post_discussion.sh \
+              "${{ steps.eco.outputs.cat_general }}" "📚 Seldon Knowledge Digest — $DATE" "$(cat seldon-digest.md)")
           echo "Seldon Digest: $URL"
 
       - name: Run meta-compounding scan
@@ -339,16 +321,7 @@ jobs:
         run: |
           DATE=$(date -u +%Y-%m-%d)
           DOW=$(date -u +%A)
-          BODY=$(cat compound-report.md | jq -Rs .)
-
-          URL=$(gh api graphql -f query="mutation {
-            createDiscussion(input: {
-              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
-              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
-              title: \"🔄 Meta-Compounding Cycle — $DOW $DATE\",
-              body: $BODY
-            }) {
-              discussion { url }
-            }
-          }" --jq '.data.createDiscussion.discussion.url' 2>/dev/null || echo "Failed to post compounding cycle")
+          URL=$(REPO_NODE_ID="${{ steps.eco.outputs.repo_node_id }}" \
+            bash .github/scripts/post_discussion.sh \
+              "${{ steps.eco.outputs.cat_general }}" "🔄 Meta-Compounding Cycle — $DOW $DATE" "$(cat compound-report.md)")
           echo "Compounding Discussion: $URL"

--- a/.github/workflows/streeling-daily.yml
+++ b/.github/workflows/streeling-daily.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Checkout Demerzel
         uses: actions/checkout@v4
 
+      - name: Ecosystem facts
+        id: eco
+        uses: ./.github/actions/ecosystem
+
       - name: Harvest knowledge via GitHub API
         id: harvest
         env:
@@ -44,13 +48,14 @@ jobs:
           HEADER
           sed -i "s/DATE_PLACEHOLDER/$DATE/" harvest-report.md
 
-          # Count governance artifacts in Demerzel
-          PERSONAS=$(ls personas/*.persona.yaml 2>/dev/null | wc -l)
-          POLICIES=$(ls policies/*.yaml 2>/dev/null | wc -l)
-          SCHEMAS=$(ls schemas/contracts/*.json 2>/dev/null | wc -l)
+          # Governance counts harvested from the manifest (ADR-0002); LOGIC is a
+          # runtime dir the manifest does not track.
+          PERSONAS=${{ steps.eco.outputs.count_persona }}
+          POLICIES=${{ steps.eco.outputs.count_policy }}
+          SCHEMAS=${{ steps.eco.outputs.count_contract_schema }}
           LOGIC=$(ls logic/*.json 2>/dev/null | wc -l)
-          TESTS=$(ls tests/behavioral/*.md 2>/dev/null | wc -l)
-          SKILLS=$(ls -d .claude/skills/*/ 2>/dev/null | wc -l)
+          TESTS=${{ steps.eco.outputs.count_behavioral_test }}
+          SKILLS=${{ steps.eco.outputs.count_skill }}
 
           cat >> harvest-report.md << EOF
           ### 📊 Demerzel Governance Inventory
@@ -161,8 +166,8 @@ jobs:
 
           URL=$(gh api graphql -f query="mutation {
             createDiscussion(input: {
-              repositoryId: \"R_kgDORnMyyQ\",
-              categoryId: \"DIC_kwDORnMyyc4C4eDS\",
+              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
+              categoryId: \"${{ steps.eco.outputs.cat_announcements }}\",
               title: \"🤖 Demerzel Governance Report — $DATE\",
               body: $BODY
             }) {
@@ -243,8 +248,8 @@ jobs:
 
           URL=$(gh api graphql -f query="mutation {
             createDiscussion(input: {
-              repositoryId: \"R_kgDORnMyyQ\",
-              categoryId: \"DIC_kwDORnMyyc4C4eDT\",
+              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
+              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
               title: \"📚 Seldon Knowledge Digest — $DATE\",
               body: $BODY
             }) {
@@ -338,8 +343,8 @@ jobs:
 
           URL=$(gh api graphql -f query="mutation {
             createDiscussion(input: {
-              repositoryId: \"R_kgDORnMyyQ\",
-              categoryId: \"DIC_kwDORnMyyc4C4eDT\",
+              repositoryId: \"${{ steps.eco.outputs.repo_node_id }}\",
+              categoryId: \"${{ steps.eco.outputs.cat_general }}\",
               title: \"🔄 Meta-Compounding Cycle — $DOW $DATE\",
               body: $BODY
             }) {

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,6 +77,22 @@ fact lives in one place and is read out, never restated.
   *agrees* with it. Makes the append-only + precedence [Architecture invariant](#architecture-invariant)
   machine-checkable without generating the headers' human rationale.
 
+## Architecture seams (designed + built 2026-06-21, Candidate 3)
+
+- **`llm_call.sh` / `post_discussion.sh`** — two deep, unit-tested scripts under
+  `.github/scripts/` that replace inline `run:` ceremony duplicated across workflows.
+  `llm_call.sh <provider> <prompt>` hides per-provider auth/payload/extraction
+  (`.content[0].text` vs `.candidates[]..` vs `.choices[]..`) behind one interface
+  (was re-typed in 8 workflows + 3× in cross-model-review). `post_discussion.sh`
+  owns the createDiscussion GraphQL and **raises on failure** instead of the
+  `|| echo "Failed"` swallow (9 workflows). The network call is the single
+  overridable function (`_http_post` / `_graphql`); bats tests (`tests/bats/`)
+  override it with fixtures so the logic is tested without a live API — the first
+  unit-tested seam for the shell layer (`.github/workflows/script-tests.yml`:
+  bats + shellcheck). Reference consumer migrated: `cross-model-review.yml` (its 3
+  near-identical provider blocks → 3 one-liners). `post_discussion.sh` takes the
+  category id as an arg, composing with the [ecosystem action](#architecture-seams-designed--built-2026-06-21-candidate-2)'s `cat_*` outputs.
+
 ## Conventions
 
 See `CLAUDE.md` / `AGENTS.md` for authoritative validation rules, the constitutional

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,6 +77,19 @@ fact lives in one place and is read out, never restated.
   *agrees* with it. Makes the append-only + precedence [Architecture invariant](#architecture-invariant)
   machine-checkable without generating the headers' human rationale.
 
+## Architecture seams (designed + built 2026-06-21, Candidate 2)
+
+- **Ecosystem facts action** — `.github/actions/ecosystem`, a composite action that is
+  the single parse point for the GuitarAlchemist ecosystem's GitHub plumbing. It reads
+  `schemas/capability-registry.json` (new `github` block: `repo_node_id`,
+  `discussion_categories` name→id) and `governance-manifest.json` (`.counts`) once and
+  exposes them as step outputs (`repo_node_id`, `cat_*`, `count_*`, `consumer_repos` from
+  `.repos | keys`). Workflows stop restating the repo id / category ids (was duplicated
+  ~22× across 9 files) and stop re-deriving counts with `ls | wc -l` (was ~4 workflows) —
+  the latter is **harvest, don't declare** (ADR-0002) finally reaching the CI surface.
+  Reference consumer migrated: `demerzel-self-improvement.yml` (counts + names harvested
+  from the manifest, ids from the action). Remaining workflows follow the same pattern.
+
 ## Conventions
 
 See `CLAUDE.md` / `AGENTS.md` for authoritative validation rules, the constitutional

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Demerzel/
 | Streeling departments | 23 | `state/streeling/departments/*.department.json` |
 | Course tracks | 21 | `state/streeling/courses/*/` |
 | IxQL pipelines | 23 | `pipelines/*.ixql` |
-| GitHub workflows | 22 | `.github/workflows/*.yml` |
+| GitHub workflows | 23 | `.github/workflows/*.yml` |
 
 ## Key concepts
 
@@ -143,7 +143,7 @@ Artifacts are consumed by agents via:
 
 ## CI workflows
 
-21 GitHub workflows under [`.github/workflows/`](./.github/workflows/). Notable:
+23 GitHub workflows under [`.github/workflows/`](./.github/workflows/). Notable:
 
 - [`qa-tribunal.yml`](./.github/workflows/qa-tribunal.yml) — repository-dispatch emitter (Phase 0).
 - [`governance-validate.yml`](./.github/workflows/governance-validate.yml) — schema + grammar validation.

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -12,7 +12,7 @@
     "policy": 45,
     "schema": 40,
     "skill": 69,
-    "workflow": 22
+    "workflow": 23
   },
   "inventory": {
     "constitution": [
@@ -1253,6 +1253,10 @@
       {
         "name": "qa-tribunal",
         "path": ".github/workflows/qa-tribunal.yml"
+      },
+      {
+        "name": "script-tests",
+        "path": ".github/workflows/script-tests.yml"
       },
       {
         "name": "seldon-plan",

--- a/schemas/capability-registry.json
+++ b/schemas/capability-registry.json
@@ -1,6 +1,18 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "GuitarAlchemist ecosystem capability registry — discovery index for cross-repo MCP federation",
+  "github": {
+    "_comment": "Single source of GitHub plumbing IDs for the Demerzel workflows. Read via .github/actions/ecosystem. Verified against the live repo 2026-06-21.",
+    "repo_node_id": "R_kgDORnMyyQ",
+    "discussion_categories": {
+      "announcements": "DIC_kwDORnMyyc4C4eDS",
+      "general": "DIC_kwDORnMyyc4C4eDT",
+      "ideas": "DIC_kwDORnMyyc4C4eDV",
+      "polls": "DIC_kwDORnMyyc4C4eDX",
+      "q-and-a": "DIC_kwDORnMyyc4C4eDU",
+      "show-and-tell": "DIC_kwDORnMyyc4C4eDW"
+    }
+  },
   "repos": {
     "ix": {
       "server": "ix",

--- a/tests/bats/fixtures/claude.json
+++ b/tests/bats/fixtures/claude.json
@@ -1,0 +1,1 @@
+{ "content": [ { "type": "text", "text": "hello from claude" } ] }

--- a/tests/bats/fixtures/empty.json
+++ b/tests/bats/fixtures/empty.json
@@ -1,0 +1,1 @@
+{ "stop_reason": "max_tokens", "content": [] }

--- a/tests/bats/fixtures/error.json
+++ b/tests/bats/fixtures/error.json
@@ -1,0 +1,1 @@
+{ "type": "error", "error": { "type": "overloaded_error", "message": "Overloaded" } }

--- a/tests/bats/fixtures/gemini.json
+++ b/tests/bats/fixtures/gemini.json
@@ -1,0 +1,1 @@
+{ "candidates": [ { "content": { "parts": [ { "text": "hello from gemini" } ] } } ] }

--- a/tests/bats/fixtures/openai.json
+++ b/tests/bats/fixtures/openai.json
@@ -1,0 +1,1 @@
+{ "choices": [ { "message": { "role": "assistant", "content": "hello from codex" } } ] }

--- a/tests/bats/llm_call.bats
+++ b/tests/bats/llm_call.bats
@@ -45,6 +45,27 @@ setup() {
   [ "$status" -ne 0 ]
 }
 
+@test "API error response -> exit 3 with stderr diagnostic" {
+  _http_post() { cat >/dev/null; cat "$FIX/error.json"; }
+  run _call_claude "hi" 100
+  [ "$status" -eq 3 ]
+  [[ "$output" == *"API error"* ]]
+  [[ "$output" == *"Overloaded"* ]]
+}
+
+@test "empty/blocked response -> exit 4" {
+  _http_post() { cat >/dev/null; cat "$FIX/empty.json"; }
+  run _call_claude "hi" 100
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"no text in response"* ]]
+}
+
+@test "transport failure (empty body) -> exit 3" {
+  _http_post() { cat >/dev/null; printf ''; }
+  run _call_claude "hi" 100
+  [ "$status" -eq 3 ]
+}
+
 @test "LLM_SYSTEM adds a system field to the claude payload" {
   _http_post() { cat > "$BATS_TEST_TMPDIR/p.json"; cat "$FIX/claude.json"; }
   LLM_SYSTEM="be terse" _call_claude "hi" 100

--- a/tests/bats/llm_call.bats
+++ b/tests/bats/llm_call.bats
@@ -44,3 +44,17 @@ setup() {
   run main claude
   [ "$status" -ne 0 ]
 }
+
+@test "LLM_SYSTEM adds a system field to the claude payload" {
+  _http_post() { cat > "$BATS_TEST_TMPDIR/p.json"; cat "$FIX/claude.json"; }
+  LLM_SYSTEM="be terse" _call_claude "hi" 100
+  run jq -er '.system == "be terse"' "$BATS_TEST_TMPDIR/p.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "no LLM_SYSTEM omits the system field" {
+  _http_post() { cat > "$BATS_TEST_TMPDIR/p.json"; cat "$FIX/claude.json"; }
+  _call_claude "hi" 100
+  run jq -er 'has("system") | not' "$BATS_TEST_TMPDIR/p.json"
+  [ "$status" -eq 0 ]
+}

--- a/tests/bats/llm_call.bats
+++ b/tests/bats/llm_call.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# Tests llm_call.sh through its interface by overriding the _http_post seam with
+# fixtures — exercises the per-provider extraction without any network call.
+
+setup() {
+  source "$BATS_TEST_DIRNAME/../../.github/scripts/llm_call.sh"
+  FIX="$BATS_TEST_DIRNAME/fixtures"
+}
+
+@test "claude: extracts .content[0].text" {
+  _http_post() { cat >/dev/null; cat "$FIX/claude.json"; }
+  run _call_claude "hi" 100
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello from claude" ]
+}
+
+@test "gemini: extracts .candidates[0].content.parts[0].text" {
+  _http_post() { cat >/dev/null; cat "$FIX/gemini.json"; }
+  run _call_gemini "hi" 100
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello from gemini" ]
+}
+
+@test "codex/openai: extracts .choices[0].message.content" {
+  _http_post() { cat >/dev/null; cat "$FIX/openai.json"; }
+  run _call_openai "hi" 100
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello from codex" ]
+}
+
+@test "main dispatches by provider" {
+  _http_post() { cat >/dev/null; cat "$FIX/claude.json"; }
+  run main claude "hi" 100
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello from claude" ]
+}
+
+@test "unknown provider exits 2" {
+  run main bogus "hi"
+  [ "$status" -eq 2 ]
+}
+
+@test "missing prompt fails" {
+  run main claude
+  [ "$status" -ne 0 ]
+}

--- a/tests/bats/post_discussion.bats
+++ b/tests/bats/post_discussion.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# Tests post_discussion.sh through its interface by overriding the _graphql seam
+# — exercises the build/validate/raise-on-fail logic without hitting GitHub.
+
+setup() {
+  export REPO_NODE_ID="R_test"
+  source "$BATS_TEST_DIRNAME/../../.github/scripts/post_discussion.sh"
+}
+
+@test "prints the discussion URL on success" {
+  _graphql() { echo "https://github.com/x/y/discussions/1"; }
+  run main "CAT_ID" "A title" "A body"
+  [ "$status" -eq 0 ]
+  [ "$output" = "https://github.com/x/y/discussions/1" ]
+}
+
+@test "raises (exit 1) when the API returns an empty URL" {
+  _graphql() { echo ""; }
+  run main "CAT_ID" "t" "b"
+  [ "$status" -eq 1 ]
+}
+
+@test "raises (exit 1) when the API returns null" {
+  _graphql() { echo "null"; }
+  run main "CAT_ID" "t" "b"
+  [ "$status" -eq 1 ]
+}
+
+@test "fails when REPO_NODE_ID is unset" {
+  unset REPO_NODE_ID
+  _graphql() { echo "https://example/x"; }
+  run main "CAT_ID" "t" "b"
+  [ "$status" -ne 0 ]
+}
+
+@test "fails when category_id is missing" {
+  run main
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Completes Candidate 3's deferred `post_discussion.sh` production wiring — the piece that needed **both** the ecosystem action (#365) and the script (#366), so it's done on an integration branch that merges both.

## What this does
Replaces **every inline `createDiscussion` GraphQL mutation** (10 sites across 8 workflows) with a `post_discussion.sh` call:

- ids resolved from `${{ steps.eco.outputs.repo_node_id / cat_* }}` (Candidate 2's action)
- raw body passed straight to the script (drops the `jq -Rs` pre-encoding — the script encodes via gh's GraphQL variables)
- **raises on failure**, replacing the `|| echo "Failed"` swallow that turned a failed post into a silent green

Workflows: showcase, cross-repo-issues, capability-expansion, autofix, ideation, self-improvement, ga-chatbot-discussions, streeling-daily (×3). **No inline `createDiscussion` remains in any workflow.**

## Verification
actionlint clean (0 errors, all `steps.eco` references resolve) across all eight. Net −66 lines.

## Merge order
This branch **contains** #365 and #366. Merge **#365 → #366 → this** (git dedupes the shared commits, leaving only the wiring as new). Or merge this alone to land all three together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)