### PR TITLE
feat(afk): graduated self-merge gated by a 2-reviewer LLM council

### DIFF
--- a/schemas/council-verdict.schema.json
+++ b/schemas/council-verdict.schema.json
@@ -15,6 +15,11 @@
       "type": "string",
       "description": "The task that triggered this council review"
     },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the council reached this verdict"
+    },
     "trigger_condition": {
       "type": "string",
       "enum": ["high_risk_self_merge", "borderline_confidence"],

--- a/scripts/council_emit.py
+++ b/scripts/council_emit.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""
+Demerzel council_emit — the LLM-council verdict emitter for self-merge gating.
+
+Convenes a two-reviewer council on a pull request and writes a verdict that
+validates against schemas/council-verdict.schema.json into state/council/. The
+verdict carries a `post_council_confidence` (0-1) which the AFK governor's
+self-merge gate (scripts/run_afk_cycle.py --harvest) consumes per the
+`confidence_threshold` in policies/autonomous-loop-policy.yaml ("Post-council
+confidence is used ... council must have run before self-merge is considered").
+
+The two reviewers are deliberately heterogeneous so the council aggregates an
+existing static gate with a fresh model opinion (multi-perspective, not
+redundant):
+
+  reviewer_a — Agent Blackbox. We read the `risk-report` CHECK CONCLUSION via
+    `gh pr checks` rather than parsing agent-blackbox's risk-report.json (that
+    JSON is produced by the external GuitarAlchemist/agent-blackbox repo at a
+    pinned ref; its field shape is not vendored here, so parsing it would be a
+    guess). A green check means the policy's pass band (risk <= 0.25, see
+    agent-blackbox.policy.json) held, which maps to correctness_score 0.75 — at
+    or above the 0.7 self-merge minimum and at/under the 0.8 single-model cap. A
+    red check maps to 0.2 (REQUEST_CHANGES). Pending/absent -> unknown (the
+    council reports incomplete and nothing self-merges).
+
+  reviewer_b — A cross-model reviewer (Claude / Gemini / Codex, whichever API
+    key is present), the same prompt the cross-model-review.yml workflow uses.
+    Its APPROVE / REQUEST_CHANGES verdict maps to correctness_score 0.85 / 0.30.
+    This is a genuinely different model from reviewer_a's static analyzer, so a
+    two-review verdict lifts the single-model confidence cap honestly.
+
+Chairman synthesis is strictest-wins (matching the tribunal panel's consensus
+doctrine): the verdict is APPROVE only if every review is APPROVE-equivalent and
+constitutionally aligned; `post_council_confidence` is the MIN of the reviewers'
+correctness scores. Any reviewer that cannot run (missing check, missing API
+key) is omitted — a verdict with fewer than two reviews is schema-valid but the
+self-merge gate requires two, so a degraded council simply never self-merges.
+
+Usage:
+  python scripts/council_emit.py --pr 365                 # emit verdict, print JSON
+  python scripts/council_emit.py --pr 365 --print-only    # do not write to disk
+
+Exit codes:
+  0  verdict emitted (any verdict value — APPROVE/REQUEST_CHANGES/REJECT)
+  1  usage / environment error (e.g. PR not found)
+
+Stdlib only (urllib for the model call) — no third-party deps, mirroring
+run_afk_cycle.py so the governor can call this in the same environment.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_SLUG = "GuitarAlchemist/Demerzel"
+COUNCIL_DIR = ROOT / "state" / "council"
+BLACKBOX_CHECK = "risk-report"
+
+# correctness_score mappings (0-1). reviewer_a green is the agent-blackbox pass
+# band (risk <= 0.25 -> 1 - 0.25 = 0.75); red is a clear REQUEST_CHANGES.
+SCORE_BLACKBOX_GREEN = 0.75
+SCORE_BLACKBOX_RED = 0.2
+SCORE_XMODEL_APPROVE = 0.85
+SCORE_XMODEL_REQUEST_CHANGES = 0.3
+
+SELF_MERGE_MIN_CONFIDENCE = 0.7   # policies/autonomous-loop-policy.yaml
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --------------------------------------------------------------------------- #
+# Pure synthesis logic (unit-tested; no IO)
+# --------------------------------------------------------------------------- #
+def review_from_blackbox(check_state: str | None) -> dict | None:
+    """Build reviewer_a from the agent-blackbox `risk-report` check conclusion.
+    Returns None when the check is absent or not yet conclusive (pending), so the
+    council reports incomplete rather than guessing."""
+    if check_state is None:
+        return None
+    state = check_state.strip().lower()
+    if state in ("pass", "success"):
+        return {
+            "reviewer": "reviewer_a",
+            "correctness_score": SCORE_BLACKBOX_GREEN,
+            "risk_assessment": "low",
+            "constitutional_alignment": "pass",
+            "rationale": "Agent Blackbox risk-report check is green: change sits in "
+                         "the policy pass band (risk <= 0.25) and violates no "
+                         "blocked-path constraint.",
+        }
+    if state in ("fail", "failure", "error"):
+        return {
+            "reviewer": "reviewer_a",
+            "correctness_score": SCORE_BLACKBOX_RED,
+            "risk_assessment": "high",
+            "constitutional_alignment": "fail",
+            "rationale": "Agent Blackbox risk-report check is red: risk exceeds the "
+                         "pass band or a blocked-path/verify constraint failed.",
+        }
+    return None  # pending / neutral / skipped — not conclusive
+
+
+def review_from_cross_model(verdict_text: str | None, model: str | None,
+                            classified_risk: str) -> dict | None:
+    """Build reviewer_b from a cross-model review's APPROVE/REQUEST_CHANGES text.
+    Returns None when no model ran (no API key/response)."""
+    if verdict_text is None:
+        return None
+    approve = "REQUEST_CHANGES" not in verdict_text.upper()
+    return {
+        "reviewer": "reviewer_b",
+        "correctness_score": SCORE_XMODEL_APPROVE if approve else SCORE_XMODEL_REQUEST_CHANGES,
+        "risk_assessment": classified_risk if classified_risk in ("low", "medium", "high", "critical") else "medium",
+        "constitutional_alignment": "pass" if approve else "fail",
+        "rationale": f"Cross-model reviewer ({model or 'unknown'}) verdict: "
+                     f"{'APPROVE' if approve else 'REQUEST_CHANGES'}.",
+    }
+
+
+def synthesize(reviews: list[dict]) -> tuple[str, float, str]:
+    """Chairman: strictest-wins. Returns (verdict, post_council_confidence,
+    chairman_synthesis).
+
+    - verdict APPROVE only if every review is constitutionally `pass` AND every
+      correctness_score >= the self-merge minimum; otherwise REQUEST_CHANGES, or
+      REJECT if any reviewer flagged a constitutional failure.
+    - post_council_confidence = min(correctness_score) — the most skeptical
+      reviewer caps the council. With a single review the value is additionally
+      capped at the policy single-model cap (0.8); min() of one score <= 0.85
+      already satisfies that, so no extra clamp is needed in practice.
+    """
+    if not reviews:
+        return "REJECT", 0.0, "No reviewers could run; council is empty."
+    scores = [r["correctness_score"] for r in reviews]
+    confidence = round(min(scores), 4)
+    all_aligned = all(r["constitutional_alignment"] == "pass" for r in reviews)
+    any_constitutional_fail = any(r["constitutional_alignment"] == "fail" for r in reviews)
+    if all_aligned and confidence >= SELF_MERGE_MIN_CONFIDENCE:
+        verdict = "APPROVE"
+    elif any_constitutional_fail:
+        verdict = "REJECT"
+    else:
+        verdict = "REQUEST_CHANGES"
+    chairman = (
+        f"{len(reviews)} reviewer(s); strictest-wins confidence "
+        f"{confidence:.2f} (min of {', '.join(f'{s:.2f}' for s in scores)}). "
+        f"Constitutional alignment: {'all pass' if all_aligned else 'at least one fail'}. "
+        f"Verdict: {verdict}."
+    )
+    return verdict, confidence, chairman
+
+
+def build_verdict(pr: int, change_summary: str, reviews: list[dict],
+                  today: str, seq: int) -> dict:
+    """Assemble a council-verdict.schema.json-valid object."""
+    verdict, confidence, chairman = synthesize(reviews)
+    return {
+        "verdict_id": f"council-{today}-{seq:03d}",
+        "task_id": f"github_pr:#{pr}",
+        "timestamp": _now_iso(),
+        "trigger_condition": "borderline_confidence",
+        "change_summary": change_summary[:500] if change_summary else f"PR #{pr}",
+        "reviews": reviews,
+        "chairman_synthesis": chairman,
+        "verdict": verdict,
+        "post_council_confidence": confidence,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# IO (thin wrappers around gh + model APIs)
+# --------------------------------------------------------------------------- #
+def _gh_json(args: list[str]) -> dict | list | None:
+    try:
+        p = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=60)
+        if p.returncode != 0:
+            print(f"warn: gh {' '.join(args)} failed: {p.stderr.strip()[:160]}", file=sys.stderr)
+            return None
+        return json.loads(p.stdout or "null")
+    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        print(f"warn: gh {' '.join(args)} unavailable: {exc}", file=sys.stderr)
+        return None
+
+
+def fetch_pr_meta(pr: int) -> dict | None:
+    return _gh_json(["pr", "view", str(pr), "--repo", REPO_SLUG,
+                     "--json", "number,title,body,headRefOid,labels"])  # type: ignore[return-value]
+
+
+def fetch_blackbox_check_state(pr: int) -> str | None:
+    """Return the `risk-report` check state ('pass'/'fail'/...) or None if absent.
+    Parses `gh pr checks` tab-separated output (name<TAB>state<TAB>...)."""
+    try:
+        p = subprocess.run(["gh", "pr", "checks", str(pr), "--repo", REPO_SLUG],
+                           capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(f"warn: gh pr checks failed: {exc}", file=sys.stderr)
+        return None
+    # gh pr checks exits non-zero when any check failed; output is still on stdout.
+    for line in p.stdout.splitlines():
+        parts = line.split("\t")
+        if parts and parts[0].strip() == BLACKBOX_CHECK and len(parts) > 1:
+            return parts[1].strip()
+    return None
+
+
+def fetch_diff(pr: int, limit: int = 12000) -> str:
+    try:
+        p = subprocess.run(["gh", "pr", "diff", str(pr), "--repo", REPO_SLUG],
+                           capture_output=True, text=True, timeout=60)
+        return (p.stdout or "")[:limit] if p.returncode == 0 else ""
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+
+
+def _review_prompt(diff: str) -> str:
+    return (
+        "You are a cross-model code reviewer for the Demerzel governance framework.\n"
+        "Review this pull request diff for:\n"
+        "1. CORRECTNESS: Logic errors, off-by-one, missing edge cases\n"
+        "2. SECURITY (OWASP): Injection risks, secrets exposure, insecure defaults\n"
+        "3. ANTI-SLOP: Vague names, cargo-cult patterns, unnecessary complexity\n"
+        "4. LOLLI: Artifacts without named consumers? Governance weight without value?\n"
+        "5. CONSTITUTIONAL: Article 4 (Proportionality), 3 (Reversibility), 9 (Bounded Autonomy)\n\n"
+        "End your response with exactly one line: 'Verdict: APPROVE' or "
+        "'Verdict: REQUEST_CHANGES' with a one-line rationale. Be direct; no filler praise.\n\n"
+        f"DIFF:\n{diff}"
+    )
+
+
+def run_cross_model(diff: str) -> tuple[str | None, str | None]:
+    """Run one cross-model review using whichever API key is present.
+    Returns (verdict_text, model_name) or (None, None) if no key / call failed.
+    Preference order mirrors cross-model-review.yml: Claude, then Gemini, then
+    Codex. Uses urllib (stdlib) so no extra deps are needed."""
+    if not diff:
+        return None, None
+    prompt = _review_prompt(diff)
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return _call_anthropic(prompt), "claude"
+    if os.environ.get("GOOGLE_AI_KEY"):
+        return _call_gemini(prompt), "gemini"
+    if os.environ.get("OPENAI_API_KEY"):
+        return _call_openai(prompt), "codex"
+    print("warn: no model API key (ANTHROPIC_API_KEY/GOOGLE_AI_KEY/OPENAI_API_KEY); "
+          "reviewer_b unavailable", file=sys.stderr)
+    return None, None
+
+
+def _http_post_json(url: str, headers: dict, payload: dict) -> dict | None:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers={"content-type": "application/json", **headers})
+    try:
+        with urllib.request.urlopen(req, timeout=90) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, OSError) as exc:
+        print(f"warn: model call failed: {exc}", file=sys.stderr)
+        return None
+
+
+def _call_anthropic(prompt: str) -> str | None:
+    body = _http_post_json(
+        "https://api.anthropic.com/v1/messages",
+        {"x-api-key": os.environ["ANTHROPIC_API_KEY"], "anthropic-version": "2023-06-01"},
+        {"model": "claude-sonnet-4-20250514", "max_tokens": 1024,
+         "messages": [{"role": "user", "content": prompt}]},
+    )
+    try:
+        return body["content"][0]["text"] if body else None
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+def _call_gemini(prompt: str) -> str | None:
+    key = os.environ["GOOGLE_AI_KEY"]
+    body = _http_post_json(
+        f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key={key}",
+        {},
+        {"contents": [{"parts": [{"text": prompt}]}], "generationConfig": {"maxOutputTokens": 1024}},
+    )
+    try:
+        return body["candidates"][0]["content"]["parts"][0]["text"] if body else None
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+def _call_openai(prompt: str) -> str | None:
+    body = _http_post_json(
+        "https://api.openai.com/v1/chat/completions",
+        {"Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}"},
+        {"model": "gpt-4o", "max_tokens": 1024,
+         "messages": [{"role": "user", "content": prompt}]},
+    )
+    try:
+        return body["choices"][0]["message"]["content"] if body else None
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+def _next_seq(today: str) -> int:
+    """Next sequence for today's verdict id (council-YYYY-MM-DD-NNN)."""
+    if not COUNCIL_DIR.is_dir():
+        return 1
+    prefix = f"council-{today}-"
+    existing = [p.stem for p in COUNCIL_DIR.glob(f"{prefix}*.json")]
+    seqs = []
+    for stem in existing:
+        tail = stem.replace(prefix, "")
+        if tail.isdigit():
+            seqs.append(int(tail))
+    return (max(seqs) + 1) if seqs else 1
+
+
+def _write_verdict(verdict: dict) -> Path:
+    COUNCIL_DIR.mkdir(parents=True, exist_ok=True)
+    out = COUNCIL_DIR / f"{verdict['verdict_id']}.json"
+    out.write_text(json.dumps(verdict, indent=2) + "\n", encoding="utf-8")
+    return out
+
+
+def convene(pr: int, classified_risk: str = "medium",
+            write: bool = True) -> dict:
+    """Convene the council for one PR end-to-end and return the verdict dict.
+    classified_risk is the governor's risk class for the PR (used for reviewer_b's
+    independent risk_assessment field)."""
+    meta = fetch_pr_meta(pr) or {}
+    change_summary = meta.get("title", f"PR #{pr}")
+
+    bb_state = fetch_blackbox_check_state(pr)
+    reviews: list[dict] = []
+    ra = review_from_blackbox(bb_state)
+    if ra:
+        reviews.append(ra)
+
+    diff = fetch_diff(pr)
+    xtext, xmodel = run_cross_model(diff)
+    rb = review_from_cross_model(xtext, xmodel, classified_risk)
+    if rb:
+        reviews.append(rb)
+
+    today = _now_iso()[:10]
+    seq = _next_seq(today)
+    verdict = build_verdict(pr, change_summary, reviews, today, seq)
+    if write:
+        path = _write_verdict(verdict)
+        print(f"council verdict written: {path}", file=sys.stderr)
+    return verdict
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="Demerzel LLM-council verdict emitter")
+    ap.add_argument("--pr", type=int, required=True, help="PR number to convene the council on")
+    ap.add_argument("--risk", default="medium", help="governor risk class for the PR (low/medium/high/critical)")
+    ap.add_argument("--print-only", action="store_true", help="print verdict JSON; do not write to state/council/")
+    args = ap.parse_args(argv)
+
+    verdict = convene(args.pr, classified_risk=args.risk, write=not args.print_only)
+    print(json.dumps(verdict, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -44,6 +44,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import council_emit  # noqa: E402  (sibling module in scripts/; self-merge gate)
+
 ROOT = Path(__file__).resolve().parents[1]            # repos/Demerzel
 HARNESS_DIR = ROOT.parent / "afk-harness"             # sibling, outside Demerzel
 PROMPT_FILE = ROOT / "prompts" / "afk-implement.prompt.md"
@@ -54,6 +57,11 @@ CRITICAL_PATHS = ("constitution", "policies/", "policy")
 HIGH_KEYWORDS = ("schema migration", "migrate schema", "cross-repo", "infrastructure")
 MEDIUM_KEYWORDS = ("persona", "refactor", "schema")
 LOW_KEYWORDS = ("doc", "documentation", "typo", "comment", "test", "config")
+
+# Self-merge gate constants (policies/autonomous-loop-policy.yaml §Self-Merge Authority)
+CONSCIENCE_SIGNALS_DIR = ROOT / "state" / "conscience" / "signals"
+CONSCIENCE_BLOCK_WEIGHT = 0.8         # an active signal at/above this blocks self-merge
+SELF_MERGE_MIN_CONFIDENCE = 0.7       # minimum post_council_confidence
 
 
 def _now_iso() -> str:
@@ -246,6 +254,210 @@ def _write_audit(summary: dict, today: str) -> None:
     os.replace(tmp, out)
 
 
+# --------------------------------------------------------------------------- #
+# Graduated self-merge (the --harvest pass)
+#
+# A SEPARATE pass from the implement queue: agent-blackbox runs asynchronously in
+# CI, so a PR's gates are not settled when _process_issue opens it. Harvest
+# re-examines already-open agent-implement PRs whose checks have settled and
+# self-merges only those that clear the council + policy gate. This NEVER applies
+# the `agent-blackbox-reviewed` override — it merges only PRs that already PASS
+# their gates. Critical/high never self-merge.
+# --------------------------------------------------------------------------- #
+def parse_authorization_trace(pr_body: str) -> str | None:
+    """Extract the authorization artifact a PR traces to. AFK PRs carry
+    'Closes #N' / 'Implements #N' / 'Fixes #N'. Returns 'github_issue:#N' or None.
+    String-based (no regex) per repo convention."""
+    if not pr_body:
+        return None
+    for kw in ("closes #", "implements #", "fixes #", "resolves #"):
+        idx = pr_body.lower().find(kw)
+        if idx == -1:
+            continue
+        tail = pr_body[idx + len(kw):]
+        num = ""
+        for ch in tail:
+            if ch.isdigit():
+                num += ch
+            else:
+                break
+        if num:
+            return f"github_issue:#{num}"
+    return None
+
+
+def active_conscience_max_weight() -> float:
+    """Max `weight` among ACTIVE conscience signals (state/conscience/signals/).
+    A signal is active unless resolved (resolved_at present, or outcome begins
+    'RESOLVED') or marked false_positive. Returns 0.0 when none or dir absent.
+    Note: the policy prose says 'severity'; the schema field is `weight`."""
+    if not CONSCIENCE_SIGNALS_DIR.is_dir():
+        return 0.0
+    mx = 0.0
+    for p in CONSCIENCE_SIGNALS_DIR.glob("*.signal.json"):
+        try:
+            d = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if d.get("false_positive") is True or d.get("resolved_at"):
+            continue
+        outcome = d.get("outcome") or ""
+        if isinstance(outcome, str) and outcome.strip().upper().startswith("RESOLVED"):
+            continue
+        w = d.get("weight")
+        if isinstance(w, (int, float)):
+            mx = max(mx, float(w))
+    return mx
+
+
+def self_merge_decision(risk: str, checks_green: bool, authz_trace: str | None,
+                        conscience_max_weight: float,
+                        council_verdict: dict | None) -> tuple[bool, str]:
+    """Pure gate predicate for graduated self-merge. Returns (merge?, reason).
+    Mirrors policies/autonomous-loop-policy.yaml §Self-Merge Authority:
+    CI pass · confidence >= 0.7 · no conscience >= 0.8 · authorization trace ·
+    critical/high never · genuine multi-model council (>= 2 reviews)."""
+    if risk not in ("low", "medium"):
+        return False, f"risk={risk}: only low/medium self-merge (critical/high never)"
+    if not checks_green:
+        return False, "CI not all green"
+    if not authz_trace:
+        return False, "no authorization trace (PR not linked to an issue)"
+    if conscience_max_weight >= CONSCIENCE_BLOCK_WEIGHT:
+        return False, (f"active conscience signal weight {conscience_max_weight:.2f} "
+                       f">= {CONSCIENCE_BLOCK_WEIGHT}")
+    if not council_verdict:
+        return False, "no council verdict"
+    reviews = council_verdict.get("reviews", [])
+    if len(reviews) < 2:
+        return False, f"council incomplete: {len(reviews)} reviewer(s), need 2 (multi-model)"
+    if council_verdict.get("verdict") != "APPROVE":
+        return False, f"council verdict {council_verdict.get('verdict')}"
+    conf = council_verdict.get("post_council_confidence", 0.0)
+    if conf < SELF_MERGE_MIN_CONFIDENCE:
+        return False, f"post_council_confidence {conf:.2f} < {SELF_MERGE_MIN_CONFIDENCE}"
+    if any(r.get("constitutional_alignment") != "pass" for r in reviews):
+        return False, "constitutional alignment not all pass"
+    return True, f"self-merge OK (post_council_confidence={conf:.2f}, {len(reviews)} reviewers)"
+
+
+def _checks_all_green(pr: int) -> bool:
+    """True iff `gh pr checks` shows at least one check and none are failing or
+    pending. pass/success/skipping/neutral count as OK; fail/pending block."""
+    try:
+        p = subprocess.run(["gh", "pr", "checks", str(pr), "--repo", REPO_SLUG],
+                           capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    saw_any = False
+    for line in p.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        saw_any = True
+        state = parts[1].strip().lower()
+        if state not in ("pass", "success", "skipping", "neutral"):
+            return False
+    return saw_any
+
+
+def _gh_open_afk_prs() -> list[dict]:
+    """Open agent-implement PRs as dicts with number/title/body/labels."""
+    try:
+        p = subprocess.run(
+            ["gh", "pr", "list", "--repo", REPO_SLUG, "--label", LABEL,
+             "--state", "open", "--json", "number,title,body,labels", "--limit", "20"],
+            capture_output=True, text=True, timeout=60)
+        if p.returncode != 0:
+            print(f"warn: gh pr list failed: {p.stderr.strip()[:160]}", file=sys.stderr)
+            return []
+        return json.loads(p.stdout or "[]")
+    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        print(f"warn: gh pr list unavailable: {exc}", file=sys.stderr)
+        return []
+
+
+def _merge_pr(pr: int) -> str:
+    """Squash-merge a gate-cleared PR. Returns 'merged' or a failure sentinel."""
+    p = subprocess.run(["gh", "pr", "merge", str(pr), "--repo", REPO_SLUG, "--squash"],
+                       capture_output=True, text=True, timeout=120)
+    return "merged" if p.returncode == 0 else f"merge-failed: {p.stderr.strip()[:160]}"
+
+
+def _harvest_pr(pr: dict, conscience_w: float) -> dict:
+    """Gate ONE open AFK PR through cheap pre-checks, then the council, then the
+    self-merge predicate. The council call (a model request) is spent only on
+    PRs that already pass the cheap gates."""
+    num = pr.get("number")
+    risk, _mode = classify_risk(pr)          # classify_risk reads title/body/labels — works on a PR dict
+    authz = parse_authorization_trace(pr.get("body", ""))
+    decision = {"pr": num, "title": pr.get("title"), "risk": risk,
+                "authorization_trace": authz}
+
+    if risk not in ("low", "medium"):
+        decision["action"] = f"skip:risk-{risk}"
+        return decision
+    if not authz:
+        decision["action"] = "skip:no-authorization-trace"
+        return decision
+    if not _checks_all_green(num):
+        decision["action"] = "hold:ci-not-green"
+        return decision
+
+    verdict = council_emit.convene(num, classified_risk=risk, write=True)
+    decision["council_verdict"] = verdict.get("verdict")
+    decision["post_council_confidence"] = verdict.get("post_council_confidence")
+    decision["reviewers"] = len(verdict.get("reviews", []))
+
+    merge, reason = self_merge_decision(risk, True, authz, conscience_w, verdict)
+    decision["gate"] = reason
+    if not merge:
+        decision["action"] = "hold:gate-not-met"
+        return decision
+    decision["action"] = "self-merge"
+    decision["merge_result"] = _merge_pr(num)
+    return decision
+
+
+def _run_harvest(dry: bool, today: str) -> int:
+    """The self-merge pass over open AFK PRs."""
+    prs = _gh_open_afk_prs()
+    conscience_w = active_conscience_max_weight()
+    if prs:
+        print(f"AFK harvest: {len(prs)} open agent-implement PR(s); "
+              f"active conscience weight {conscience_w:.2f}", file=sys.stderr)
+
+    decisions: list[dict] = []
+    for pr in prs:
+        if dry:
+            risk, _ = classify_risk(pr)
+            authz = parse_authorization_trace(pr.get("body", ""))
+            decisions.append({
+                "pr": pr.get("number"), "title": pr.get("title"), "risk": risk,
+                "authorization_trace": authz,
+                "action": "plan:would-gate" if risk in ("low", "medium") else f"skip:risk-{risk}"})
+        else:
+            decisions.append(_harvest_pr(pr, conscience_w))
+
+    def _tally(prefix: str) -> int:
+        return sum(1 for d in decisions if str(d.get("action", "")).startswith(prefix))
+    summary = {
+        "harvest_at": _now_iso(), "dry_run": dry, "halted": False,
+        "conscience_max_weight": conscience_w, "queue_size": len(prs),
+        "decisions": decisions,
+        "tally": {"self_merge": _tally("self-merge"), "held": _tally("hold"),
+                  "skipped": _tally("skip")},
+    }
+    if not dry:
+        out = ROOT / "state" / "oversight" / f"afk-harvest-{today}.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        tmp = out.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, out)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
 def _process_issue(issue: dict, seq: int, today: str, backend: str) -> tuple[dict, dict]:
     """Live processing of ONE issue end-to-end (runs inside the thread pool).
     Each call is independent: its own clone, its own branch, its own PR, its own
@@ -343,6 +555,10 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--backend", choices=["local", "remote"], default="local",
                     help="local = per-agent clone + Podman (default); "
                          "remote = Vercel isolated sandboxes (not yet implemented)")
+    ap.add_argument("--harvest", action="store_true",
+                    help="self-merge pass: gate already-open AFK PRs through the "
+                         "council + policy thresholds and merge qualifiers, instead "
+                         "of processing the issue queue")
     args = ap.parse_args(argv)
 
     if args.max_parallel < 1:
@@ -355,6 +571,12 @@ def main(argv: list[str]) -> int:
         return 3
 
     today = _now_iso()[:10]
+
+    # Self-merge harvest is a distinct pass (CI gates settle asynchronously after
+    # the implement pass opens a PR), so it has its own queue and audit.
+    if args.harvest:
+        return _run_harvest(args.dry_run, today)
+
     issues = _gh_queue(args.dry_run)
 
     # Dry-run: plan only, strictly no side effects (no clone/podman/files).

--- a/scripts/test_council_emit.py
+++ b/scripts/test_council_emit.py
@@ -1,0 +1,101 @@
+import json
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import council_emit as c
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _green_a():
+    return c.review_from_blackbox("pass")
+
+
+def _approve_b(risk="low"):
+    return c.review_from_cross_model("Looks good.\nVerdict: APPROVE", "claude", risk)
+
+
+class TestReviewBuilders(unittest.TestCase):
+    def test_blackbox_green_is_pass_band(self):
+        r = c.review_from_blackbox("pass")
+        self.assertEqual(r["reviewer"], "reviewer_a")
+        self.assertEqual(r["correctness_score"], c.SCORE_BLACKBOX_GREEN)
+        self.assertEqual(r["constitutional_alignment"], "pass")
+
+    def test_blackbox_red_requests_changes(self):
+        r = c.review_from_blackbox("fail")
+        self.assertEqual(r["correctness_score"], c.SCORE_BLACKBOX_RED)
+        self.assertEqual(r["constitutional_alignment"], "fail")
+
+    def test_blackbox_pending_is_none(self):
+        self.assertIsNone(c.review_from_blackbox("pending"))
+        self.assertIsNone(c.review_from_blackbox(None))
+
+    def test_cross_model_approve(self):
+        r = c.review_from_cross_model("fine\nVerdict: APPROVE", "gemini", "medium")
+        self.assertEqual(r["correctness_score"], c.SCORE_XMODEL_APPROVE)
+        self.assertEqual(r["constitutional_alignment"], "pass")
+
+    def test_cross_model_request_changes(self):
+        r = c.review_from_cross_model("issue\nVerdict: REQUEST_CHANGES", "codex", "low")
+        self.assertEqual(r["correctness_score"], c.SCORE_XMODEL_REQUEST_CHANGES)
+        self.assertEqual(r["constitutional_alignment"], "fail")
+
+    def test_cross_model_none(self):
+        self.assertIsNone(c.review_from_cross_model(None, None, "low"))
+
+
+class TestSynthesize(unittest.TestCase):
+    def test_two_approvals_approve_strictest_wins(self):
+        verdict, conf, _ = c.synthesize([_green_a(), _approve_b()])
+        self.assertEqual(verdict, "APPROVE")
+        # min(0.75, 0.85) = 0.75
+        self.assertAlmostEqual(conf, 0.75)
+
+    def test_red_a_rejects(self):
+        verdict, conf, _ = c.synthesize([c.review_from_blackbox("fail"), _approve_b()])
+        self.assertEqual(verdict, "REJECT")  # a constitutional fail present
+        self.assertAlmostEqual(conf, c.SCORE_BLACKBOX_RED)
+
+    def test_request_changes_b_below_threshold(self):
+        rb = c.review_from_cross_model("Verdict: REQUEST_CHANGES", "claude", "low")
+        verdict, conf, _ = c.synthesize([_green_a(), rb])
+        self.assertEqual(verdict, "REJECT")  # rb alignment fail -> reject
+        self.assertAlmostEqual(conf, c.SCORE_XMODEL_REQUEST_CHANGES)
+
+    def test_empty_is_reject(self):
+        verdict, conf, _ = c.synthesize([])
+        self.assertEqual(verdict, "REJECT")
+        self.assertEqual(conf, 0.0)
+
+
+class TestBuildVerdictSchema(unittest.TestCase):
+    def _schema(self):
+        return json.loads((ROOT / "schemas" / "council-verdict.schema.json").read_text(encoding="utf-8"))
+
+    def test_verdict_id_pattern_and_required_fields(self):
+        v = c.build_verdict(365, "Some change", [_green_a(), _approve_b()], "2026-06-23", 1)
+        self.assertRegex(v["verdict_id"], r"^council-\d{4}-\d{2}-\d{2}-\d{3}$")
+        schema = self._schema()
+        for key in schema["required"]:
+            self.assertIn(key, v, f"missing required field {key}")
+        self.assertIn(v["trigger_condition"], ["high_risk_self_merge", "borderline_confidence"])
+        self.assertIn(v["verdict"], ["APPROVE", "REQUEST_CHANGES", "REJECT"])
+        for rev in v["reviews"]:
+            self.assertIn(rev["reviewer"], ["reviewer_a", "reviewer_b"])
+            self.assertGreaterEqual(rev["correctness_score"], 0.0)
+            self.assertLessEqual(rev["correctness_score"], 1.0)
+
+    def test_jsonschema_validates_when_available(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        v = c.build_verdict(365, "Some change", [_green_a(), _approve_b()], "2026-06-23", 2)
+        jsonschema.validate(v, self._schema())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -103,5 +103,98 @@ class TestArgValidation(unittest.TestCase):
         self.assertEqual(rc, 1)
 
 
+def _council(verdict="APPROVE", conf=0.75, n_reviews=2, aligned=True):
+    reviews = []
+    align = "pass" if aligned else "fail"
+    for i in range(n_reviews):
+        reviews.append({"reviewer": f"reviewer_{'ab'[i % 2]}", "correctness_score": conf,
+                        "risk_assessment": "low", "constitutional_alignment": align,
+                        "rationale": "x"})
+    return {"verdict": verdict, "post_council_confidence": conf, "reviews": reviews}
+
+
+class TestAuthorizationTrace(unittest.TestCase):
+    def test_closes(self):
+        self.assertEqual(g.parse_authorization_trace("Implements #381 via AFK.\nCloses #381"),
+                         "github_issue:#381")
+
+    def test_implements_lowercase(self):
+        self.assertEqual(g.parse_authorization_trace("implements #42"), "github_issue:#42")
+
+    def test_none_when_absent(self):
+        self.assertIsNone(g.parse_authorization_trace("no linkage here"))
+        self.assertIsNone(g.parse_authorization_trace(""))
+
+
+class TestSelfMergeDecision(unittest.TestCase):
+    OK = dict(risk="low", checks_green=True, authz_trace="github_issue:#1",
+              conscience_max_weight=0.0)
+
+    def _decide(self, **over):
+        kw = dict(self.OK); kw.update(over)
+        cv = kw.pop("council_verdict", _council())
+        return g.self_merge_decision(kw["risk"], kw["checks_green"], kw["authz_trace"],
+                                     kw["conscience_max_weight"], cv)
+
+    def test_happy_path_merges(self):
+        merge, reason = self._decide()
+        self.assertTrue(merge, reason)
+
+    def test_medium_also_ok(self):
+        self.assertTrue(self._decide(risk="medium")[0])
+
+    def test_high_never(self):
+        merge, reason = self._decide(risk="high")
+        self.assertFalse(merge)
+        self.assertIn("only low/medium", reason)
+
+    def test_critical_never(self):
+        self.assertFalse(self._decide(risk="critical")[0])
+
+    def test_ci_red_blocks(self):
+        self.assertFalse(self._decide(checks_green=False)[0])
+
+    def test_missing_authz_blocks(self):
+        self.assertFalse(self._decide(authz_trace=None)[0])
+
+    def test_conscience_block(self):
+        merge, reason = self._decide(conscience_max_weight=0.85)
+        self.assertFalse(merge)
+        self.assertIn("conscience", reason)
+
+    def test_conscience_below_threshold_ok(self):
+        self.assertTrue(self._decide(conscience_max_weight=0.79)[0])
+
+    def test_single_reviewer_blocks(self):
+        merge, reason = self._decide(council_verdict=_council(n_reviews=1))
+        self.assertFalse(merge)
+        self.assertIn("need 2", reason)
+
+    def test_request_changes_verdict_blocks(self):
+        self.assertFalse(self._decide(council_verdict=_council(verdict="REQUEST_CHANGES"))[0])
+
+    def test_low_confidence_blocks(self):
+        self.assertFalse(self._decide(council_verdict=_council(conf=0.65))[0])
+
+    def test_constitutional_fail_blocks(self):
+        self.assertFalse(self._decide(council_verdict=_council(aligned=False))[0])
+
+    def test_no_council_blocks(self):
+        self.assertFalse(self._decide(council_verdict=None)[0])
+
+
+class TestHarvestDryRun(unittest.TestCase):
+    def test_dry_run_no_council_no_merge(self):
+        prs = [{"number": 9, "title": "fix docs typo", "body": "Closes #9", "labels": []}]
+        with mock.patch.object(g, "_gh_open_afk_prs", return_value=prs), \
+             mock.patch.object(g, "active_conscience_max_weight", return_value=0.0), \
+             mock.patch.object(g.council_emit, "convene") as convene, \
+             mock.patch.object(g, "_merge_pr") as merge:
+            rc = g.main(["--harvest", "--dry-run"])
+        self.assertEqual(rc, 0)
+        convene.assert_not_called()   # dry-run convenes no council
+        merge.assert_not_called()     # and merges nothing
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Adds the deferred **graduated self-merge** automation to the AFK governor. A new `--harvest` pass re-examines already-open `agent-implement` PRs (CI gates settle asynchronously *after* the implement pass opens a PR) and self-merges only those that clear **`policies/autonomous-loop-policy.yaml` §Self-Merge Authority**:

- risk ∈ {low, medium} (critical/high **never** self-merge)
- all CI green
- authorization trace present (`Closes #N` / `Implements #N`)
- no active conscience signal with `weight >= 0.8`
- council **APPROVE** with `post_council_confidence >= 0.7`
- **≥ 2 reviewers** — a degraded 1-reviewer council never self-merges

The agent-blackbox `risk-report` gate is **never overridden** — only PRs that already pass it qualify. This is the principled fill for the gap the digest flagged: gate-passing AFK PRs previously waited for a human click because self-merge automation was deferred.

## Confidence source — the LLM council

New `scripts/council_emit.py` aggregates two **heterogeneous** reviewers into a schema-valid `council-verdict.json`:

| Reviewer | Source | Mapping |
|---|---|---|
| reviewer_a | agent-blackbox `risk-report` **check conclusion** (not the un-vendored `risk-report.json`) | green → 0.75 (pass band, risk ≤ 0.25), red → 0.2 |
| reviewer_b | real cross-model call (Claude/Gemini/Codex by available key), same prompt as `cross-model-review.yml` | APPROVE → 0.85, REQUEST_CHANGES → 0.30 |

Chairman synthesis = **strictest-wins**: `post_council_confidence = min(scores)`. Two genuinely different models lift the policy's single-model 0.8 cap honestly.

## Schema fix (pre-existing bug)

`schemas/council-verdict.schema.json` listed `timestamp` in `required` but never defined it under `properties`, and `additionalProperties: false` then forbade it — **no verdict could ever validate**. Surfaced by a new schema test; added the missing `timestamp` property (date-time).

## Tests

- `scripts/test_council_emit.py` — synthesis, reviewer mapping, verdict schema validity
- `scripts/test_run_afk_cycle.py` — new `self_merge_decision` gate cases (risk gating, CI-red, missing authz, conscience block, single-reviewer block, REQUEST_CHANGES, low-confidence, constitutional fail), authz parsing, harvest dry-run
- **41 tests green**; `python scripts/validate_governance.py` green

## Not yet proven (follow-up)

The **live** path (real council convene + `gh pr merge`) needs an open low-risk AFK PR *and* a model API key in the environment. Gate/synthesis logic is fully unit-tested; the first real self-merge is the tracer-bullet finish.

## Note for reviewer

Touches `schemas/**` (a blocked path), so `risk-report` will hold this PR by design — it needs the human `agent-blackbox-reviewed` override to merge, same checkpoint as the governance PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)