### PR TITLE
Add AIW prompt and harness engineering artifacts

### DIFF
--- a/docs/workflows/aiw-prompt-harness-engineering.md
+++ b/docs/workflows/aiw-prompt-harness-engineering.md
@@ -1,0 +1,156 @@
+# AIW Prompt and Harness Engineering
+
+Related: #455, #457, #459, #461, #465, #467, #471.
+
+## Purpose
+
+AIW agents should not run from vague prompts. Every AFK-capable task needs a job contract and a harness that makes the work observable, bounded, repeatable, and reviewable.
+
+This document defines the prompt and harness discipline for AIW provider tasks.
+
+## Core principle
+
+A prompt is not enough. The harness owns the execution boundary.
+
+The prompt describes the job. The harness materializes context, restricts scope, runs checks, collects evidence, caps retries, records budget, and stops when governance requires it.
+
+## Minimum provider prompt sections
+
+Every provider task prompt should contain:
+
+1. **Role** — which provider role is being used.
+2. **Task** — one bounded task.
+3. **Source of truth** — issue, PR, doc, or job spec.
+4. **Context bundle** — relevant files, summaries, links, prior attempts.
+5. **Allowed scope** — paths and operations allowed.
+6. **Non-goals** — explicit exclusions.
+7. **Constraints** — budget, sandbox, secrets, network, style, risk.
+8. **Required process** — small steps, tests first where applicable, no broad rewrites.
+9. **Required outputs** — patch, branch, PR, summary, tests, risk notes, ledger.
+10. **Stop conditions** — missing context, failing tests, budget exceeded, risk escalation, HALT.
+
+See `prompts/aiw/provider-task.prompt.md`.
+
+## Harness responsibilities
+
+The harness should provide:
+
+- input materialization: issue body, source bundle, prompt pack, linked docs;
+- workspace isolation: worktree, container, WSL, VM, GitHub runner, or cloud worker;
+- command allowlist: exact commands or approved command classes;
+- output collection: diff, logs, checks, structured JSON result;
+- failure capture: failed command, stderr excerpt, minimized repro, next action;
+- retry policy: max retries, allowed retry causes, escalation rules;
+- budget ledger: estimated and actual tokens, calls, runner minutes, cost;
+- trace links: issue, branch, PR, workflow runs, artifacts.
+
+## Autonomy modes
+
+```yaml
+autonomy:
+  mode: observe|draft|patch|pr|harvest
+  max_steps: 5
+  requires_human_before:
+    - broad_scope_change
+    - new_secret
+    - policy_change
+    - cost_over_budget
+    - risk_high_or_critical
+  allowed_without_human:
+    - create_context_bundle
+    - classify_issue
+    - produce_design_draft
+    - make_small_doc_patch
+    - make_low_risk_tested_code_patch
+```
+
+| Mode | Meaning |
+|---|---|
+| `observe` | summarize, classify, inspect; no repo changes |
+| `draft` | create docs, specs, comments, examples; no runtime code |
+| `patch` | create local branch or patch with validation evidence |
+| `pr` | open PR only when checks and evidence are present |
+| `harvest` | review and merge path only through Demerzel gates |
+
+## Matt-readiness integration
+
+Before `patch` or `pr` mode, the task must pass the Matt-before-AFK readiness gate from `docs/workflows/aiw-matt-readiness-gate.md`.
+
+The generated job must include:
+
+- single vertical slice;
+- shared language or links to context;
+- allowed paths;
+- explicit non-goals;
+- test or validation commands;
+- evidence requirements;
+- stop conditions;
+- budget cap;
+- no high or critical governance risk.
+
+## Budget-router integration
+
+Before a remote, paid, or large-context provider is invoked, the job must include a budget block compatible with `docs/workflows/aiw-budget-router.md`.
+
+The harness must stop before exceeding the cap or request human approval when the configured approval threshold is crossed.
+
+## Harness result shape
+
+Each execution episode should produce a structured result with:
+
+- job id and issue;
+- lane and autonomy mode;
+- provider and workspace;
+- context bundle hash;
+- prompt pack version;
+- budget summary;
+- commands run;
+- changed files;
+- outputs;
+- observations;
+- decision;
+- stop reason;
+- risk notes.
+
+See `examples/aiw-harness-result.example.json`.
+
+## Retry policy
+
+Allowed retry reasons:
+
+- transient provider failure;
+- formatting or lint failure;
+- localized test failure with a clear diagnosis;
+- incomplete structured output;
+- missing dependency that can be installed with allowed commands.
+
+Blocked retry reasons:
+
+- vague failure without new diagnosis;
+- repeated same strategy after a failed test;
+- scope expansion;
+- policy, HALT, or secret conflict;
+- budget threshold exceeded;
+- provider asks for broader permissions.
+
+## Human-required gates
+
+Human review is required before:
+
+- policy or governance changes;
+- new or changed secrets;
+- high or critical risk work;
+- broad refactors;
+- merge authority changes;
+- budget increases beyond the approval threshold;
+- changes outside allowed paths;
+- any action while HALT is active.
+
+## Non-goals
+
+- Do not make prompts the source of truth.
+- Do not let provider instructions override Demerzel governance.
+- Do not claim safety from prompt text alone.
+- Do not give AFK agents broad filesystem or secret access.
+- Do not auto-merge based on model confidence.
+- Do not create giant prompt templates that encourage broad unreviewable changes.

