### PR TITLE
Define capability-based routing and evaluate AI workers

### DIFF
--- a/docs/governance/capability-registry.md
+++ b/docs/governance/capability-registry.md
@@ -1,0 +1,112 @@
+# Capability Registry
+
+This registry defines the durable taxonomy of capabilities and the workers available to provide them within the ecosystem.
+
+## Registry Version: 1
+
+## Capability Taxonomy
+
+| Capability | Role Name | Purpose |
+| :--- | :--- | :--- |
+| `repository_navigation` | Navigator | Repository analysis, dependency mapping, impact analysis, context preparation. |
+| `implementation` | Builder | Code implementation, refactoring, tests, workflows. |
+| `research` | Researcher | Research synthesis, methodology, ADRs, governance documentation. |
+| `adversarial_review` | Critic | Architecture critique, governance critique, ambiguity detection, policy/safety review. |
+| `bug_hunting` | Bug Hunter | Narrow defect finding, regression suspicion, PR review comments, test gap detection. |
+| `security_review` | Security Reviewer | Secret exposure review, permission creep detection, workflow safety, supply-chain risk. |
+| `orchestration` | Supervisor | Routing, metrics, escalation, collision avoidance, status monitoring. |
+| `architecture` | Architect | Vision, product direction, strategic trade-offs, final authority. |
+
+## Worker Registry
+
+```yaml
+workers:
+  augment:
+    capabilities:
+      - repository_navigation
+    authority: read_only
+    cost_tier: existing_subscription_or_app
+    preferred_for:
+      - impact_analysis
+      - pre_implementation_context
+
+  claude:
+    capabilities:
+      - implementation
+    authority: pr
+    cost_tier: paid_or_subscription
+    preferred_for:
+      - complex_logic
+      - heavy_refactoring
+
+  jules:
+    capabilities:
+      - research
+    authority: pr
+    cost_tier: free_or_hosted
+    preferred_for:
+      - governance_docs
+      - methodology_research
+
+  gemini:
+    capabilities:
+      - adversarial_review
+    authority: read_only_review
+    cost_tier: paid_allowed_guarded
+    preferred_for:
+      - cross_file_policy_check
+      - large_context_review
+
+  codex:
+    capabilities:
+      - bug_hunting
+      - security_review
+    authority: review_or_pr
+    cost_tier: subscription_or_platform
+    preferred_for:
+      - narrow_fix
+      - security_scanning
+
+  qodo:
+    capabilities:
+      - bug_hunting # PR-focused review
+    authority: review
+    cost_tier: subscription
+    preferred_for:
+      - pr_quality_gate
+
+  sourcegraph:
+    capabilities:
+      - repository_navigation
+    authority: read_only
+    cost_tier: enterprise
+    preferred_for:
+      - multi_repo_context
+
+  ollama_local:
+    capabilities:
+      - research # Basic summarization
+      - bug_hunting # Basic classification
+    authority: read_only
+    cost_tier: free_local
+    preferred_for:
+      - low_risk_summarization
+      - triage_classification
+
+  demerzel:
+    capabilities:
+      - orchestration
+    authority: supervisor
+    cost_tier: infrastructure
+    preferred_for:
+      - governance_dispatch
+
+  human:
+    capabilities:
+      - architecture
+    authority: owner
+    cost_tier: high
+    preferred_for:
+      - final_signoff
+      - vision_setting
+```

