### PR TITLE
Migrate qa_tribunal_emit onto demerzel_kit

### DIFF
--- a/scripts/qa_tribunal_emit.py
+++ b/scripts/qa_tribunal_emit.py
@@ -44,15 +44,13 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import datetime as dt
 import json
 import os
 import re
-import subprocess
 import sys
 from pathlib import Path
 
-import jsonschema  # type: ignore[import-not-found]
+import demerzel_kit as kit
 
 
 # ---------------------------------------------------------------------------
@@ -68,8 +66,6 @@ REPO_ALLOWLIST = {
 
 PRODUCER_SLUG = "qa-architect-cycle"
 PRODUCER_VERSION = "0.1.0"
-
-SCHEMA_PATH = Path("schemas/contracts/qa-verdict.schema.json")
 
 VERDICT_ROOT = Path("state/quality/verdicts")
 SWEEP_ROOT = VERDICT_ROOT / "sweeps"
@@ -115,22 +111,10 @@ class PayloadError(ValueError):
 
 def _gh_api(path: str) -> dict | None:
     """Call `gh api <path>`. Returns parsed JSON or None on non-200."""
-    try:
-        result = subprocess.run(
-            ["gh", "api", path],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=30,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
-    if result.returncode != 0:
-        return None
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return None
+    result = kit.gh_json(["api", path])
+    if isinstance(result, dict):
+        return result
+    return None
 
 
 def validate_dispatch_payload(payload: dict) -> dict:
@@ -205,19 +189,10 @@ def validate_dispatch_payload(payload: dict) -> dict:
 
 def changed_files(repo: str, pr: int) -> list[str]:
     """Return list of changed file paths via `gh pr diff --name-only`."""
-    try:
-        result = subprocess.run(
-            ["gh", "pr", "diff", str(pr), "--repo", repo, "--name-only"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=60,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+    out = kit.gh_text(["pr", "diff", str(pr), "--repo", repo, "--name-only"], ok_nonzero=True)
+    if not out:
         return []
-    if result.returncode != 0:
-        return []
-    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return [line.strip() for line in out.splitlines() if line.strip()]
 
 
 def derive_blast_radius(paths: list[str]) -> dict:
@@ -255,17 +230,10 @@ def derive_blast_radius(paths: list[str]) -> dict:
 # Verdict construction
 # ---------------------------------------------------------------------------
 
-def _iso_now() -> tuple[str, str]:
-    """Return (iso_rfc3339, iso_filename_safe) for the current UTC time."""
-    now = dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
-    iso = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-    file_safe = now.strftime("%Y-%m-%dT%H-%M-%SZ")
-    return iso, file_safe
-
-
 def build_pr_verdict(payload: dict, paths: list[str]) -> dict:
     """Build a contract-conforming verdict for a pull_request target."""
-    iso, file_safe = _iso_now()
+    iso = kit.now_iso()
+    file_safe = iso.replace(":", "-")
     blast = derive_blast_radius(paths)
 
     return {
@@ -317,7 +285,8 @@ def build_pr_verdict(payload: dict, paths: list[str]) -> dict:
 
 def build_sweep_verdict() -> dict:
     """Build a scheduled-sweep informational verdict."""
-    iso, file_safe = _iso_now()
+    iso = kit.now_iso()
+    file_safe = iso.replace(":", "-")
     return {
         "schema_version": 1,
         "verdict_id": f"{file_safe}-sweep-{PRODUCER_SLUG}",
@@ -363,14 +332,6 @@ def build_sweep_verdict() -> dict:
 
 def emit_verdict(verdict: dict, payload: dict | None) -> Path:
     """Validate against schema + write to verdict path. Returns the output path."""
-    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
-        schema = json.load(f)
-
-    try:
-        jsonschema.validate(instance=verdict, schema=schema)
-    except jsonschema.ValidationError as exc:
-        raise PayloadError(f"emitter produced schema-invalid verdict: {exc.message}") from exc
-
     if payload is not None:
         # Per-PR verdict path
         repo_slug = payload["repo"].replace("/", "_")
@@ -378,12 +339,9 @@ def emit_verdict(verdict: dict, payload: dict | None) -> Path:
     else:
         # Sweep path
         out_dir = SWEEP_ROOT / verdict["target"]["ref"]
-    out_dir.mkdir(parents=True, exist_ok=True)
+
     out_path = out_dir / f"{verdict['verdict_id']}.json"
-    with open(out_path, "w", encoding="utf-8") as f:
-        json.dump(verdict, f, indent=2)
-        f.write("\n")
-    return out_path
+    return kit.write_artifact(out_path, verdict, schema="contracts/qa-verdict")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/test_qa_tribunal_emit.py
+++ b/scripts/test_qa_tribunal_emit.py
@@ -1,0 +1,116 @@
+import json
+import tempfile
+import unittest
+import unittest.mock as mock
+import os
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import qa_tribunal_emit as q
+import demerzel_kit as kit
+
+ROOT = Path(__file__).resolve().parents[1]
+
+class TestTribunalBuilders(unittest.TestCase):
+    def test_derive_blast_radius_single_layer(self):
+        paths = ["docs/plans/my-plan.md"]
+        blast = q.derive_blast_radius(paths)
+        self.assertEqual(blast["layers_touched"], ["docs"])
+        self.assertEqual(blast["invariants_at_risk"], [])
+        self.assertAlmostEqual(blast["estimated_blast_score"], 0.2)
+
+    def test_derive_blast_radius_multiple_layers(self):
+        paths = ["docs/plans/my-plan.md", "ReactComponents/button.tsx", "Common/GA.Core/Program.cs"]
+        blast = q.derive_blast_radius(paths)
+        self.assertCountEqual(blast["layers_touched"], ["docs", "frontend", "core"])
+        self.assertEqual(blast["invariants_at_risk"], [])
+        self.assertAlmostEqual(blast["estimated_blast_score"], 0.6)
+
+    def test_derive_blast_radius_invariants(self):
+        paths = ["Common/GA.Business.ML/Embeddings/some.cs", "docs/contracts/something.schema.json"]
+        blast = q.derive_blast_radius(paths)
+        self.assertCountEqual(blast["layers_touched"], ["ai_ml", "docs"])
+        self.assertCountEqual(blast["invariants_at_risk"], ["optick.dim=240", "schema-locked-contract"])
+        self.assertAlmostEqual(blast["estimated_blast_score"], 0.7)  # 2 layers (0.4) + invariant (0.3)
+
+
+class TestTribunalSeam(unittest.TestCase):
+    def _fake_gh_json(self, args, **kwargs):
+        if args[:2] == ["api", "repos/GuitarAlchemist/Demerzel/commits/abcdef1"]:
+            return {"sha": "abcdef1"}
+        if args[:2] == ["api", "repos/GuitarAlchemist/Demerzel/pulls/123"]:
+            return {"head": {"sha": "abcdef1", "repo": {"full_name": "GuitarAlchemist/Demerzel"}}}
+        return None
+
+    def _fake_gh_text(self, args, **kwargs):
+        if args[:2] == ["pr", "diff"]:
+            return "docs/contracts/my.schema.json\nReactComponents/comp.tsx"
+        return ""
+
+    def test_main_sweep_writes_valid_schema(self):
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(q, "SWEEP_ROOT", Path(d)):
+                # Mock kit.now_iso to control output if needed, but not strictly necessary
+                # Run the sweep
+                res = q.main(["--sweep"])
+                self.assertEqual(res, 0)
+
+                # Check output exists
+                files = list(Path(d).glob("*/*.json"))
+                self.assertEqual(len(files), 1)
+
+                on_disk = json.loads(files[0].read_text(encoding="utf-8"))
+                self.assertEqual(on_disk["target"]["kind"], "scheduled_sweep")
+
+                try:
+                    import jsonschema
+                    schema = json.loads((ROOT / "schemas/contracts/qa-verdict.schema.json").read_text(encoding="utf-8"))
+                    jsonschema.validate(on_disk, schema)
+                except ImportError:
+                    pass
+
+    def test_main_dispatch_payload_writes_valid_schema(self):
+        payload = {
+            "action": "repository_dispatch",
+            "client_payload": {
+                "repo": "GuitarAlchemist/Demerzel",
+                "pr": 123,
+                "head_sha": "abcdef1",
+                "base_sha": "1234567890abcdef",
+                "idempotency_key": "some-key"
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as d_env, tempfile.TemporaryDirectory() as d_out:
+            event_path = Path(d_env) / "event.json"
+            event_path.write_text(json.dumps(payload))
+
+            with mock.patch.dict(os.environ, {"GITHUB_EVENT_PATH": str(event_path)}), \
+                 mock.patch.object(q.kit, "gh_json", self._fake_gh_json), \
+                 mock.patch.object(q.kit, "gh_text", self._fake_gh_text), \
+                 mock.patch.object(q, "VERDICT_ROOT", Path(d_out)):
+
+                res = q.main([])
+                self.assertEqual(res, 0)
+
+                files = list(Path(d_out).glob("*/*/*.json"))
+                self.assertEqual(len(files), 1)
+
+                on_disk = json.loads(files[0].read_text(encoding="utf-8"))
+                self.assertEqual(on_disk["target"]["kind"], "pull_request")
+                self.assertEqual(on_disk["target"]["repo"], "GuitarAlchemist/Demerzel")
+                self.assertEqual(on_disk["target"]["ref"], "pr/123")
+
+                self.assertCountEqual(on_disk["blast_radius"]["layers_touched"], ["docs", "frontend"])
+                self.assertCountEqual(on_disk["blast_radius"]["invariants_at_risk"], ["schema-locked-contract"])
+
+                try:
+                    import jsonschema
+                    schema = json.loads((ROOT / "schemas/contracts/qa-verdict.schema.json").read_text(encoding="utf-8"))
+                    jsonschema.validate(on_disk, schema)
+                except ImportError:
+                    pass
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replaces custom gh subprocess invocations, file generation, and timestamp methods with demerzel_kit standard primitives.

- Removes unused subprocess, datetime, jsonschema imports.
- Replaces custom file path creation and json writing with kit.write_artifact.
- Replaces `_gh_api` and `changed_files` gh CLI commands with `kit.gh_json` and `kit.gh_text`.
- Adds comprehensive pure-logic tests and an offline seam IO test.

Fixes #406

---
*PR created automatically by Jules for task [6028966670826188021](https://jules.google.com/task/6028966670826188021) started by @spareilleux*