--- a/examples/aiw-harness-result.example.json
+++ b/examples/aiw-harness-result.example.json
@@ -1,0 +1,43 @@
+{
+  "job_id": "aiw-0461-example",
+  "issue": 461,
+  "lane": "loop",
+  "autonomy_mode": "draft",
+  "provider": "docs-worker",
+  "workspace": "github-worktree",
+  "context_bundle_sha": "sha256:example-context-bundle",
+  "prompt_pack_version": "aiw-provider-task-v1",
+  "budget": {
+    "tier": "free-local",
+    "max_total_tokens": 50000,
+    "max_model_calls": 2,
+    "max_retries": 0,
+    "max_runner_minutes": 10,
+    "max_cost_usd": 0.0,
+    "approval_required_above_usd": 1.0
+  },
+  "commands_run": [],
+  "changed_files": [
+    "docs/workflows/aiw-prompt-harness-engineering.md",
+    "prompts/aiw/provider-task.prompt.md",
+    "examples/aiw-provider-prompt.example.md"
+  ],
+  "outputs": {
+    "branch": "aiw-prompt-harness-461",
+    "pr": null,
+    "diff_summary": "docs-only AIW prompt and harness engineering contract",
+    "validation_log": "docs-only change; no runtime validation required"
+  },
+  "observations": [
+    "task stayed within draft autonomy",
+    "no runtime code was changed",
+    "no secrets or policy authority were requested"
+  ],
+  "decision": "complete_draft_ready_for_review",
+  "stop_reason": "bounded_docs_patch_complete",
+  "risk_notes": [
+    "no provider invocation authority added",
+    "no merge authority changed",
+    "no HALT behavior changed"
+  ]
+}

--- a/examples/aiw-harness-result.example.json
+++ b/examples/aiw-harness-result.example.json
@@ -16,7 +16,13 @@
     "max_cost_usd": 0.0,
     "approval_required_above_usd": 1.0
   },
-  "commands_run": [],
+  "commands_run": [
+    {
+      "command": "pwsh scripts/verify.ps1",
+      "status": "passed",
+      "log": "verification completed successfully"
+    }
+  ],
   "changed_files": [
     "docs/workflows/aiw-prompt-harness-engineering.md",
     "prompts/aiw/provider-task.prompt.md",
@@ -26,15 +32,16 @@
     "branch": "aiw-prompt-harness-461",
     "pr": null,
     "diff_summary": "docs-only AIW prompt and harness engineering contract",
-    "validation_log": "docs-only change; no runtime validation required"
+    "validation_log": "pwsh scripts/verify.ps1 passed"
   },
   "observations": [
     "task stayed within draft autonomy",
     "no runtime code was changed",
+    "standard verification evidence was collected",
     "no secrets or policy authority were requested"
   ],
   "decision": "complete_draft_ready_for_review",
