### PR TITLE
fix(tribunal): grant id-token write so claude-code-action can mint its token

### DIFF
--- a/.github/workflows/tribunal-panel.yml
+++ b/.github/workflows/tribunal-panel.yml
@@ -30,6 +30,12 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  # claude-code-action@v1 exchanges an OIDC token for its GitHub token;
+  # without this the action dies with "Unable to get
+  # ACTIONS_ID_TOKEN_REQUEST_URL" before the panel even starts — observed
+  # failing on every sibling-pr-opened dispatch (qa-tribunal.yml passes,
+  # this lane silently never produced a verdict).
+  id-token: write
 
 concurrency:
   group: tribunal-panel-${{ github.event.client_payload.repo || inputs.repo }}-${{ github.event.client_payload.pr || inputs.pr }}


### PR DESCRIPTION
## What Changed and Why

One-line permission fix on `.github/workflows/tribunal-panel.yml`: adds `id-token: write` (with a comment explaining why it is required).

The multi-persona tribunal panel has been failing on **every** `sibling-pr-opened` dispatch with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL` — `claude-code-action@v1` exchanges an OIDC token for its GitHub token, and this workflow only granted `contents: write` + `pull-requests: read`. The sibling `qa-tribunal.yml` lane was green, so the fleet looked healthy while this lane never produced a single verdict (`state/quality/verdicts/` always empty at upload). Same silent-failure family as the 2026-07-02 delegation-chain fixes in ga. Confirmed on runs 28606299149, 28606292077 (2026-07-02, ga#503 / tars#188 dispatches) and prior runs back to at least 04:56 UTC.

Resolves # — no tracking issue; found during a delegation audit of today's Jarvis Track PR dispatches.

---

## ERGOL: Who Benefits?

- **Consumer(s):** all (ga / tars / ix sibling PRs dispatch into this lane)
- **Agent role:** QA tribunal panel (multi-persona)
- **Goal enabled:** the panel can actually run and emit verdicts — until now it died before its first step on every invocation.

---

## Constitutional Alignment

- [x] Article 7 — Auditability (the lane now produces the verdict artifacts it claims to)
- [x] Article 8 — Observability (removes a silent always-red limb that never surfaced)
- [x] Article 9 — Bounded Autonomy (`id-token: write` is the minimum additional grant the action needs; nothing else widened)

---

## Tests

- [ ] Behavioral test added or updated in `tests/behavioral/` (not a persona change)
- [x] Schema validation passes (no artifact change; workflow YAML parses)
- [x] No runtime code introduced (CI configuration only)
- [x] No secrets committed

---

## MetaSync

- [x] No count changes
- [x] No new artifact type

---

## Checklist

- [x] Conventional commit messages (`fix:`)
- [x] Artifacts placed in the correct directory
- [x] Constitution amendments include written justification (none)
- [x] Cross-repo impact noted: none required in ix/tars/ga — their dispatch side is unchanged; the next `sibling-pr-opened` will exercise the fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvEdT41S77Lnm6dLBMHJSW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvEdT41S77Lnm6dLBMHJSW)_