### PR TITLE
fix: target master for Jules delegation

### DIFF
--- a/.github/workflows/jules-auto-delegate.yml
+++ b/.github/workflows/jules-auto-delegate.yml
@@ -166,7 +166,7 @@ jobs:
             exit 0
           fi
 
-          gh issue comment "$issue" --repo "$REPO" --body "🤖 Delegating this \`ready-for-agent\` + \`worker:jules\` issue to Jules via governed AFK workflow. $marker\n\nJules should open a PR targeting \`main\`. Human/Demerzel review is still required before merge."
+          gh issue comment "$issue" --repo "$REPO" --body "🤖 Delegating this \`ready-for-agent\` + \`worker:jules\` issue to Jules via governed AFK workflow. $marker\n\nJules should open a PR targeting \`master\`. Human/Demerzel review is still required before merge."
 
           echo "issue=$issue" >> "$GITHUB_OUTPUT"
           echo "proceed=true" >> "$GITHUB_OUTPUT"
@@ -201,7 +201,7 @@ jobs:
             echo "- Do not auto-merge, do not change secrets, and do not bypass human/Demerzel review."
             echo "- If the issue is broad, produce the smallest safe first PR and document follow-ups."
             echo ""
-            echo "Open a pull request targeting main. Include a concise summary, evidence, tests/validation performed, risk notes, and any follow-up issues needed."
+            echo "Open a pull request targeting master. Include a concise summary, evidence, tests/validation performed, risk notes, and any follow-up issues needed."
             echo "JULES_EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -211,4 +211,4 @@ jobs:
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           jules_api_key: ${{ secrets.JULES_API_KEY }}
-          starting_branch: main
+          starting_branch: master


### PR DESCRIPTION
This fixes the Demerzel Jules workflow branch target.

Demerzel uses `master` as the default branch and has no `main` branch. The Jules workflow previously configured `starting_branch: main` and asked Jules to target `main`, which would fail after the `JULES_API_KEY` secret gate is resolved.

Changes:
- `starting_branch: main` → `starting_branch: master`
- Jules prompt text now asks Jules to target `master`

Notes:
- This does not add or expose secrets.
- Human still needs to configure `JULES_API_KEY` in repository Actions secrets.
- This was created directly via GitHub and does not touch the dirty local Demerzel working tree.