### PR TITLE
AFK: Migrate run_afk_cycle onto demerzel_kit (#407)

### DIFF
--- a/.github/workflows/governance-validate.yml
+++ b/.github/workflows/governance-validate.yml
@@ -12,8 +12,7 @@ on:
       - 'tests/behavioral/**'
       - 'README.md'
       - 'governance-manifest.json'
-      - 'scripts/validate_governance.py'
-      - 'scripts/build_manifest.py'
+      - 'scripts/**'
       - '.github/workflows/governance-validate.yml'
   pull_request:
     paths:
@@ -26,8 +25,7 @@ on:
       - 'tests/behavioral/**'
       - 'README.md'
       - 'governance-manifest.json'
-      - 'scripts/validate_governance.py'
-      - 'scripts/build_manifest.py'
+      - 'scripts/**'
   workflow_dispatch:
 
 permissions:
@@ -73,3 +71,24 @@ jobs:
             echo "::error::governance-manifest.json is stale. Run: python scripts/build_manifest.py"
             exit 1
           fi
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # jsonschema enables the validate()/write_artifact() seam in demerzel_kit;
+      # without it those tests skip rather than fail (graceful degradation).
+      - name: Install deps
+        run: pip install jsonschema
+
+      # The scripts/ emitters are the operational code; demerzel_kit makes their
+      # gh/filesystem calls an injectable seam so convene() et al. are testable
+      # without the network. Run the whole unittest suite.
+      - name: Run scripts/ unit tests
+        run: python -m unittest discover -s scripts -p 'test_*.py'

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -128,6 +128,28 @@ fact lives in one place and is read out, never restated.
   bats + shellcheck). `post_discussion.sh` takes the category id as an arg, composing
   with the ecosystem action's `cat_*` outputs.
 
+## Architecture seams (designed + built 2026-06-25 via `/improve-codebase-architecture`, Python emitter kit)
+
+- **`demerzel_kit`** — `scripts/demerzel_kit.py`, the Python sibling of
+  `DigestState.psm1` and the `llm_call.sh` shell seams: one small interface the
+  `scripts/` **emitters** share, owning the four primitives each was re-deriving
+  (`now_iso` — copy-pasted ×7; `atomic_write` — ×6; schema `validate`; and the `gh`
+  subprocess wrapper — ×3, with three different error contracts). `write_artifact(
+  path, data, schema=…)` validates **then** atomic-writes, so an invalid governance
+  artifact never reaches disk for a read-time consumer to choke on — the gap that
+  let `council_emit._write_verdict` write unvalidated verdicts despite its docstring.
+  `gh_json` / `gh_text` take an injectable `run=` seam, which is what finally makes
+  the emitters testable through their interface: `council_emit.convene()` now runs
+  end-to-end offline in `scripts/test_council_emit.py`, the test the un-seamed `gh`
+  calls used to make impossible. `validate` lazily imports `jsonschema` and degrades
+  when absent (matching `demerzel_halt`), so an emitter still runs stdlib-only. Wired
+  into CI via `governance-validate.yml` (`python -m unittest discover -s scripts`).
+  `council_emit` is the first migrated emitter (tracer bullet); the other six
+  (`qa_tribunal_emit`, `run_afk_cycle`, `apply_ml_feedback`, `compliance_report`,
+  `run_ml_feedback_cycle`, `demerzel_halt`) follow. Does **not** auto-stamp a
+  timestamp — domain artifacts carry their own (`timestamp`, `halted_at`) and several
+  schemas set `additionalProperties: false`, so callers stamp with `now_iso()`.
+
 ## Conventions
 
 See `CLAUDE.md` / `AGENTS.md` for authoritative validation rules, the constitutional

--- a/scripts/council_emit.py
+++ b/scripts/council_emit.py
@@ -44,20 +44,22 @@ Exit codes:
   0  verdict emitted (any verdict value — APPROVE/REQUEST_CHANGES/REJECT)
   1  usage / environment error (e.g. PR not found)
 
