### PR TITLE
Epic [P0]: Add Demerzel policy engine and lifecycle state machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ Demerzel/
 | Personas | 17 | `personas/*.persona.yaml` |
 | Policies | 45 | `policies/*.yaml` |
 | Grammars | 20 | `grammars/*.ebnf` |
-| Schemas | 40 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
+| Schemas | 41 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
 | Behavioral tests | 114 | `tests/behavioral/*.md` |
 | Skills | 69 | `.claude/skills/*/` |
 | Streeling departments | 23 | `state/streeling/departments/*.department.json` |
 | Course tracks | 21 | `state/streeling/courses/*/` |
 | IxQL pipelines | 23 | `pipelines/*.ixql` |
-| GitHub workflows | 23 | `.github/workflows/*.yml` |
+| GitHub workflows | 24 | `.github/workflows/*.yml` |
 
 ## Key concepts
 
@@ -143,7 +143,7 @@ Artifacts are consumed by agents via:
 
 ## CI workflows
 
-23 GitHub workflows under [`.github/workflows/`](./.github/workflows/). Notable:
+24 GitHub workflows under [`.github/workflows/`](./.github/workflows/). Notable:
 
 - [`qa-tribunal.yml`](./.github/workflows/qa-tribunal.yml) — repository-dispatch emitter (Phase 0).
 - [`governance-validate.yml`](./.github/workflows/governance-validate.yml) — schema + grammar validation.

