### PR TITLE
feat(tribunal): pin multi-persona panel to claude-sonnet-5

### DIFF
--- a/.github/workflows/tribunal-panel.yml
+++ b/.github/workflows/tribunal-panel.yml
@@ -79,7 +79,7 @@ jobs:
             It fetches the PR diff via gh, fans it to the persona panel, and writes a
             schema-valid verdict under state/quality/verdicts/. Do not merge or comment
             on the PR — only emit the verdict file.
-          claude_args: '--allowed-tools Bash(gh pr:*),Bash(gh api:*),Bash(python:*),Read,Write'
+          claude_args: '--model claude-sonnet-5 --allowed-tools Bash(gh pr:*),Bash(gh api:*),Bash(python:*),Read,Write'
 
       - name: Commit verdict if produced
         shell: bash


### PR DESCRIPTION
## What Changed and Why

One `claude_args` line in `.github/workflows/tribunal-panel.yml`: the panel now runs on `--model claude-sonnet-5` instead of riding `claude-code-action`'s default. Now that the lane actually runs (#652), Sonnet 5 makes N parallel personas affordable on the subscription quota; escalation to a heavier model stays reserved for contested verdicts, per the existing escalation semantics.

Resolves # — follow-up to #652, part of the ecosystem-wide Sonnet 5 rollout (ga#504, tars#189).

---

## ERGOL: Who Benefits?

- **Consumer(s):** all (ga / tars / ix sibling PRs dispatch into this lane)
- **Agent role:** QA tribunal panel (multi-persona)
- **Goal enabled:** the full persona fan-out runs at a sustainable cost per dispatch, so the panel can stay always-on.

---

## Constitutional Alignment

- [x] Article 4 — Proportionality (model tier matched to the task; heavier models reserved for contested verdicts)
- [x] Article 9 — Bounded Autonomy (explicit pin replaces an implicit default — the lane's behavior is now declared, not inherited)

---

## Tests

- [ ] Behavioral test added or updated in `tests/behavioral/` (not a persona change)
- [x] Schema validation passes (workflow YAML parses; verdict schema untouched)
- [x] No runtime code introduced (CI configuration only)
- [x] No secrets committed

---

## MetaSync

- [x] No count changes
- [x] No new artifact type

---

## Checklist

- [x] Conventional commit messages (`feat:`)
- [x] Artifacts placed in the correct directory
- [x] Constitution amendments include written justification (none)
- [x] Cross-repo impact noted: none — the dispatch side in ga/tars/ix is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvEdT41S77Lnm6dLBMHJSW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvEdT41S77Lnm6dLBMHJSW)_