### PR TITLE
chore(gitignore): ignore local tooling, editor, and session scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,11 @@ __pycache__/
 # paths + stale head), regenerated each preflight. Like state/digests/, this is
 # the tracked-state exception, not canonical governance state.
 state/governance/dev-process-overseer.json
+
+# Local tooling / editor / per-session scratch (machine-specific, not repo content)
+.claude-octopus/
+.claude/*.local.md
+.claude/scheduled_tasks.lock
+.claude/session-intent.md
+.claude/session-plan.md
+.zed/


### PR DESCRIPTION
## Summary
Ignore the last six untracked entries — all machine-specific local state, not repo content:

- `.claude-octopus/` — Octopus plugin local state
- `.claude/*.local.md` — local-only notes (e.g. `claude-octopus.local.md`)
- `.claude/scheduled_tasks.lock` — lock file
- `.claude/session-intent.md`, `.claude/session-plan.md` — per-session scratch
- `.zed/` — Zed editor config

After this the working tree is clean. Verified no already-tracked file matches the new patterns.

## Test plan
No code; `.gitignore` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)