-  "stop_reason": "bounded_docs_patch_complete",
+  "stop_reason": "bounded_docs_patch_validated",
   "risk_notes": [
     "no provider invocation authority added",
     "no merge authority changed",

--- a/examples/aiw-provider-prompt.example.md
+++ b/examples/aiw-provider-prompt.example.md
@@ -38,6 +38,7 @@ Allowed operations:
 
 - `read`
 - `write-doc`
+- `run-command`
 
 ## Non-goals
 
@@ -63,21 +64,24 @@ budget:
 ```
 
 Network: `blocked`.
-Commands: no commands required for docs-only work.
+Commands:
+
+- `pwsh scripts/verify.ps1`
 
 ## Required process
 
 1. Confirm the requested change is docs-only.
 2. Edit only the allowed paths.
 3. Keep the patch small.
-4. Produce a diff summary and risk notes.
-5. Stop if the change requires runtime code or governance authority.
+4. Run `pwsh scripts/verify.ps1` or stop with a clear reason if the harness cannot run it.
+5. Produce a diff summary, validation evidence, and risk notes.
+6. Stop if the change requires runtime code or governance authority.
 
 ## Required outputs
 
 - diff summary;
 - changed files;
-- validation note;
+- validation command and result;
 - risk notes;
 - stop reason.
 
@@ -88,5 +92,6 @@ Stop if:
 - the issue asks for runtime implementation;
 - policy or HALT changes are needed;
 - files outside allowed paths are required;
+- validation cannot be run or explained;
 - a secret or credential is needed;
 - budget would exceed the cap.

--- a/examples/aiw-provider-prompt.example.md
+++ b/examples/aiw-provider-prompt.example.md
@@ -1,0 +1,92 @@
+# Example AIW Provider Prompt
+
+## Role
+
+You are acting as: `docs-worker`.
+
+You are executing one bounded AIW task under Demerzel governance.
+
+## Task
+
+Add a documentation-only clarification to the AIW budget router.
+
+## Source of truth
+
+- Issue: `#461`
+- Related artifacts:
+  - `docs/workflows/aiw-budget-router.md`
+  - `docs/workflows/aiw-matt-readiness-gate.md`
+- Current lane: `loop`
+- Autonomy mode: `draft`
+
+## Context bundle
+
+- `docs/workflows/aiw-budget-router.md`
+- `docs/workflows/aiw-matt-readiness-gate.md`
+- `docs/workflows/aiw-prompt-harness-engineering.md`
+
+Context bundle SHA: `sha256:example-context-bundle`
+
+## Allowed scope
+
+Allowed paths:
+
+- `docs/workflows/`
+- `examples/`
+
+Allowed operations:
+
+- `read`
+- `write-doc`
+
+## Non-goals
+
+Do not:
+
+- change runtime code;
+- change policy or HALT behavior;
+- create or modify secrets;
+- open a merge decision;
+- expand beyond documentation and examples.
+
+## Constraints
+
+```yaml
+budget:
+  tier: free-local
+  max_total_tokens: 50000
+  max_model_calls: 2
+  max_retries: 0
+  max_runner_minutes: 10
+  max_cost_usd: 0.00
+  approval_required_above_usd: 1.00
+```
+
+Network: `blocked`.
+Commands: no commands required for docs-only work.
+
+## Required process
+
+1. Confirm the requested change is docs-only.
+2. Edit only the allowed paths.
+3. Keep the patch small.
+4. Produce a diff summary and risk notes.
+5. Stop if the change requires runtime code or governance authority.
+
+## Required outputs
+
+- diff summary;
+- changed files;
+- validation note;
+- risk notes;
+- stop reason.
+
+## Stop conditions
+
+Stop if:
+
+- the issue asks for runtime implementation;
+- policy or HALT changes are needed;
+- files outside allowed paths are required;
+- a secret or credential is needed;
+- budget would exceed the cap.

--- a/prompts/aiw/provider-task.prompt.md
+++ b/prompts/aiw/provider-task.prompt.md
@@ -1,0 +1,105 @@
+# AIW Provider Task Prompt
+
+## Role
+
+You are acting as: `<provider-role>`.
+
+You are executing one bounded AIW task under Demerzel governance.
+
+## Task
+
+`<one bounded task>`
+
+## Source of truth
+
+- Issue: `<issue-url-or-number>`
+- Parent or related artifacts: `<links>`
+- Current lane: `<explore|shape|loop|verify|govern>`
+- Autonomy mode: `<observe|draft|patch|pr|harvest>`
+
+## Context bundle
+
+Use only the supplied context bundle and the allowed repository paths.
+
+Context bundle:
+
+- `<file-or-summary>`
+- `<file-or-summary>`
+
+Context bundle SHA: `<sha256:...>`
+
+## Allowed scope
+
+Allowed paths:
+
+- `<path>`
+
+Allowed operations:
+
+- `<read|write-doc|write-test|write-code|run-command|open-pr>`
+
+## Non-goals
+
+Do not:
+
+- broaden the issue scope;
+- touch files outside the allowed paths;
+- change policy, HALT, secrets, or merge authority;
+- introduce broad refactors;
+- use model confidence as evidence.
+
+## Constraints
+
+Budget:
+
+```yaml
+budget:
+  tier: `<free-local|cheap-hosted|paid-agent|manual-approval>`
+  max_total_tokens: `<number>`
+  max_model_calls: `<number>`
+  max_retries: `<number>`
+  max_runner_minutes: `<number>`
+  max_cost_usd: `<number>`
+  approval_required_above_usd: `<number>`
+```
+
+Sandbox and access:
+
+- Secrets: unavailable unless explicitly provided by the harness.
+- Network: `<allowed|blocked|limited>`.
+- Commands: only the command allowlist may be executed.
+
+## Required process
+
+1. Restate the bounded task.
+2. Inspect only the supplied context and allowed paths.
+3. Make the smallest useful change.
+4. Run the required validation commands when available.
+5. Stop instead of guessing when context is missing.
+6. Stop instead of expanding scope.
+7. Produce structured evidence.
+
+## Required outputs
+
+Return a structured result containing:
+
+- summary;
+- changed files;
+- commands run;
+- validation output;
+- risk notes;
+- budget notes;
+- stop reason;
+- next suggested action.
+
+## Stop conditions
+
+Stop immediately when:
+
+- required context is missing;
+- allowed paths are insufficient;
+- tests fail repeatedly without new information;
+- budget cap would be exceeded;
+- risk escalates to high or critical;
+- policy, HALT, secrets, or merge authority is involved;
+- the requested task is not in the `loop` lane for `patch` or `pr` autonomy.


### PR DESCRIPTION
Adds the first bounded prompt/harness engineering artifacts for #461:

- `docs/workflows/aiw-prompt-harness-engineering.md`
- `prompts/aiw/provider-task.prompt.md`
- `examples/aiw-provider-prompt.example.md`
- `examples/aiw-harness-result.example.json`

This PR intentionally keeps the scope to docs/templates/examples. Schema and executable tests can follow in a narrower implementation PR if needed.

Refs #461