### PR TITLE
chore(afk): track the self-merge provenance trail (council verdicts + audits)

### DIFF
--- a/state/council/council-2026-06-24-001.json
+++ b/state/council/council-2026-06-24-001.json
@@ -1,0 +1,19 @@
+{
+  "verdict_id": "council-2026-06-24-001",
+  "task_id": "github_pr:#391",
+  "timestamp": "2026-06-24T00:31:54Z",
+  "trigger_condition": "borderline_confidence",
+  "change_summary": "AFK: AFK smoke #2: add a dated 'self-merge proven' line to docs/agents/afk-agent.md (#389)",
+  "reviews": [
+    {
+      "reviewer": "reviewer_a",
+      "correctness_score": 0.75,
+      "risk_assessment": "low",
+      "constitutional_alignment": "pass",
+      "rationale": "Agent Blackbox risk-report check is green: change sits in the policy pass band (risk <= 0.25) and violates no blocked-path constraint."
+    }
+  ],
+  "chairman_synthesis": "1 reviewer(s); strictest-wins confidence 0.75 (min of 0.75). Constitutional alignment: all pass. Verdict: APPROVE.",
+  "verdict": "APPROVE",
+  "post_council_confidence": 0.75
+}

--- a/state/council/council-2026-06-24-002.json
+++ b/state/council/council-2026-06-24-002.json
@@ -1,0 +1,26 @@
+{
+  "verdict_id": "council-2026-06-24-002",
+  "task_id": "github_pr:#391",
+  "timestamp": "2026-06-24T00:33:09Z",
+  "trigger_condition": "borderline_confidence",
+  "change_summary": "AFK: AFK smoke #2: add a dated 'self-merge proven' line to docs/agents/afk-agent.md (#389)",
+  "reviews": [
+    {
+      "reviewer": "reviewer_a",
+      "correctness_score": 0.75,
+      "risk_assessment": "low",
+      "constitutional_alignment": "pass",
+      "rationale": "Agent Blackbox risk-report check is green: change sits in the policy pass band (risk <= 0.25) and violates no blocked-path constraint."
+    },
+    {
+      "reviewer": "reviewer_b",
+      "correctness_score": 0.3,
+      "risk_assessment": "low",
+      "constitutional_alignment": "fail",
+      "rationale": "Cross-model reviewer (claude) verdict: REQUEST_CHANGES."
+    }
+  ],
+  "chairman_synthesis": "2 reviewer(s); strictest-wins confidence 0.30 (min of 0.75, 0.30). Constitutional alignment: at least one fail. Verdict: REJECT.",
+  "verdict": "REJECT",
+  "post_council_confidence": 0.3
+}

--- a/state/council/council-2026-06-24-003.json
+++ b/state/council/council-2026-06-24-003.json
@@ -1,0 +1,26 @@
+{
+  "verdict_id": "council-2026-06-24-003",
+  "task_id": "github_pr:#391",
+  "timestamp": "2026-06-24T00:35:28Z",
+  "trigger_condition": "borderline_confidence",
+  "change_summary": "AFK: AFK smoke #2: add a dated 'self-merge proven' line to docs/agents/afk-agent.md (#389)",
+  "reviews": [
+    {
+      "reviewer": "reviewer_a",
+      "correctness_score": 0.75,
+      "risk_assessment": "low",
+      "constitutional_alignment": "pass",
+      "rationale": "Agent Blackbox risk-report check is green: change sits in the policy pass band (risk <= 0.25) and violates no blocked-path constraint."
+    },
+    {
+      "reviewer": "reviewer_b",
+      "correctness_score": 0.3,
+      "risk_assessment": "low",
+      "constitutional_alignment": "fail",
+      "rationale": "Cross-model reviewer (claude) verdict: REQUEST_CHANGES."
+    }
+  ],
+  "chairman_synthesis": "2 reviewer(s); strictest-wins confidence 0.30 (min of 0.75, 0.30). Constitutional alignment: at least one fail. Verdict: REJECT.",
+  "verdict": "REJECT",
+  "post_council_confidence": 0.3
+}

