### PR TITLE
chore: track tree-sitter-ixql lockfile, ignore overseer preflight report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ node_modules/
 __pycache__/
 *.pyc
 *.stackdump
+
+# dev-process-overseer preflight report — transient, machine-specific (absolute
+# paths + stale head), regenerated each preflight. Like state/digests/, this is
+# the tracked-state exception, not canonical governance state.
+state/governance/dev-process-overseer.json

--- a/tree-sitter-ixql/package-lock.json
+++ b/tree-sitter-ixql/package-lock.json
@@ -1,0 +1,38 @@
+{
+  "name": "tree-sitter-ixql",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tree-sitter-ixql",
+      "version": "0.1.0",
+      "dependencies": {
+        "nan": "^2.18.0"
+      },
+      "devDependencies": {
+        "tree-sitter-cli": "^0.23.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "license": "MIT"
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.2.tgz",
+      "integrity": "sha512-kPPXprOqREX+C/FgUp2Qpt9jd0vSwn+hOgjzVv/7hapdoWpa+VeWId53rf4oNNd29ikheF12BYtGD/W90feMbA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Resolve the two ambiguous untracked entries left after #370.

- **Track** `tree-sitter-ixql/package-lock.json` — `package.json` and the grammar subproject are already tracked; the lockfile belongs with its manifest for reproducible builds.
- **Ignore** `state/governance/dev-process-overseer.json` — a transient dev-process-overseer preflight report carrying absolute machine paths + username (`C:\Users\spare\...`) and a stale frozen head. This repo does track emitted state (609 files under `state/`), but this file is the same kind of machine-specific, regenerable exception as `state/digests/`.

## Test plan
No code; `.gitignore` + one tracked lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)