-Stdlib only (urllib for the model call) — no third-party deps, mirroring
-run_afk_cycle.py so the governor can call this in the same environment.
+Stdlib only at import (urllib for the model call); GitHub reads and the
+schema-validated write go through demerzel_kit, which uses jsonschema when
+present and degrades otherwise, so the governor can still call this in a
+minimal environment.
 """
 from __future__ import annotations
 
 import argparse
 import json
 import os
-import subprocess
 import sys
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
 from pathlib import Path
+
+import demerzel_kit as kit
 
 ROOT = Path(__file__).resolve().parents[1]
 REPO_SLUG = "GuitarAlchemist/Demerzel"
@@ -72,10 +74,6 @@ SCORE_XMODEL_APPROVE = 0.85
 SCORE_XMODEL_REQUEST_CHANGES = 0.3
 
 SELF_MERGE_MIN_CONFIDENCE = 0.7   # policies/autonomous-loop-policy.yaml
-
-
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 # --------------------------------------------------------------------------- #
@@ -183,7 +181,7 @@ def build_verdict(pr: int, change_summary: str, reviews: list[dict],
     return {
         "verdict_id": f"council-{today}-{seq:03d}",
         "task_id": f"github_pr:#{pr}",
-        "timestamp": _now_iso(),
+        "timestamp": kit.now_iso(),
         "trigger_condition": "borderline_confidence",
         "change_summary": change_summary[:500] if change_summary else f"PR #{pr}",
         "reviews": reviews,
@@ -194,36 +192,22 @@ def build_verdict(pr: int, change_summary: str, reviews: list[dict],
 
 
 # --------------------------------------------------------------------------- #
-# IO (thin wrappers around gh + model APIs)
+# IO — GitHub reads via the demerzel_kit gh seam; model APIs via urllib below.
 # --------------------------------------------------------------------------- #
-def _gh_json(args: list[str]) -> dict | list | None:
-    try:
-        p = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=60)
-        if p.returncode != 0:
-            print(f"warn: gh {' '.join(args)} failed: {p.stderr.strip()[:160]}", file=sys.stderr)
-            return None
-        return json.loads(p.stdout or "null")
-    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
-        print(f"warn: gh {' '.join(args)} unavailable: {exc}", file=sys.stderr)
-        return None
-
-
 def fetch_pr_meta(pr: int) -> dict | None:
-    return _gh_json(["pr", "view", str(pr), "--repo", REPO_SLUG,
-                     "--json", "number,title,body,headRefOid,labels"])  # type: ignore[return-value]
+    return kit.gh_json(["pr", "view", str(pr), "--repo", REPO_SLUG,
+                        "--json", "number,title,body,headRefOid,labels"])  # type: ignore[return-value]
 
 
 def fetch_blackbox_check_state(pr: int) -> str | None:
     """Return the `risk-report` check state ('pass'/'fail'/...) or None if absent.
-    Parses `gh pr checks` tab-separated output (name<TAB>state<TAB>...)."""
-    try:
-        p = subprocess.run(["gh", "pr", "checks", str(pr), "--repo", REPO_SLUG],
-                           capture_output=True, text=True, timeout=60)
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        print(f"warn: gh pr checks failed: {exc}", file=sys.stderr)
+    Parses `gh pr checks` tab-separated output (name<TAB>state<TAB>...). `gh pr
+    checks` exits non-zero when any check failed but the table is still valid, so
+    the read uses ok_nonzero=True."""
+    out = kit.gh_text(["pr", "checks", str(pr), "--repo", REPO_SLUG], ok_nonzero=True)
+    if out is None:
         return None
-    # gh pr checks exits non-zero when any check failed; output is still on stdout.
-    for line in p.stdout.splitlines():
+    for line in out.splitlines():
         parts = line.split("\t")
         if parts and parts[0].strip() == BLACKBOX_CHECK and len(parts) > 1:
             return parts[1].strip()
@@ -231,45 +215,35 @@ def fetch_blackbox_check_state(pr: int) -> str | None:
 
 
 def fetch_diff(pr: int, limit: int = 30000) -> str:
-    try:
-        p = subprocess.run(["gh", "pr", "diff", str(pr), "--repo", REPO_SLUG],
-                           capture_output=True, text=True, timeout=60)
-        return (p.stdout or "")[:limit] if p.returncode == 0 else ""
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
+    out = kit.gh_text(["pr", "diff", str(pr), "--repo", REPO_SLUG])
+    return (out or "")[:limit]
 
 
 def fetch_changed_files(pr: int) -> list[str]:
     """Changed file paths for the PR (via `gh pr diff --name-only`)."""
