### PR TITLE
Formalize AIW Operating Doctrine (Karpathy/Pocock/Cherny/Demerzel)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,9 @@ once" failure mode:
 - **Vertical, not horizontal, decomposition.** Each task/PR is a thin slice
   cutting through all integration layers (surfacing unknowns early), not a
   horizontal layer.
+- **AIW Operating Doctrine.** Adhere to the Karpathy (exploration), Pocock
+  (discipline), Cherny (loops), and Demerzel (governance) lanes. See
+  `docs/workflows/aiw-operating-doctrine.md` for details.
 
 Prefer existing planning/review/quality tooling over adding new skills — aihero's
 `/grill-me`, `/to-prd`, `/to-issues`, `/tdd`, `/improve-codebase-architecture`

--- a/docs/workflows/aiw-operating-doctrine.md
+++ b/docs/workflows/aiw-operating-doctrine.md
@@ -169,9 +169,18 @@ aiw_principles:
 
 Exploration output is not canonical until shaped (Pocock lane) and validated (Cherny lane with Demerzel gates).
 
+## Stop Conditions / Escalation
+
+Agents and orchestrators must halt and escalate to a human (Demerzel lane) when:
+- **Contradiction (C)** or **Unknown (U)** belief states are detected during lane classification.
+- Budget ceilings are reached or would be exceeded by the next loop.
+- A task touches more than one file without a pre-existing Pocock-lane shaping artifact.
+- Constitutional articles (especially Asimov laws) are potentially violated.
+- A "HALT-ALL" marker is present in the ecosystem.
+
 ## Follow-up Implementation
 
 The following implementation issues are required to turn this doctrine into executable workflow rules:
