### PR TITLE
fix(self-improvement): tolerate zero-match gaps

### DIFF
--- a/.github/scripts/count_matching_files.sh
+++ b/.github/scripts/count_matching_files.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+count_matching_files() {
+  local pattern=$1
+  shift
+
+  # grep exits 1 when no file matches. That is valid scanner data (a zero
+  # reference count), not a workflow failure under `set -o pipefail`.
+  grep -rl -- "$pattern" "$@" 2>/dev/null | wc -l || true
+}
+
+main() {
+  if [[ $# -lt 2 ]]; then
+    echo "usage: count_matching_files.sh PATTERN PATH..." >&2
+    return 2
+  fi
+
+  count_matching_files "$@"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/workflows/demerzel-self-improvement.yml
+++ b/.github/workflows/demerzel-self-improvement.yml
@@ -109,7 +109,7 @@ jobs:
           # Gap 2: Policies not referenced in any constitution or persona
           for pol in policies/*.yaml; do
             POLNAME=$(basename "$pol" .yaml)
-            REFS=$(grep -rl "$POLNAME" constitutions/ personas/ contracts/ 2>/dev/null | wc -l)
+            REFS=$(bash .github/scripts/count_matching_files.sh "$POLNAME" constitutions/ personas/ contracts/)
             if [ "$REFS" -eq 0 ]; then
               GAPS="${GAPS}\n- **Orphan policy:** \`$POLNAME\` is not referenced by any constitution, persona, or contract"
               GAP_COUNT=$((GAP_COUNT + 1))
@@ -119,7 +119,7 @@ jobs:
           # Gap 3: Schemas without examples
           for schema in schemas/contracts/*.json; do
             SNAME=$(basename "$schema" .json)
-            EXAMPLES=$(grep -rl "$SNAME" examples/ 2>/dev/null | wc -l)
+            EXAMPLES=$(bash .github/scripts/count_matching_files.sh "$SNAME" examples/)
             if [ "$EXAMPLES" -eq 0 ]; then
               GAPS="${GAPS}\n- **Missing example:** Schema \`$SNAME\` has no example data file"
               GAP_COUNT=$((GAP_COUNT + 1))

--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get install -y bats shellcheck
 
       - name: Shellcheck the extracted scripts
-        run: shellcheck .github/scripts/llm_call.sh .github/scripts/post_discussion.sh
+        run: shellcheck .github/scripts/llm_call.sh .github/scripts/post_discussion.sh .github/scripts/count_matching_files.sh
 
       - name: Run bats tests
         run: bats tests/bats

--- a/tests/bats/count_matching_files.bats
+++ b/tests/bats/count_matching_files.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+# Regression coverage for the self-improvement scanner's zero-match boundary.
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../../.github/scripts/count_matching_files.sh"
+  mkdir -p "$BATS_TEST_TMPDIR/fixture"
+  printf 'references known-policy\n' > "$BATS_TEST_TMPDIR/fixture/referenced.txt"
+}
+
+@test "zero references are scanner data, not a pipefail error" {
+  run bash "$SCRIPT" orphan-policy "$BATS_TEST_TMPDIR/fixture"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+@test "matching references are counted" {
+  run bash "$SCRIPT" known-policy "$BATS_TEST_TMPDIR/fixture"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}
+
+@test "missing arguments fail with usage" {
+  run bash "$SCRIPT" known-policy
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"usage:"* ]]
+}


### PR DESCRIPTION
## What changed

- route zero-match reference counts through a pipefail-safe helper
- use the helper for orphan-policy and missing-schema-example detection
- add offline Bats coverage for zero, positive, and invalid-argument boundaries
- include the helper in shellcheck CI

## Root cause

The scanner runs with `bash -e -o pipefail`. A legitimate zero-match `grep` returns exit code 1, so the first orphan policy (`agent-evaluation.policy` in the latest failed run) terminated the `Detect structural gaps` step before the gap could be recorded.

## Verification

- extracted `Detect structural gaps` workflow step: passes, reports 38 gaps
- `python -m unittest discover -s scripts -p 'test_*.py'`: 83 passed
- `python scripts/validate_governance.py`: passed
- `python scripts/build_manifest.py`: passed with no generated drift
- workflow YAML parse: passed
- `pwsh scripts/verify.ps1`: blocked by pre-existing PowerShell JSON conversion failure in `tree-sitter-ixql/package-lock.json` (empty property name)

## Post-merge canary

```powershell
gh workflow run demerzel-self-improvement.yml --repo GuitarAlchemist/Demerzel --ref master
```

Fixes #702