--- a/state/council/council-2026-06-24-004.json
+++ b/state/council/council-2026-06-24-004.json
@@ -1,0 +1,26 @@
+{
+  "verdict_id": "council-2026-06-24-004",
+  "task_id": "github_pr:#391",
+  "timestamp": "2026-06-24T01:15:04Z",
+  "trigger_condition": "borderline_confidence",
+  "change_summary": "AFK: AFK smoke #2: add a dated 'self-merge proven' line to docs/agents/afk-agent.md (#389)",
+  "reviews": [
+    {
+      "reviewer": "reviewer_a",
+      "correctness_score": 0.75,
+      "risk_assessment": "low",
+      "constitutional_alignment": "pass",
+      "rationale": "Agent Blackbox risk-report check is green: change sits in the policy pass band (risk <= 0.25) and violates no blocked-path constraint."
+    },
+    {
+      "reviewer": "reviewer_b",
+      "correctness_score": 0.3,
+      "risk_assessment": "low",
+      "constitutional_alignment": "fail",
+      "rationale": "Cross-model reviewer (claude) verdict: REQUEST_CHANGES."
+    }
+  ],
+  "chairman_synthesis": "2 reviewer(s); strictest-wins confidence 0.30 (min of 0.75, 0.30). Constitutional alignment: at least one fail. Verdict: REJECT.",
+  "verdict": "REJECT",
+  "post_council_confidence": 0.3
+}

--- a/state/council/council-2026-06-24-005.json
+++ b/state/council/council-2026-06-24-005.json
@@ -1,0 +1,26 @@
+{
+  "verdict_id": "council-2026-06-24-005",
+  "task_id": "github_pr:#391",
+  "timestamp": "2026-06-24T01:19:53Z",
+  "trigger_condition": "borderline_confidence",
+  "change_summary": "AFK: AFK smoke #2: add a dated 'self-merge proven' line to docs/agents/afk-agent.md (#389)",
+  "reviews": [
+    {
+      "reviewer": "reviewer_a",
+      "correctness_score": 0.75,
+      "risk_assessment": "low",
+      "constitutional_alignment": "pass",
+      "rationale": "Agent Blackbox risk-report check is green: change sits in the policy pass band (risk <= 0.25) and violates no blocked-path constraint."
+    },
+    {
+      "reviewer": "reviewer_b",
+      "correctness_score": 0.85,
+      "risk_assessment": "low",
+      "constitutional_alignment": "pass",
+      "rationale": "Cross-model reviewer (claude) verdict: APPROVE."
+    }
+  ],
+  "chairman_synthesis": "2 reviewer(s); strictest-wins confidence 0.75 (min of 0.75, 0.85). Constitutional alignment: all pass. Verdict: APPROVE.",
+  "verdict": "APPROVE",
+  "post_council_confidence": 0.75
+}

--- a/state/loops/loop-2026-06-23-001.loop.json
+++ b/state/loops/loop-2026-06-23-001.loop.json
@@ -1,0 +1,21 @@
+{
+  "loop_id": "loop-2026-06-23-001",
+  "goal": "AFK-implement issue #381: AFK smoke: add a one-line 'first proven' note to docs/agents/afk-agent.md",
+  "repo": "demerzel",
+  "risk": "low",
+  "governance_mode": "boundary-only",
+  "status": "completed",
+  "iterations": [
+    {
+      "iteration": 1,
+      "timestamp": "2026-06-23T01:58:53Z",
+      "action": "opened PR for #381",
+      "outcome": "progress",
+      "governance_decision": null
+    }
+  ],
+  "stall_count": 0,
+  "authorization_artifact": "github_issue:#381",
+  "started_at": "2026-06-23T01:57:24Z",
+  "max_iterations": 10
+}

--- a/state/loops/loop-2026-06-24-001.loop.json
+++ b/state/loops/loop-2026-06-24-001.loop.json
@@ -1,0 +1,21 @@
+{
+  "loop_id": "loop-2026-06-24-001",
+  "goal": "AFK-implement issue #389: AFK smoke #2: add a dated 'self-merge proven' line to docs/agents/afk-agent.md",
+  "repo": "demerzel",
+  "risk": "low",
+  "governance_mode": "boundary-only",
+  "status": "completed",
+  "iterations": [
+    {
+      "iteration": 1,
+      "timestamp": "2026-06-24T00:30:20Z",
+      "action": "opened PR for #389",
+      "outcome": "progress",
+      "governance_decision": null
+    }
+  ],
+  "stall_count": 0,
+  "authorization_artifact": "github_issue:#389",
+  "started_at": "2026-06-24T00:28:21Z",
+  "max_iterations": 10
+}

