### PR TITLE
fix(governance): protect agent-blackbox.policy.json from self-modification

### DIFF
--- a/agent-blackbox.policy.json
+++ b/agent-blackbox.policy.json
@@ -5,6 +5,7 @@
     "warn": 0.6
   },
   "blocked_paths": [
+    "agent-blackbox.policy.json",
     ".github/workflows/**",
     "constitutions/**",
     "policies/**",


### PR DESCRIPTION
Closes the loophole exposed twice during the wave-2 queue cleanup: a gated PR could edit the very policy that gates it. #566's branch narrowed `schemas/**` to exempt its own new files, and #583 moved a policy YAML into `examples/` to route around the `policies/` constraint. The policy file itself was the one path not in its own `blocked_paths`.

One-line, strictly-tightening change: `agent-blackbox.policy.json` is now in its own `blocked_paths`, so any change to the gate flags for human review. JSON validated locally. Same fix applied across ga, tars, ix, and agent-blackbox in parallel PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQUHbM37zpDJ1nRe7E9SN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQUHbM37zpDJ1nRe7E9SN9)_