### PR TITLE
chore(gitignore): ignore regenerable build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ state/digests/*
 
 # /teach generated courses (personal, regenerable)
 learning/
+
+# Build artifacts and tooling output (regenerable, never committed)
+node_modules/
+__pycache__/
+*.pyc
+*.stackdump


### PR DESCRIPTION
## Summary
`node_modules/`, `__pycache__/`, `*.pyc`, and `*.stackdump` crash dumps were sitting untracked in the working tree (including a 19 MB `tree-sitter.exe`). Add `.gitignore` rules so they can't be accidentally committed.

## Scope
- Verified no already-tracked file matches the new patterns (nothing gets hidden).
- Deliberately left ambiguous untracked entries alone (`.claude-octopus/`, `.claude/*.local.md`, session scratch, `.zed/`, `state/governance/`, `tree-sitter-ixql/package-lock.json`) — those may be intentional and warrant a separate decision.

## Test plan
No code; `.gitignore` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)