--- a/docs/architecture/policy-engine.md
+++ b/docs/architecture/policy-engine.md
@@ -1,0 +1,91 @@
+# Demerzel Policy Engine
+
+This document outlines the design, boundaries, and components of the Demerzel Policy Engine, the core decision layer that enforces governance and orchestration rules across the AI workspace.
+
+## Core Principle
+
+```text
+Rules decide the guard.
+State machines enforce the lifecycle.
+Events record what happened.
+Humans/Demerzel own final authority.
+```
+
+## Purpose and Boundaries
+
+The Demerzel Policy Engine evaluates structured context (events, state transitions, risk analyses) to emit **advisory decisions**.
+
+### Boundaries
+- **Lightweight:** It is not a monolithic "magic rules" engine. It maps defined conditions to standard reason codes.
+- **Explicit Lifecycle:** Rules operate on explicitly defined state machines. The engine prevents state transitions that violate rules.
+- **No Direct Mutation:** The MVP is strictly **advisory** and **dry-run**. It computes the "should this be allowed" output but delegates actual merging or execution to human reviewers or outer orchestration wrappers.
+- **Human-in-the-Loop:** Auto-merge is strictly forbidden by project policies. The policy engine highlights risks and blocks unauthorized autonomous actions.
+- **No Hidden State:** State must be explicitly tracked in the system, not implied via GitHub comment threads.
+
+## Target Flow
+
+```text
+GitHub event
+  -> normalized event
+  -> lifecycle state update
+  -> policy evaluation
+  -> advisory decision
+  -> human/Demerzel decision point
+  -> optional action
+  -> evidence captured
+```
+
+## Component Catalogs
+
+### Rule Pack Catalog
+
+Rules are logically grouped into packs to govern specific dimensions of the AI workflow:
+
+1. **Safety & Security Pack**
+   - Blocks secret leakage.
+   - Enforces Asimov priority (e.g., cannot weaken constraints).
+   - Blocks autonomous deployment/merge without human review.
+
+2. **Lifecycle & Grooming Pack**
+   - Enforces Definition of Ready (DoR) for issues before they can be routed to an agent.
+   - Enforces Definition of Done (DoD) before PRs can be merged.
+   - Ensures issues are shaped in the Pocock lane before autonomous execution.
+
+3. **Budget & Token Economics Pack**
+   - Prevents agent loops from running beyond predefined ceilings.
+   - Recommends cheaper tools/models when appropriate.
+
+4. **Review & Adversarial Pack**
+   - Demands adversarial review for Tier 2/Tier 3 complexity tasks.
+   - Enforces minimum conversation hygiene and halts repetitive loops.
+
+### Reason Code Taxonomy
+
+When the policy engine blocks or escalates an action, it provides a specific reason code to aid human review.
+
+- `SAFE_001`: Allowed under default limits.
+- `RISK_001`: High-risk file modified (e.g., constitution).
+- `RISK_002`: Action blocked due to Asimov law violation.
+- `RISK_003`: Auto-merge attempt blocked.
+- `DOR_001`: Issue rejected for lack of shaping (Pocock lane requirement).
+- `DOD_001`: PR rejected for lack of test coverage.
+- `BUDGET_001`: Loop halted due to token threshold exceeded.
+- `STATE_001`: Invalid lifecycle transition.
+- `ESCALATE_001`: Sent to Demerzel/Human for review due to C-mass threshold > 0.3.
+
+## Dry-run Evaluator Design (MVP)
+
+The MVP policy evaluator operates in a dry-run mode:
+1. **Input:** Receives the requested action, current state, and relevant payload (e.g., diff, agent log).
+2. **Evaluation:** Evaluates the request against the active Rule Packs.
+3. **Output:** Emits an **Advisory Decision** (schema: `advisory-decision.schema.json`).
+4. **Action:** The system appends the decision payload as evidence and posts a summary comment to the GitHub thread. It does not automatically execute block or merge actions natively in GitHub until human intervention.
+
+## Integration Points
+
+The policy engine acts as the gatekeeper across several architectural areas:
+
+- **Fan-out / Fan-in (#568):** Regulates how many concurrent tasks can be spawned and enforces rules for when fan-in merge requires human review.
+- **Adaptive Backpressure (#584, #586):** Evaluates system load and HALT markers to block new issue creation or dispatch when backpressure is constrained or halted.
+- **Worker Lanes (#570):** Ensures agents do not escape their assigned capability lanes (e.g., forcing a task to stay in the Karpathy exploration lane rather than executing a loop).
+- **Mission Control / Supervisor (#579):** Provides the deterministic "Allow/Block/Escalate" verdict to the supervisor, keeping the supervisor logic declarative rather than imperative.

--- a/docs/workflows/aiw-lifecycle-state-machines.md
+++ b/docs/workflows/aiw-lifecycle-state-machines.md
@@ -1,0 +1,108 @@
+# AIW Lifecycle State Machines
+
+This document outlines the explicit lifecycle state machines for AI Worker (AIW) entities across the Demerzel ecosystem. These state machines provide stable, deterministic state inputs for policy evaluation, preventing "hidden state" that relies purely on unstructured conversation or LLM context.
+
+## Guiding Principles
+
+1. **Explicit over Implicit:** If an AI worker is doing work, the state of that work must be explicitly represented in a tracked state machine.
+2. **Deterministic Inputs:** The Demerzel Policy Engine uses these states to evaluate transitions.
+3. **No Hidden State:** We do not rely on "reading the GitHub comments" to know what stage of work an agent is in.
+4. **Hexavalent alignment:** States should be clearly categorizable or evaluate cleanly within our governance frameworks.
+
+## 1. Issue Lifecycle
+
+The Issue lifecycle tracks the progression of an idea from creation to being shaped and ready for work, to completion.
+
+**Valid States:**
+- `raw`: Newly created, unshaped issue.
+- `shaping`: Currently being defined in the Pocock lane (clarifying constraints, acceptance criteria).
+- `ready`: Shaped, meets Definition of Ready (DoR), waiting for a worker assignment.
+- `in_progress`: Assigned to a worker, actively being executed.
+- `blocked`: Execution halted (e.g., due to missing information or a policy violation).
+- `resolved`: Completed and verified, related PRs merged.
+- `closed_wontfix`: Rejected or abandoned.
+
+**Allowed Transitions:**
+- `raw` -> `shaping`, `closed_wontfix`
+- `shaping` -> `ready`, `closed_wontfix`
+- `ready` -> `in_progress`, `blocked`, `closed_wontfix`
+- `in_progress` -> `blocked`, `resolved`
+- `blocked` -> `in_progress`, `closed_wontfix`
+
+## 2. Pull Request (PR) Lifecycle
+
+The PR lifecycle manages the validation and review of code changes proposed by an AI worker.
+
+**Valid States:**
+- `draft`: Code is being written, not ready for review.
+- `verifying`: Running CI/CD, tests, and automated policy checks.
+- `in_review`: Undergoing human or adversarial AI review.
+- `changes_requested`: Reviewers found issues; sent back to the worker.
+- `approved`: Review passed, meets Definition of Done (DoD).
+- `merged`: Merged into the target branch.
+- `closed_unmerged`: Rejected or abandoned.
+
+**Allowed Transitions:**
+- `draft` -> `verifying`, `closed_unmerged`
+- `verifying` -> `in_review`, `draft` (if checks fail)
+- `in_review` -> `changes_requested`, `approved`
+- `changes_requested` -> `draft`, `verifying`
+- `approved` -> `merged`, `closed_unmerged`
+
+## 3. WorkPackage / Task Lifecycle
+
+WorkPackages define the granular chunks of work assigned to specific AI capabilities.
+
+**Valid States:**
+- `pending`: Task created, not yet started.
+- `dispatched`: Sent to an AI worker or sub-agent.
+- `executing`: Worker is actively processing the task.
+- `yielding`: Worker paused to ask for human input or missing context.
+- `completed`: Worker finished the task successfully.
+- `failed`: Worker encountered an unrecoverable error.
+- `halted`: Task forcibly stopped by policy or Demerzel supervisor.
+
+**Allowed Transitions:**
+- `pending` -> `dispatched`
+- `dispatched` -> `executing`, `failed`
+- `executing` -> `yielding`, `completed`, `failed`, `halted`
+- `yielding` -> `executing`, `halted`
+
+## 4. Review Lifecycle
+
+The Review state machine tracks the adversarial or human review process for a specific artifact or PR.
+
+**Valid States:**
+- `unassigned`: Review required but no reviewer selected.
+- `assigned`: Sent to a reviewer (human or AI).
+- `auditing`: Actively being reviewed.
+- `commented`: Feedback provided, but no definitive verdict yet.
+- `request_changes`: Definitively rejected until changes are made.
+- `approved`: Definitively approved.
+
+**Allowed Transitions:**
+- `unassigned` -> `assigned`
+- `assigned` -> `auditing`
+- `auditing` -> `commented`, `request_changes`, `approved`
+- `commented` -> `auditing`, `request_changes`, `approved`
+
+## 5. Execution Episode (Agent Loop) Lifecycle
+
+An Execution Episode tracks the micro-lifecycle of a single Cherny-lane agent loop (e.g., plan -> execute -> verify).
+
+**Valid States:**
+- `initializing`: Setting up context and tools.
+- `planning`: Deriving a plan from the task.
+- `acting`: Executing tool calls or writing code.
+- `observing`: Evaluating the results of the actions.
+- `reflecting`: Comparing observations against the goal.
+- `success`: Loop achieved goal.
+- `budget_exhausted`: Loop stopped due to token/cost limits.
+- `max_iterations_reached`: Loop stopped to prevent runaway recursion.
+
+**Allowed Transitions:**
+- `initializing` -> `planning`
+- `planning` -> `acting`
+- `acting` -> `observing`
+- `observing` -> `reflecting`
+- `reflecting` -> `success`, `planning` (re-plan), `budget_exhausted`, `max_iterations_reached`

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -10,9 +10,9 @@
     "persona": 17,
     "pipeline": 23,
     "policy": 45,
-    "schema": 40,
+    "schema": 41,
     "skill": 69,
-    "workflow": 23
+    "workflow": 24
   },
   "inventory": {
     "constitution": [
@@ -355,6 +355,10 @@
       {
         "name": "a2a-protocol.schema",
         "path": "schemas/a2a-protocol.schema.json"
+      },
+      {
+        "name": "advisory-decision.schema",
+        "path": "schemas/advisory-decision.schema.json"
       },
       {
         "name": "agent-card.schema",
@@ -1241,6 +1245,10 @@
       {
         "name": "governance-validate",
         "path": ".github/workflows/governance-validate.yml"
+      },
+      {
+        "name": "jules-auto-delegate",
+        "path": ".github/workflows/jules-auto-delegate.yml"
       },
       {
         "name": "karpathy-cherny-discipline",

--- a/schemas/advisory-decision.schema.json
+++ b/schemas/advisory-decision.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GuitarAlchemist/Demerzel/schemas/advisory-decision",
+  "title": "Advisory Decision",
+  "description": "JSON schema for advisory governance decisions emitted by the Demerzel Policy Engine.",
+  "type": "object",
+  "required": ["decision_id", "subject", "decision", "reason_codes", "transition_result"],
+  "properties": {
+    "decision_id": {
+      "type": "string",
+      "description": "Unique identifier for the decision event."
+    },
+    "subject": {
+      "type": "string",
+      "description": "The entity or action being evaluated (e.g., issue URL, PR, transition attempt)."
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["allow", "block", "escalate", "recommend"],
+      "description": "The policy engine's verdict."
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "List of reason codes (e.g., RISK_001, DOR_001) justifying the decision."
+    },
+    "transition_result": {
+      "type": "object",
+      "description": "Details about the requested lifecycle state transition.",
+      "required": ["from_state", "to_state", "allowed"],
+      "properties": {
+        "from_state": {
+          "type": "string",
+          "description": "The current state before the transition."
+        },
+        "to_state": {
+          "type": "string",
+          "description": "The requested target state."
+        },
+        "allowed": {
+          "type": "boolean",
+          "description": "Whether the transition is permitted according to the state machine."
+        },
+        "required_rules": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Rules evaluated for this transition."
+        },
+        "blocking_reasons": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Reasons why the transition is blocked, if applicable."
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "References to logs, diffs, or artifacts used as evidence."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the foundational architecture for the Demerzel Policy Engine as requested in Epic #588. 

The policy engine acts as a lightweight, explicitly defined advisory layer. It enforces deterministic state machines and outputs JSON-formatted advisory decisions without automatically performing merges, preserving human authority per the project's Asimov directives.

Included in this PR:
1. **Policy Engine Docs (`docs/architecture/policy-engine.md`)**: Boundaries, rule pack definitions, reason code taxonomy, and MVP dry-run logic.
2. **Lifecycle State Machines (`docs/workflows/aiw-lifecycle-state-machines.md`)**: Deterministic states for Issues, PRs, Tasks, Reviews, and Loops.
3. **Advisory Decision Schema (`schemas/advisory-decision.schema.json`)**: Draft 2020-12 valid schema for emitting decisions.
4. Updates to `README.md` to fix workflow count drift and pass the `build_manifest.py` checks.

---
*PR created automatically by Jules for task [63365046279677780](https://jules.google.com/task/63365046279677780) started by @spareilleux*