### PR TITLE
fix(afk): invoke harness via node --import tsx, not npx (Windows)

### DIFF
--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -108,8 +108,14 @@ def build_loop_state(issue: dict, seq: int, risk: str, mode: str, today: str) ->
 
 
 def _invoke_harness(issue: dict) -> dict:
-    """Run the sandcastle harness for one issue. Returns {branch,commits,blocked}."""
-    cmd = ["npx", "tsx", str(HARNESS_DIR / ".sandcastle" / "main.mts"),
+    """Run the sandcastle harness for one issue. Returns {branch,commits,blocked}.
+
+    Invokes node with the tsx loader directly rather than `npx tsx`: on Windows
+    `npx` is `npx.cmd` (no .exe) and Python's subprocess cannot CreateProcess it
+    without a shell — and a shell would expose the issue body to command
+    injection. `node` is a real executable and args pass straight through as argv.
+    """
+    cmd = ["node", "--import", "tsx", str(HARNESS_DIR / ".sandcastle" / "main.mts"),
            "--repo", str(ROOT), "--issue", str(issue.get("number")),
            "--title", issue.get("title", ""), "--body", issue.get("body", "")]
     p = subprocess.run(cmd, cwd=str(HARNESS_DIR), capture_output=True, text=True, timeout=1800)


### PR DESCRIPTION
Follow-up to #380. The end-to-end dogfood (issue #381) surfaced a Windows-only bug in the governor: `_invoke_harness` ran `["npx", "tsx", ...]` via Python `subprocess` (no shell). On Windows `npx` is `npx.cmd` (no `.exe`), so `CreateProcess` fails with WinError 2 — and using a shell would expose the issue body to command injection.

Fix: invoke `node --import tsx <main.mts>` directly. `node.exe` is a real executable and all args pass through as argv (no shell, no injection surface).

**Proven:** after this fix the AFK agent ran the full path autonomously — picked #381 off the queue, implemented it in the Podman sandbox, and opened #383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)