--- a/docs/governance/capability-routing.md
+++ b/docs/governance/capability-routing.md
@@ -1,0 +1,75 @@
+# Capability-Based Routing
+
+This document defines the policy and mechanisms for routing work to AI capabilities rather than specific vendor products. This evolution of Harness-Driven Development (HDD) ensures vendor independence and optimized resource allocation.
+
+## Routing Principles
+
+1. **Capability First:** The Supervisor identifies the *what* (capability required) before selecting the *who* (worker).
+2. **Authority Least-Privilege:** Workers are selected based on the minimum authority level required for the task.
+3. **Deterministic Selection:** Initial routing is based on a deterministic scoring model; future iterations may use learned optimization (IX).
+4. **Human Final Authority:** Architecture and final sign-off remain human capabilities.
+
+## Routing Logic
+
+### 1. Capability Identification
+The Supervisor (Demerzel) analyzes the incoming Issue or PR to determine the primary capability required:
+- **Research/Documentation:** -> `research`
+- **Code Change/Feature:** -> `implementation` (preceded by `repository_navigation`)
+- **Review/Policy Check:** -> `adversarial_review`
+- **Bug/Vulnerability:** -> `bug_hunting` or `security_review`
+
+### 2. Worker Selection
+Once a capability is identified, the Supervisor selects a worker from the `capability-registry.md` using the **Scoring Model**.
+
+### 3. Fallback Policy
+If the primary worker for a capability is:
+- **Busy:** Select the next highest scoring available worker.
+- **Unavailable:** Escalate to backup workers listed in the registry.
+- **Too Expensive:** Re-route to a lower cost-tier worker if risk thresholds allow.
+- **Low-Confidence:** If a worker's self-reported confidence or historical success is < 0.5, the Supervisor MUST request a second opinion from a different worker or escalate to a human.
+
+## Scoring Model (Deterministic v1)
+
+Workers are scored on a scale of 0.0 to 1.0 across several dimensions:
+
+| Field | Weight | Description |
+| :--- | :--- | :--- |
+| `capability_fit` | 0.3 | How well the worker matches the required capability. |
+| `historical_success`| 0.2 | Observed performance on similar tasks. |
+| `availability` | 0.1 | Current load and responsiveness. |
+| `cost_fit` | 0.1 | Alignment with the issue's budget tier. |
+| `risk_fit` | 0.1 | Alignment with the task's risk level. |
+| `repo_context_fit` | 0.1 | Prior experience with the specific repository. |
+| `confidence` | 0.1 | Worker's self-assessed confidence for the specific task. |
+
+**Formula:** `Score = Σ (Field * Weight)`
+
+## Policy FAQs
+
+### How are cost ceilings enforced?
+- Each routing request must specify a budget tier (Free, Low, Standard, High).
+- Workers with `cost_tier > budget_tier` are excluded unless a human override is provided.
+- Local models (Ollama) are prioritized for "Free" tiers.
+
+### How are collisions avoided?
+- The Supervisor maintains a `state/active_workers.json` registry.
+- Workers touching the same repository or overlapping file sets are serialized or assigned to separate worktrees.
+- Lock files (`skills-lock.json`) prevent concurrent modification of governance artifacts.
+
+### Which capabilities are read-only?
+- `repository_navigation`, `adversarial_review`, and `security_review` are read-only by default. They generate observations, not commits.
+
+### Which capabilities can open PRs?
+- `implementation`, `research` (for docs), and `bug_hunting` (for narrow fixes) are permitted to open PRs, subject to the Harness Signature Layer.
+
+### Which actions require human approval?
+- Any change to the `constitutions/` or `policies/`.
+- Deployments to production environments.
+- Budget overrides for high-cost workers.
+- High-risk implementations (Risk > Medium).
+
+## Supervisor Implications
+
+This routing model aligns with **Harness-Driven Development (#482)** by treating workers as interchangeable components of the harness. It also reinforces the **Adversarial Review Policy (#477)** by ensuring that the `Critic` capability is distinct from the `Builder` capability for any non-trivial change.
+
+The Supervisor no longer "calls Claude"; it "requests Implementation" and handles the result according to the governance pipeline.

--- a/docs/research/github-ai-worker-evaluation.md
+++ b/docs/research/github-ai-worker-evaluation.md
@@ -1,0 +1,82 @@
+# GitHub AI Worker Evaluation
+
+This document evaluates various AI workers as potential capability providers within the Harness-Driven Development (HDD) framework. The goal is to move from vendor-locked dependencies to a capability-based routing model.
+
+## Evaluation Framework
+
+Workers are evaluated based on their performance, cost, and suitability for specific roles within the ecosystem.
+
+| Worker | Primary Role(s) | Strength | Weakness |
+| :--- | :--- | :--- | :--- |
+| **Augment Code** | Navigator | Deep repository intelligence, impact analysis. | Proprietary, requires indexing. |
+| **Claude** | Builder | Code implementation, refactoring, test generation. | Costly at high volumes. |
+| **Jules** | Researcher | Governance documentation, research synthesis. | Limited implementation breadth. |
+| **Gemini** | Critic | Adversarial review, policy checking, long context. | Variable code implementation quality. |
+| **Codex** | Bug Hunter / Security | Narrow defect finding, security review. | Context window limitations. |
+| **Qodo** | PR Reviewer | PR quality review, test-gap analysis. | Specific to PR workflow. |
+| **Sourcegraph Amp** | Navigator | Codebase-wide context and navigation. | Requires Sourcegraph infrastructure. |
+| **GitHub Agent HQ** | Supervisor | Upstream dispatch surface, GitHub-native. | Evolving, may have platform lock-in. |
+| **JetBrains AI** | Navigator / Builder | IDE-integrated navigation and implementation. | Local to IDE, harder to use in AFK loops. |
+| **Local Ollama** | Utility / Classifier | Low-cost classification, summarization, dry-runs. | Limited capability for complex logic. |
+
+## Capability Provider Details
+
+### 1. Augment Code (Navigator)
+- **Capability:** Repository Intelligence & Impact Analysis.
+- **Suitability:** High. Excels at understanding complex dependencies and preparing context for builders.
+- **Authority:** Read-only.
+- **Cost Tier:** Existing subscription/app.
+
+### 2. Claude (Builder)
+- **Capability:** Implementation, Refactoring, Tests.
+- **Suitability:** Very High. Currently the benchmark for reliable code generation and complex refactoring.
+- **Authority:** PR.
+- **Cost Tier:** Paid/Subscription.
+
+### 3. Jules (Researcher)
+- **Capability:** Research Synthesis, Methodology, Governance.
+- **Suitability:** High. Tailored for maintaining the Demerzel governance corpus.
+- **Authority:** PR (for documentation).
+- **Cost Tier:** Free/Hosted.
+
+### 4. Gemini via Google AI Studio (Critic)
+- **Capability:** Adversarial Review, Architecture Critique.
+- **Suitability:** High. Massive context window allows for reviewing entire repos against policy.
+- **Authority:** Read-only review.
+- **Cost Tier:** Paid (guarded).
+
+### 5. Codex (Bug Hunter / Security Reviewer)
+- **Capability:** Narrow defect finding, security review, second implementation opinion.
+- **Suitability:** Medium-High. Good for specific, scoped verification tasks.
+- **Authority:** Review or PR (narrow fix).
+- **Cost Tier:** Subscription/Platform.
+
+### 6. Qodo (PR Reviewer)
+- **Capability:** PR Quality, Test-Gap Analysis.
+- **Suitability:** High for specific PR gates.
+- **Authority:** Review.
+- **Cost Tier:** Subscription.
+
+### 7. Sourcegraph Amp (Navigator)
+- **Capability:** Large-scale repository navigation.
+- **Suitability:** High for very large or multi-repo contexts.
+- **Authority:** Read-only.
+- **Cost Tier:** Enterprise.
+
+### 8. GitHub Agent HQ (Supervisor)
+- **Capability:** Agent Orchestration.
+- **Suitability:** Potential upstream dispatcher.
+- **Authority:** Orchestration.
+- **Cost Tier:** Platform-native.
+
+### 9. JetBrains AI / Local IDE Agents
+- **Capability:** Local Navigation & Implementation.
+- **Suitability:** Best for developer-in-the-loop (DITL) support.
+- **Authority:** Local.
+- **Cost Tier:** IDE Subscription.
+
+### 10. Local Ollama Models
+- **Capability:** Classification, Summarization, Dry-runs.
+- **Suitability:** High for non-critical, high-volume tasks that benefit from zero marginal cost.
+- **Authority:** Internal/Read-only.
+- **Cost Tier:** Free/Local.


### PR DESCRIPTION
Defined a capability-based routing model for the ecosystem, including a worker registry, routing policies, and an evaluation of current AI worker candidates. This ensures vendor independence and optimized resource allocation within Harness-Driven Development.

Fixes #487

---
*PR created automatically by Jules for task [8190508807820004752](https://jules.google.com/task/8190508807820004752) started by @spareilleux*