-    try:
-        p = subprocess.run(["gh", "pr", "diff", str(pr), "--repo", REPO_SLUG, "--name-only"],
-                           capture_output=True, text=True, timeout=60)
-        return [ln.strip() for ln in p.stdout.splitlines() if ln.strip()] if p.returncode == 0 else []
-    except (OSError, subprocess.TimeoutExpired):
-        return []
+    out = kit.gh_text(["pr", "diff", str(pr), "--repo", REPO_SLUG, "--name-only"])
+    return [ln.strip() for ln in out.splitlines() if ln.strip()] if out else []
 
 
 def fetch_file_at_ref(path: str, ref: str) -> str | None:
     """Full content of `path` at commit `ref` (the PR head), via the contents API.
     Lets reviewer_b verify the WHOLE changed file for internal consistency, not
     just the diff hunk (which can't reveal a contradicting line elsewhere).
-    `gh api --jq .content` returns raw (multi-line) base64, NOT JSON — capture it
-    directly and decode rather than routing through the json-parsing helper."""
+    `gh api --jq .content` returns raw (multi-line) base64, NOT JSON — fetch it as
+    text and decode rather than routing through gh_json."""
     import base64
+    out = kit.gh_text(["api", f"repos/{REPO_SLUG}/contents/{path}?ref={ref}", "--jq", ".content"])
+    if not out or not out.strip():
+        return None
     try:
-        p = subprocess.run(
-            ["gh", "api", f"repos/{REPO_SLUG}/contents/{path}?ref={ref}", "--jq", ".content"],
-            capture_output=True, text=True, timeout=60)
-        if p.returncode != 0 or not p.stdout.strip():
-            return None
-        return base64.b64decode(p.stdout.replace("\n", "")).decode("utf-8", errors="replace")
-    except (OSError, subprocess.TimeoutExpired, ValueError, UnicodeDecodeError):
+        return base64.b64decode(out.replace("\n", "")).decode("utf-8", errors="replace")
+    except (ValueError, UnicodeDecodeError):
         return None
 
 
 def fetch_issue_body(issue_num: str) -> str:
     """The linked issue's title+body, so reviewer_b knows the authorized intent."""
-    obj = _gh_json(["issue", "view", issue_num, "--repo", REPO_SLUG, "--json", "title,body"])
+    obj = kit.gh_json(["issue", "view", issue_num, "--repo", REPO_SLUG, "--json", "title,body"])
     if isinstance(obj, dict):
         return f"#{issue_num}: {obj.get('title', '')}\n\n{obj.get('body', '')}"
     return ""
@@ -423,10 +397,11 @@ def _next_seq(today: str) -> int:
 
 
 def _write_verdict(verdict: dict) -> Path:
-    COUNCIL_DIR.mkdir(parents=True, exist_ok=True)
+    """Validate against schemas/council-verdict.schema.json, then atomic-write —
+    both via demerzel_kit.write_artifact, so an invalid verdict never reaches
+    state/council/ for a downstream reader to choke on."""
     out = COUNCIL_DIR / f"{verdict['verdict_id']}.json"