--- a/state/oversight/afk-cycle-2026-06-23.json
+++ b/state/oversight/afk-cycle-2026-06-23.json
@@ -1,0 +1,22 @@
+{
+  "cycle_at": "2026-06-23T01:58:53Z",
+  "dry_run": false,
+  "halted": false,
+  "queue_size": 1,
+  "decisions": [
+    {
+      "issue": 381,
+      "title": "AFK smoke: add a one-line 'first proven' note to docs/agents/afk-agent.md",
+      "risk": "low",
+      "mode": "boundary-only",
+      "eligible": true,
+      "action": "implement",
+      "pr": "https://github.com/GuitarAlchemist/Demerzel/pull/383",
+      "branch": "agent/issue-381"
+    }
+  ],
+  "tally": {
+    "implement": 1,
+    "skipped": 0
+  }
+}

--- a/state/oversight/afk-cycle-2026-06-24.json
+++ b/state/oversight/afk-cycle-2026-06-24.json
@@ -1,0 +1,27 @@
+{
+  "cycle_at": "2026-06-24T00:30:22Z",
+  "dry_run": false,
+  "halted": false,
+  "backend": "local",
+  "max_parallel": 1,
+  "queue_size": 1,
+  "decisions": [
+    {
+      "issue": 389,
+      "title": "AFK smoke #2: add a dated 'self-merge proven' line to docs/agents/afk-agent.md",
+      "risk": "low",
+      "mode": "boundary-only",
+      "eligible": true,
+      "action": "implement",
+      "pr": "https://github.com/GuitarAlchemist/Demerzel/pull/391",
+      "branch": "agent/issue-389"
+    }
+  ],
+  "tally": {
+    "implement": 1,
+    "skipped": 0,
+    "stalled": 0,
+    "blocked": 0,
+    "error": 0
+  }
+}

--- a/state/oversight/afk-harvest-2026-06-24.json
+++ b/state/oversight/afk-harvest-2026-06-24.json
@@ -1,0 +1,26 @@
+{
+  "harvest_at": "2026-06-24T01:19:56Z",
+  "dry_run": false,
+  "halted": false,
+  "conscience_max_weight": 0.0,
+  "queue_size": 1,
+  "decisions": [
+    {
+      "pr": 391,
+      "title": "AFK: AFK smoke #2: add a dated 'self-merge proven' line to docs/agents/afk-agent.md (#389)",
+      "risk": "low",
+      "authorization_trace": "github_issue:#389",
+      "council_verdict": "APPROVE",
+      "post_council_confidence": 0.75,
+      "reviewers": 2,
+      "gate": "self-merge OK (post_council_confidence=0.75, 2 reviewers)",
+      "action": "self-merge",
+      "merge_result": "merged"
+    }
+  ],
+  "tally": {
+    "self_merge": 1,
+    "held": 0,
+    "skipped": 0
+  }
+}


### PR DESCRIPTION
Tracks the evidence artifacts from the **first live council-gated self-merge** (issue #389 → PR #391, merged 2026-06-24 via `9c04482`) so the autonomy-boundary audit trail is in version control.

### The council decision trail (`state/council/`)
| Verdict | Outcome | Why |
|---|---|---|
| `001` | incomplete (1 reviewer) | stale model id → reviewer_b 404'd |
| `002`–`004` | **REJECT** | three *real* internal contradictions the council caught (new "self-merge live" line vs stale "deferred" lines) |
| `005` | **APPROVE** (conf 0.75, 2 reviewers) | doc made consistent → self-merge fired |

### Cycle + harvest audits (`state/oversight/`, `state/loops/`)
- `afk-harvest-2026-06-24.json` — the harvest pass that fired the merge (`"action": "self-merge"`, `"merge_result": "merged"`)
- `afk-cycle-2026-06-2{3,4}.json` + `loop-*.loop.json` — the implement-cycle/loop-state records that opened the PR

State artifacts only (not a blocked path); all 10 are valid JSON, council verdicts schema-conform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)