### PR TITLE
docs: port HDD cross-links from #484 (wave-2 reconciliation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Demerzel Agent Team
 
-Team definition for Claude Code agent teams.
+Team definition for Claude Code agent teams, following the [Harness-Driven Development (HDD)](docs/methodology/harness-driven-development.md) methodology.
 
 ## Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ The hooks are validated in CI by `.github/workflows/karpathy-cherny-discipline.y
 
 ## Harness doctrine (Pocock delta, 2026-06-22)
 
+See: [Harness-Driven Development (HDD)](docs/methodology/harness-driven-development.md) for the full engineering methodology.
+
 From the Matt Pocock × David Ondrej transcript (`sources/chats/matt-pocock-david-ondrej-agentic-workflow.md`). Reconciles with the Karpathy 4 Rules and Cherny patterns above — **agree = keep, diverge = adjust**.
 
 - **Harness ≈ model (50/50), stay agent-agnostic.** Optimize the harness (prompts, skills, codebase, sandbox) as much as the model, and don't over-fit to one model. A codebase that's *easy to change* lets a *cheaper* model do the same work. Optimize **AX (Agent Experience)** the way you optimize DX. *(New — extends `project_harness_engineering_direction`.)*

--- a/docs/governance-model.md
+++ b/docs/governance-model.md
@@ -7,6 +7,8 @@ Effective: 2026-03-22
 
 This document defines how governance works in the GuitarAlchemist ecosystem — who makes decisions, how changes are proposed and approved, how conflicts are resolved, and how governance itself evolves. It is the definitive operational guide for anyone participating in Demerzel governance.
 
+See [Harness-Driven Development (HDD)](methodology/harness-driven-development.md) for the overarching engineering methodology that these governance processes support.
+
 Inspired by the [Hyperlight Project Governance](https://github.com/hyperlight-dev/hyperlight/blob/main/GOVERNANCE.md) model — adapted from open-source project governance to AI agent governance.
 
 ## 1. Constitutional Hierarchy

--- a/docs/methodology/agentic-engineering.md
+++ b/docs/methodology/agentic-engineering.md
@@ -1,5 +1,7 @@
 # Agentic Engineering — the harness is the work
 
+See also: [Harness-Driven Development (HDD)](harness-driven-development.md) for the operational methodology.
+
 > A read-on-demand reference, **not** an always-loaded instruction block. Distilled from Matt
 > Pocock's "Agentic Engineering Workflow" (aihero.dev) + Ousterhout's *A Philosophy of Software
 > Design*, and mapped to **this repo's** existing machinery. Read it when you're deciding *how* to


### PR DESCRIPTION
Wave-2 reconciliation follow-up. When #484 was closed as superseded by #564, its four one-line cross-links to `docs/methodology/harness-driven-development.md` were flagged "not lost — to port": `AGENTS.md`, `CLAUDE.md`, `docs/governance-model.md`, `docs/methodology/agentic-engineering.md`. This ports them, completing the #482 story.

Manifest and governance validation green (`build_manifest.py`, `validate_governance.py` 13/13). No count drift — the wave-2 merges each regenerated the manifest, so no further reconciliation was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQUHbM37zpDJ1nRe7E9SN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQUHbM37zpDJ1nRe7E9SN9)_