-    out.write_text(json.dumps(verdict, indent=2) + "\n", encoding="utf-8")
-    return out
+    return kit.write_artifact(out, verdict, schema="council-verdict")
 
 
 def convene(pr: int, classified_risk: str = "medium",
@@ -449,7 +424,7 @@ def convene(pr: int, classified_risk: str = "medium",
     if rb:
         reviews.append(rb)
 
-    today = _now_iso()[:10]
+    today = kit.now_iso()[:10]
     seq = _next_seq(today)
     verdict = build_verdict(pr, change_summary, reviews, today, seq)
     if write:

--- a/scripts/demerzel_kit.py
+++ b/scripts/demerzel_kit.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Demerzel emitter kit — the shared substrate for the scripts/ layer.
+
+Demerzel has no runtime app; the scripts/ emitters (council_emit, qa_tribunal_emit,
+run_afk_cycle, apply_ml_feedback, compliance_report, run_ml_feedback_cycle) ARE the
+operational code. Each was re-deriving the same four primitives: a UTC provenance
+stamp (`_now_iso`, ×7), a crash-safe write (`atomic_write`, ×6), ad-hoc schema
+validation (or none), and a `gh` subprocess wrapper (×3, with three different error
+contracts). None of the gh/filesystem calls were an overridable seam, which is why
+only 2 of 12 scripts had tests.
+
+This module is the Python sibling of the PowerShell `DigestState.psm1` deep module
+and the `llm_call.sh` / `post_discussion.sh` shell seams: one small interface that
+owns those primitives once, with the `gh` runner as an injectable seam so the
+emitters become testable through their interface.
+
+Interface:
+  now_iso()                         -> str          # the one true UTC stamp
+  atomic_write(path, content)       -> None         # temp-file + os.replace
+  validate(data, schema)            -> None         # raises on invalid; degrades if jsonschema absent
+  write_artifact(path, data, schema=...) -> Path    # validate (optional) then atomic-write JSON
+  gh_json(args, *, run=...)         -> dict|list|None
+  gh_text(args, *, ok_nonzero=..., run=...) -> str|None
+
+Design notes:
+  * write_artifact does NOT inject timestamps. Domain artifacts carry their own
+    semantically-named ones (`timestamp`, `halted_at`, `decided_at`) and several
+    schemas set `additionalProperties: false`, so a generic envelope stamp would
+    fail validation. Stamp with now_iso() in the caller.
+  * validate() lazily imports jsonschema (optional dependency, matching
+    demerzel_halt.py) and degrades to a stderr warning when it is absent, so an
+    emitter still runs in a stdlib-only environment.
+  * The `run` parameter on gh_json/gh_text is the test seam: pass a fake callable
+    that returns a CompletedProcess-shaped object. Callers may also patch
+    `demerzel_kit.gh_json` / `gh_text` directly.
+
+Stdlib only at import time (jsonschema is imported lazily inside validate()).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas"
+
+
+def now_iso() -> str:
+    """UTC RFC3339 stamp, 'YYYY-MM-DDTHH:MM:SSZ'. The single timestamp helper the
+    scripts/ emitters share (was copy-pasted as `_now_iso` / `now_rfc3339` ×7)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Write `content` atomically: temp file + os.replace, so a crash mid-write
+    never leaves a torn artifact on disk. Promoted from demerzel_halt.py, which
+    held the canonical copy."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def validate(data: object, schema: str) -> None:
+    """Validate `data` against `schemas/<schema>.schema.json`. Raises
+    jsonschema.ValidationError on invalid data.
+
+    `schema` is a path under schemas/ without the `.schema.json` suffix, e.g.
+    "council-verdict" or "contracts/qa-verdict".
+
+    jsonschema is imported lazily (optional dependency, matching demerzel_halt.py).
+    When it is absent the check degrades to a stderr warning and returns, so an
+    emitter still runs in a stdlib-only environment — validation is enforced
+    wherever jsonschema is installed (CI, the governor env)."""
+    try:
+        import jsonschema  # noqa: PLC0415 — optional dependency, imported lazily by design
+    except ImportError:
+        print(f"warn: jsonschema absent; skipped validation against {schema}",
+              file=sys.stderr)
+        return
+    spec = json.loads((SCHEMA_DIR / f"{schema}.schema.json").read_text(encoding="utf-8"))
+    jsonschema.validate(data, spec)
+
+
+def write_artifact(path: Path, data: object, *, schema: str | None = None) -> Path:
+    """Emit a governance artifact: validate against `schema` (if given), then
+    atomic-write as pretty JSON with a trailing newline. The single seam through
+    which the scripts/ emitters reach disk.
+
+    Raises before writing if validation fails — invalid JSON never lands on disk
+    (the gap that previously let a read-time consumer choke on it). Does not stamp
+    timestamps; see the module docstring."""
+    if schema is not None:
+        validate(data, schema)
+    atomic_write(path, json.dumps(data, indent=2) + "\n")
+    return path
+
+
+def gh_json(args: list[str], *, run=subprocess.run) -> dict | list | None:
+    """Run `gh <args>` and parse stdout as JSON. Returns None on any failure
+    (non-zero exit, unavailable gh, non-JSON output) after a stderr warning — the
+    non-raising contract the emitters expect.
+
+    `run` is the injectable test seam."""
+    try:
+        p = run(["gh", *args], capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(f"warn: gh {' '.join(args)} unavailable: {exc}", file=sys.stderr)
+        return None
+    if p.returncode != 0:
+        print(f"warn: gh {' '.join(args)} failed: {p.stderr.strip()[:160]}", file=sys.stderr)
+        return None
+    try:
+        return json.loads(p.stdout or "null")
+    except json.JSONDecodeError as exc:
+        print(f"warn: gh {' '.join(args)} non-JSON: {exc}", file=sys.stderr)
+        return None
+
+
+def gh_text(args: list[str], *, ok_nonzero: bool = False, run=subprocess.run) -> str | None:
+    """Run `gh <args>` and return stdout as text. Returns None on failure.
+
+    ok_nonzero=True keeps stdout even when gh exits non-zero — e.g. `gh pr checks`
+    exits non-zero when a check has failed, but the check table is still valid
+    output that the caller needs to parse.
+
+    `run` is the injectable test seam."""
+    try:
+        p = run(["gh", *args], capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(f"warn: gh {' '.join(args)} unavailable: {exc}", file=sys.stderr)
+        return None
+    if p.returncode != 0 and not ok_nonzero:
+        print(f"warn: gh {' '.join(args)} failed: {p.stderr.strip()[:160]}", file=sys.stderr)
+        return None
+    return p.stdout or ""

--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -46,6 +45,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import council_emit  # noqa: E402  (sibling module in scripts/; self-merge gate)
+import demerzel_kit as kit  # noqa: E402  (shared gh / write-artifact seam)
 
 ROOT = Path(__file__).resolve().parents[1]            # repos/Demerzel
 HARNESS_DIR = ROOT.parent / "afk-harness"             # sibling, outside Demerzel
@@ -62,10 +62,6 @@ LOW_KEYWORDS = ("doc", "documentation", "typo", "comment", "test", "config")
 CONSCIENCE_SIGNALS_DIR = ROOT / "state" / "conscience" / "signals"
 CONSCIENCE_BLOCK_WEIGHT = 0.8         # an active signal at/above this blocks self-merge
 SELF_MERGE_MIN_CONFIDENCE = 0.7       # minimum post_council_confidence
-
-
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def halt_active() -> tuple[bool, str]:
@@ -125,7 +121,7 @@ def build_loop_state(issue: dict, seq: int, risk: str, mode: str, today: str) ->
         "iterations": [],
         "stall_count": 0,
         "authorization_artifact": f"github_issue:#{issue.get('number')}",
-        "started_at": _now_iso(),
+        "started_at": kit.now_iso(),
         "max_iterations": 10,
     }
 
@@ -227,35 +223,23 @@ def _comment_needs_preapproval(issue: dict) -> None:
 
 def _gh_queue(dry: bool) -> list[dict]:
     """Fetch open agent-implement issues via gh. Returns [] on any failure."""
-    try:
-        p = subprocess.run(
-            ["gh", "issue", "list", "--repo", REPO_SLUG, "--label", LABEL,
-             "--state", "open", "--json", "number,title,body,labels", "--limit", "20"],
-            capture_output=True, text=True, timeout=60)
-        if p.returncode != 0:
-            print(f"warn: gh issue list failed: {p.stderr.strip()[:160]}", file=sys.stderr)
-            return []
-        return json.loads(p.stdout or "[]")
-    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
-        print(f"warn: gh queue unavailable: {exc}", file=sys.stderr)
-        return []
+    out = kit.gh_json(
+        ["issue", "list", "--repo", REPO_SLUG, "--label", LABEL,
+         "--state", "open", "--json", "number,title,body,labels", "--limit", "20"])
+    return out if isinstance(out, list) else []
 
 
 def _write_loop_state(state: dict) -> None:
-    """Persist one loop-state file. Distinct filename per issue → thread-safe."""
-    loops_dir = ROOT / "state" / "loops"
-    loops_dir.mkdir(parents=True, exist_ok=True)
-    (loops_dir / f"{state['loop_id']}.loop.json").write_text(
-        json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    """Persist one loop-state file (schema-validated). Distinct filename per issue
+    → thread-safe."""
+    out = ROOT / "state" / "loops" / f"{state['loop_id']}.loop.json"
+    kit.write_artifact(out, state, schema="loop-state")
 
 
 def _write_audit(summary: dict, today: str) -> None:
     """Persist the combined cycle audit atomically to state/oversight/."""
     out = ROOT / "state" / "oversight" / f"afk-cycle-{today}.json"
-    out.parent.mkdir(parents=True, exist_ok=True)
-    tmp = out.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
-    os.replace(tmp, out)
+    kit.write_artifact(out, summary)
 
 
 # --------------------------------------------------------------------------- #
@@ -347,14 +331,14 @@ def self_merge_decision(risk: str, checks_green: bool, authz_trace: str | None,
 
 def _checks_all_green(pr: int) -> bool:
     """True iff `gh pr checks` shows at least one check and none are failing or
-    pending. pass/success/skipping/neutral count as OK; fail/pending block."""
-    try:
-        p = subprocess.run(["gh", "pr", "checks", str(pr), "--repo", REPO_SLUG],
-                           capture_output=True, text=True, timeout=60)
-    except (OSError, subprocess.TimeoutExpired):
+    pending. pass/success/skipping/neutral count as OK; fail/pending block.
+    `gh pr checks` exits non-zero when any check failed but the table is still
+    valid output, so the read uses ok_nonzero=True."""
+    out = kit.gh_text(["pr", "checks", str(pr), "--repo", REPO_SLUG], ok_nonzero=True)
+    if out is None:
         return False
     saw_any = False
-    for line in p.stdout.splitlines():
+    for line in out.splitlines():
         parts = line.split("\t")
         if len(parts) < 2:
             continue
@@ -367,18 +351,10 @@ def _checks_all_green(pr: int) -> bool:
 
 def _gh_open_afk_prs() -> list[dict]:
     """Open agent-implement PRs as dicts with number/title/body/labels."""
-    try:
-        p = subprocess.run(
-            ["gh", "pr", "list", "--repo", REPO_SLUG, "--label", LABEL,
-             "--state", "open", "--json", "number,title,body,labels", "--limit", "20"],
-            capture_output=True, text=True, timeout=60)
-        if p.returncode != 0:
-            print(f"warn: gh pr list failed: {p.stderr.strip()[:160]}", file=sys.stderr)
-            return []
-        return json.loads(p.stdout or "[]")
-    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
-        print(f"warn: gh pr list unavailable: {exc}", file=sys.stderr)
-        return []
+    out = kit.gh_json(
+        ["pr", "list", "--repo", REPO_SLUG, "--label", LABEL,
+         "--state", "open", "--json", "number,title,body,labels", "--limit", "20"])
+    return out if isinstance(out, list) else []
 
 
 def _merge_pr(pr: int) -> str:
@@ -446,7 +422,7 @@ def _run_harvest(dry: bool, today: str) -> int:
     def _tally(prefix: str) -> int:
         return sum(1 for d in decisions if str(d.get("action", "")).startswith(prefix))
     summary = {
-        "harvest_at": _now_iso(), "dry_run": dry, "halted": False,
+        "harvest_at": kit.now_iso(), "dry_run": dry, "halted": False,
         "conscience_max_weight": conscience_w, "queue_size": len(prs),
         "decisions": decisions,
         "tally": {"self_merge": _tally("self-merge"), "held": _tally("hold"),
@@ -454,10 +430,7 @@ def _run_harvest(dry: bool, today: str) -> int:
     }
     if not dry:
         out = ROOT / "state" / "oversight" / f"afk-harvest-{today}.json"
-        out.parent.mkdir(parents=True, exist_ok=True)
-        tmp = out.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
-        os.replace(tmp, out)
+        kit.write_artifact(out, summary)
     print(json.dumps(summary, indent=2))
     return 0
 
@@ -505,7 +478,7 @@ def _process_issue(issue: dict, seq: int, today: str, backend: str) -> tuple[dic
                 state["halt_reason"] = pr
             else:
                 state["iterations"].append({
-                    "iteration": 1, "timestamp": _now_iso(),
+                    "iteration": 1, "timestamp": kit.now_iso(),
                     "action": f"opened PR for #{issue.get('number')}",
                     "outcome": "progress", "governance_decision": None})
                 state["status"] = "completed"
@@ -532,7 +505,7 @@ def _print_summary(decisions: list[dict], queue_size: int, dry_run: bool,
     def _tally(prefix: str) -> int:
         return sum(1 for d in decisions if str(d.get("action", "")).startswith(prefix))
     summary = {
-        "cycle_at": _now_iso(), "dry_run": dry_run, "halted": False,
+        "cycle_at": kit.now_iso(), "dry_run": dry_run, "halted": False,
         "backend": backend, "max_parallel": workers, "queue_size": queue_size,
         "decisions": decisions,
         "tally": {
@@ -574,7 +547,7 @@ def main(argv: list[str]) -> int:
         print(f"ABORT: {why}", file=sys.stderr)
         return 3
 
-    today = _now_iso()[:10]
+    today = kit.now_iso()[:10]
 
     # Self-merge harvest is a distinct pass (CI gates settle asynchronously after
     # the implement pass opens a PR), so it has its own queue and audit.

--- a/scripts/test_council_emit.py
+++ b/scripts/test_council_emit.py
@@ -1,5 +1,7 @@
 import json
+import tempfile
 import unittest
+import unittest.mock as mock
 from pathlib import Path
 import sys
 
@@ -106,6 +108,62 @@ class TestBuildVerdictSchema(unittest.TestCase):
             self.skipTest("jsonschema not installed")
         v = c.build_verdict(365, "Some change", [_green_a(), _approve_b()], "2026-06-23", 2)
         jsonschema.validate(v, self._schema())
+
+
+class TestConveneSeam(unittest.TestCase):
+    """End-to-end through the demerzel_kit seam: convene() with the gh reads and the
+    cross-model review injected, proving the council writes a schema-valid verdict to
+    disk without touching the network. This is the test the un-seamed gh calls made
+    impossible before the kit migration."""
+
+    def _fake_gh_json(self, args, **kwargs):
+        if args[:2] == ["pr", "view"]:
+            return {"number": 365, "title": "Add a thing", "body": "Closes #1",
+                    "headRefOid": "", "labels": []}
+        if args[:2] == ["issue", "view"]:
+            return {"title": "Issue 1", "body": "Do the thing"}
+        return None
+
+    def _fake_gh_text(self, args, **kwargs):
+        if args[:2] == ["pr", "checks"]:
+            return "risk-report\tpass\thttps://example/checks"
+        return ""  # diff / changed-files / api-content empty -> no file fetches
+
+    def _convene_in(self, tmp, xmodel=("Clean.\nVerdict: APPROVE", "claude")):
+        with mock.patch.object(c.kit, "gh_json", self._fake_gh_json), \
+             mock.patch.object(c.kit, "gh_text", self._fake_gh_text), \
+             mock.patch.object(c, "run_cross_model", return_value=xmodel), \
+             mock.patch.object(c, "COUNCIL_DIR", Path(tmp)):
+            return c.convene(365, classified_risk="low", write=True)
+
+    def test_convene_writes_schema_valid_verdict_to_disk(self):
+        with tempfile.TemporaryDirectory() as d:
+            verdict = self._convene_in(d)
+            written = Path(d) / f"{verdict['verdict_id']}.json"
+            self.assertTrue(written.exists(), "verdict must be written to disk")
+            on_disk = json.loads(written.read_text(encoding="utf-8"))
+            self.assertEqual(on_disk["verdict_id"], verdict["verdict_id"])
+            try:
+                import jsonschema
+            except ImportError:
+                self.skipTest("jsonschema not installed")
+            schema = json.loads((ROOT / "schemas" / "council-verdict.schema.json")
+                                .read_text(encoding="utf-8"))
+            jsonschema.validate(on_disk, schema)  # write_artifact already did; double-check
+
+    def test_convene_two_green_reviews_approve_strictest_wins(self):
+        with tempfile.TemporaryDirectory() as d:
+            verdict = self._convene_in(d)
+            # reviewer_a green (0.75) + reviewer_b approve (0.85) -> APPROVE, conf min=0.75
+            self.assertEqual(verdict["verdict"], "APPROVE")
+            self.assertEqual(len(verdict["reviews"]), 2)
+            self.assertAlmostEqual(verdict["post_council_confidence"], 0.75)
+
+    def test_convene_request_changes_when_cross_model_rejects(self):
+        with tempfile.TemporaryDirectory() as d:
+            verdict = self._convene_in(d, xmodel=("Bug.\nVerdict: REQUEST_CHANGES", "claude"))
+            # reviewer_b constitutional fail -> REJECT under strictest-wins
+            self.assertEqual(verdict["verdict"], "REJECT")
 
 
 if __name__ == "__main__":

--- a/scripts/test_demerzel_kit.py
+++ b/scripts/test_demerzel_kit.py
@@ -1,0 +1,105 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import demerzel_kit as kit
+
+
+def _proc(returncode=0, stdout="", stderr=""):
+    """A CompletedProcess-shaped stand-in for an injected gh runner."""
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestPrimitives(unittest.TestCase):
+    def test_now_iso_is_utc_rfc3339(self):
+        self.assertRegex(kit.now_iso(), r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+    def test_atomic_write_creates_parents_and_content(self):
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "nested" / "deep" / "out.json"
+            kit.atomic_write(target, '{"ok": true}')
+            self.assertEqual(target.read_text(encoding="utf-8"), '{"ok": true}')
+            # the temp sibling must not survive a successful write
+            self.assertFalse((target.with_suffix(".json.tmp")).exists())
+
+
+class TestValidate(unittest.TestCase):
+    def test_invalid_data_raises(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        # empty object is missing every required council-verdict field
+        with self.assertRaises(jsonschema.ValidationError):
+            kit.validate({}, "council-verdict")
+
+    def test_absent_jsonschema_degrades(self):
+        # Simulate jsonschema being unavailable: validate must return, not raise.
+        real = sys.modules.get("jsonschema")
+        sys.modules["jsonschema"] = None  # forces `import jsonschema` to ImportError
+        try:
+            kit.validate({}, "council-verdict")  # would raise if it actually validated
+        finally:
+            if real is not None:
+                sys.modules["jsonschema"] = real
+            else:
+                sys.modules.pop("jsonschema", None)
+
+
+class TestWriteArtifact(unittest.TestCase):
+    def test_writes_pretty_json_with_newline(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "a.json"
+            kit.write_artifact(out, {"b": 1, "a": 2})
+            text = out.read_text(encoding="utf-8")
+            self.assertTrue(text.endswith("\n"))
+            self.assertEqual(json.loads(text), {"b": 1, "a": 2})
+
+    def test_invalid_against_schema_does_not_write(self):
+        try:
+            import jsonschema  # noqa: F401
+        except ImportError:
+            self.skipTest("jsonschema not installed")
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "bad.json"
+            with self.assertRaises(Exception):
+                kit.write_artifact(out, {}, schema="council-verdict")
+            self.assertFalse(out.exists(), "invalid artifact must never reach disk")
+
+
+class TestGhSeam(unittest.TestCase):
+    def test_gh_json_parses_stdout(self):
+        out = kit.gh_json(["pr", "view", "1"], run=lambda *a, **k: _proc(stdout='{"number": 1}'))
+        self.assertEqual(out, {"number": 1})
+
+    def test_gh_json_none_on_nonzero(self):
+        self.assertIsNone(kit.gh_json(["x"], run=lambda *a, **k: _proc(returncode=1, stderr="boom")))
+
+    def test_gh_json_none_on_unavailable(self):
+        def boom(*a, **k):
+            raise OSError("gh not found")
+        self.assertIsNone(kit.gh_json(["x"], run=boom))
+
+    def test_gh_json_none_on_non_json(self):
+        self.assertIsNone(kit.gh_json(["x"], run=lambda *a, **k: _proc(stdout="not json")))
+
+    def test_gh_text_returns_stdout(self):
+        self.assertEqual(kit.gh_text(["pr", "diff", "1"], run=lambda *a, **k: _proc(stdout="DIFF")), "DIFF")
+
+    def test_gh_text_ok_nonzero_keeps_stdout(self):
+        # gh pr checks exits non-zero when a check failed, but the table is valid.
+        run = lambda *a, **k: _proc(returncode=1, stdout="risk-report\tfail\t")
+        self.assertEqual(kit.gh_text(["pr", "checks", "1"], ok_nonzero=True, run=run),
+                         "risk-report\tfail\t")
+
+    def test_gh_text_none_on_nonzero_by_default(self):
+        self.assertIsNone(kit.gh_text(["x"], run=lambda *a, **k: _proc(returncode=1)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -1,3 +1,5 @@
+import json
+import tempfile
 import unittest
 import unittest.mock as mock
 from pathlib import Path
@@ -211,6 +213,70 @@ class TestHarvestDryRun(unittest.TestCase):
         self.assertEqual(rc, 0)
         convene.assert_not_called()   # dry-run convenes no council
         merge.assert_not_called()     # and merges nothing
+
+
+class TestLoopStateWriteSeam(unittest.TestCase):
+    """The loop-state write now goes through kit.write_artifact, which validates
+    against schemas/loop-state.schema.json before atomic-writing — so an invalid
+    state never lands on disk (it had no validation before this migration)."""
+
+    def test_write_loop_state_validates_and_writes(self):
+        issue = {"number": 42, "title": "Fix docs typo", "body": "x", "labels": []}
+        st = g.build_loop_state(issue, seq=1, risk="low", mode="boundary-only",
+                                today="2026-06-25")
+        with tempfile.TemporaryDirectory() as d, \
+             mock.patch.object(g, "ROOT", Path(d)):
+            g._write_loop_state(st)
+            written = Path(d) / "state" / "loops" / f"{st['loop_id']}.loop.json"
+            self.assertTrue(written.exists(), "loop-state must be written to disk")
+            on_disk = json.loads(written.read_text(encoding="utf-8"))
+            self.assertEqual(on_disk["loop_id"], st["loop_id"])
+            try:
+                import jsonschema
+            except ImportError:
+                self.skipTest("jsonschema not installed")
+            schema_path = (Path(g.__file__).resolve().parents[1] / "schemas"
+                           / "loop-state.schema.json")
+            schema = json.loads(schema_path.read_text(encoding="utf-8"))
+            jsonschema.validate(on_disk, schema)  # write_artifact already did; double-check
+
+
+class TestHarvestSeam(unittest.TestCase):
+    """End-to-end through the demerzel_kit seam: a live --harvest pass with the gh
+    reads (gh_json/gh_text) injected, proving the harvest path gates a PR and writes
+    its audit to disk without touching the network. This is the test the un-seamed
+    gh calls made impossible before the kit migration."""
+
+    def _fake_gh_json(self, args, **kwargs):
+        if args[:2] == ["pr", "list"]:
+            return [{"number": 9, "title": "fix docs typo", "body": "Closes #9",
+                     "labels": []}]
+        return None
+
+    def _fake_gh_text(self, args, **kwargs):
+        if args[:2] == ["pr", "checks"]:
+            return "ci\tpass\thttps://example/checks"
+        return ""
+
+    def test_harvest_self_merges_and_writes_audit(self):
+        verdict = _council(verdict="APPROVE", conf=0.75, n_reviews=2)
+        with tempfile.TemporaryDirectory() as d, \
+             mock.patch.object(g.kit, "gh_json", self._fake_gh_json), \
+             mock.patch.object(g.kit, "gh_text", self._fake_gh_text), \
+             mock.patch.object(g, "active_conscience_max_weight", return_value=0.0), \
+             mock.patch.object(g.council_emit, "convene", return_value=verdict), \
+             mock.patch.object(g, "_merge_pr", return_value="merged") as merge, \
+             mock.patch.object(g, "ROOT", Path(d)):
+            rc = g.main(["--harvest"])
+            self.assertEqual(rc, 0)
+            merge.assert_called_once_with(9)
+            audit = Path(d) / "state" / "oversight"
+            files = list(audit.glob("afk-harvest-*.json"))
+            self.assertEqual(len(files), 1, "one harvest audit must be written")
+            summary = json.loads(files[0].read_text(encoding="utf-8"))
+        self.assertEqual(summary["tally"]["self_merge"], 1)
+        self.assertEqual(summary["decisions"][0]["action"], "self-merge")
+        self.assertEqual(summary["decisions"][0]["merge_result"], "merged")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements #407 via the AFK agent.

Review gates: agent-blackbox + cross-model-review.
Closes #407