-- Lane classification: automate the identification of which lane a task belongs to.
-- Matt-before-AFK gating: implement the requirement that Pocock-style shaping occurs before AFK autonomy is granted.
-- Loop/budget routing: implement Cherny-style budget-aware agent loops and routing.
+- **Lane classification (#465):** automate the identification of which lane a task belongs to.
+- **Matt-before-AFK gating (#467):** implement the requirement that Pocock-style shaping occurs before AFK autonomy is granted.
+- **Loop/budget routing (#459, #461, #471):** implement Cherny-style budget-aware agent loops and routing.

--- a/docs/workflows/aiw-operating-doctrine.md
+++ b/docs/workflows/aiw-operating-doctrine.md
@@ -1,0 +1,177 @@
+# AIW Operating Doctrine
+
+Capture the AIW operating doctrine that combines three complementary engineering styles:
+
+- **Karpathy** gives speed and exploration.
+- **Matt Pocock** gives engineering discipline.
+- **Boris Cherny** gives agentic loop/runtime thinking.
+- **Demerzel** owns governance, risk, budget, HALT, audit, and merge gates.
+
+Related: #455, #457, #459, #461
+
+## Lane Overview
+
+| Layer | Role in AIW | Primary value | Main risk |
+|-------|-------------|---------------|-----------|
+| **Karpathy lane** | Exploration / prototype | Fast intent-driven iteration | Accepting unreviewed generated code |
+| **Pocock lane** | Task shaping / engineering discipline | Clear issues, shared language, TDD, small slices | Too much ceremony if overused |
+| **Cherny lane** | Agentic loop / orchestration runtime | Tools, worktrees, loops, subagents, budget routing | Expensive or runaway loops |
+| **Demerzel lane** | Governance / audit / gates | Risk, authorization, HALT, review, merge control | Over-centralizing policy into prompts |
+
+## 1. Karpathy lane — explore, do not canonize
+
+**Use for:**
+- idea exploration;
+- throwaway prototypes;
+- alternative designs;
+- creative iteration;
+- quick demos;
+- finding what breaks.
+
+**Never use directly for:**
+- unreviewed merge;
+- broad autonomous refactor;
+- policy changes;
+- secret-bearing tasks;
+- canonical runtime changes without harness evidence.
+
+**Expected output:**
+- notes;
+- prototype branch;
+- comparison table;
+- throwaway artifact;
+- issue-shaping input for the Pocock lane.
+
+## 2. Pocock lane — shape work before autonomy
+
+**Use for:**
+- grilling vague tasks;
+- creating shared language / CONTEXT.md-style vocabulary;
+- converting conversation into PRD or issues;
+- decomposing broad work into vertical slices;
+- TDD and red-green-refactor loops;
+- diagnosing bugs through reproduction/minimization;
+- improving codebase architecture without creating a ball of mud.
+
+**Required before:**
+- AFK patch mode;
+- AFK pr mode;
+- multi-provider implementation;
+- runtime changes with more than one touched file;
+- work that could otherwise burn large token/context budgets.
+
+**Expected output:**
+- crisp GitHub issue;
+- files/directories in scope;
+- explicit non-goals;
+- test command;
+- risk class;
+- acceptance criteria;
+- rollback / HALT notes where applicable.
+
+## 3. Cherny lane — agent loops with harnesses
+
+**Use for:**
+- provider orchestration;
+- worktree isolation;
+- tool permissions;
+- subagent delegation;
+- budget-aware loops;
+- prompt/harness execution;
+- context compaction;
+- collecting logs/tests/diffs;
+- converting worker results into PR/check/artifact evidence.
+
+**Required for:**
+- multi-provider execution;
+- remote/cloud workers;
+- repeated retries;
+- paid-agent escalation;
+- long-running tasks;
+- any job that claims AFK capability.
+
+**Expected output:**
+- branch/PR;
+- structured harness result;
+- budget ledger;
+- provider trace;
+- test logs;
+- failure minimization report if failed.
+
+## 4. Demerzel lane — governance and final authority
+
+Demerzel owns:
+- authorization;
+- risk classification;
+- budget ceilings;
+- HALT decisions;
+- audit trail;
+- allowed autonomy level;
+- review routing;
+- merge gates;
+- policy compliance.
+
+Demerzel must not delegate these to provider prompts alone.
+
+## AIW Principles
+
+```yaml
+aiw_principles:
+  karpathy:
+    use_for:
+      - exploration
+      - prototypes
+      - creative_iteration
+      - discovering_possible_shapes
+    never_for:
+      - unreviewed_merge
+      - broad_autonomous_refactor
+      - governance_or_policy_change
+
+  pocock:
+    use_for:
+      - issue_shaping
+      - grilling
+      - shared_language
+      - tdd
+      - diagnosing_bugs
+      - architecture_hygiene
+    required_before:
+      - afk_patch
+      - afk_pr
+      - multi_provider_implementation
+
+  cherny:
+    use_for:
+      - agent_loops
+      - provider_orchestration
+      - worktree_isolation
+      - token_budget_routing
+      - subagent_delegation
+      - harness_execution
+    required_for:
+      - remote_workers
+      - paid_agent_escalation
+      - repeated_retries
+
+  demerzel:
+    owns:
+      - risk
+      - budget
+      - authorization
+      - halt
+      - audit
+      - review
+      - merge_gates
+```
+
+## Exploration Output Canonization
+
+Exploration output is not canonical until shaped (Pocock lane) and validated (Cherny lane with Demerzel gates).
+
+## Follow-up Implementation
+
+The following implementation issues are required to turn this doctrine into executable workflow rules:
+- Lane classification: automate the identification of which lane a task belongs to.
+- Matt-before-AFK gating: implement the requirement that Pocock-style shaping occurs before AFK autonomy is granted.
+- Loop/budget routing: implement Cherny-style budget-aware agent loops and routing.

--- a/examples/agent-cards/demerzel.agent-card.json
+++ b/examples/agent-cards/demerzel.agent-card.json
@@ -132,7 +132,8 @@
       "Never acquire capabilities beyond her defined affordances",
       "Never suppress Contradictory (C) or Unknown (U) belief states — surface them",
       "Never exceed experiment budget thresholds without appropriate approval",
-      "Never run experiments that could cause irreversible harm to production systems"
+      "Never run experiments that could cause irreversible harm to production systems",
+      "Always adhere to the Karpathy, Pocock, Cherny, and Demerzel lanes defined in the AIW Operating Doctrine"
     ],
     "constitutional_authority": "https://github.com/GuitarAlchemist/Demerzel/blob/master/constitutions/asimov.constitution.md"
   }

--- a/prompts/afk-implement.prompt.md
+++ b/prompts/afk-implement.prompt.md
@@ -9,14 +9,15 @@ Issue body:
 {{ISSUE_BODY}}
 
 ## AIW Operating Doctrine
-You are operating in the **Cherny lane** (agentic loop), executing a task that has already been shaped in the **Pocock lane** (discipline/shaping). Use Karpathy-style minimalism only as an implementation constraint: keep the patch small, surgical, and disposable until validated.
+You are operating in the **Cherny lane** (agentic loop), executing a task that has been shaped in the **Pocock lane** (discipline/shaping). You must adhere to the **Karpathy lane** rules for implementation (exploration/speed without canonizing waste).
 
 ## Rules (non-negotiable)
 1. SCOPE: change only what this issue asks for. No refactoring of adjacent code,
    no unrelated style fixes (Karpathy R3 — surgical changes).
 2. SIMPLICITY: the minimum change that satisfies the issue (Karpathy R2).
-3. DOCTRINE: Respect the Pocock-before-AFK gating; do not proceed if the issue
-   is vague or lacks clear acceptance criteria.
+3. DOCTRINE: Respect the Pocock-before-AFK gating; if the issue is vague or
+   lacks clear acceptance criteria, STOP, make no commits, and write a single
+   line to stdout: `BLOCKED: vague issue / lacks acceptance criteria`.
 4. FORBIDDEN: do NOT edit anything under `constitutions/` or `policies/`. If the
    issue requires that, STOP, make no commits, and write a single line to stdout:
    `BLOCKED: requires constitution/policy change — needs human pre-approval`.

--- a/prompts/afk-implement.prompt.md
+++ b/prompts/afk-implement.prompt.md
@@ -9,7 +9,7 @@ Issue body:
 {{ISSUE_BODY}}
 
 ## AIW Operating Doctrine
-You are operating in the **Cherny lane** (agentic loop), executing a task that has been shaped in the **Pocock lane** (discipline/shaping). You must adhere to the **Karpathy lane** rules for implementation (exploration/speed without canonizing waste).
+You are operating in the **Cherny lane** (agentic loop), executing a task that has already been shaped in the **Pocock lane** (discipline/shaping). Use Karpathy-style minimalism only as an implementation constraint: keep the patch small, surgical, and disposable until validated.
 
 ## Rules (non-negotiable)
 1. SCOPE: change only what this issue asks for. No refactoring of adjacent code,

--- a/prompts/afk-implement.prompt.md
+++ b/prompts/afk-implement.prompt.md
@@ -8,14 +8,19 @@ Implement GitHub issue #{{ISSUE_NUMBER}}: "{{ISSUE_TITLE}}"
 Issue body:
 {{ISSUE_BODY}}
 
+## AIW Operating Doctrine
+You are operating in the **Cherny lane** (agentic loop), executing a task that has been shaped in the **Pocock lane** (discipline/shaping). You must adhere to the **Karpathy lane** rules for implementation (exploration/speed without canonizing waste).
+
 ## Rules (non-negotiable)
 1. SCOPE: change only what this issue asks for. No refactoring of adjacent code,
    no unrelated style fixes (Karpathy R3 — surgical changes).
 2. SIMPLICITY: the minimum change that satisfies the issue (Karpathy R2).
-3. FORBIDDEN: do NOT edit anything under `constitutions/` or `policies/`. If the
+3. DOCTRINE: Respect the Pocock-before-AFK gating; do not proceed if the issue
+   is vague or lacks clear acceptance criteria.
+4. FORBIDDEN: do NOT edit anything under `constitutions/` or `policies/`. If the
    issue requires that, STOP, make no commits, and write a single line to stdout:
    `BLOCKED: requires constitution/policy change — needs human pre-approval`.
-4. NO RUNTIME CODE: Demerzel holds only governance artifacts (YAML/MD/JSON/schemas/
+5. NO RUNTIME CODE: Demerzel holds only governance artifacts (YAML/MD/JSON/schemas/
    tests). Do not add executable application code.
 
 ## Definition of done


### PR DESCRIPTION
Formalized the AIW operating doctrine by creating a dedicated workflow document and integrating its principles into core agent guidelines, implementation prompts, and example agent cards. This ensures that AI agents operate within defined lanes (Karpathy for exploration, Pocock for shaping, Cherny for loops, Demerzel for governance) and respect the 'Pocock-before-AFK' gating rule.

Fixes #463

---
*PR created automatically by Jules for task [10676663593264272725](https://jules.google.com/task/10676663593264272725) started by @spareilleux*