### PR TITLE
fix(loop-health): require live proof for every scheduled loop

### DIFF
--- a/.github/loop-health.yml
+++ b/.github/loop-health.yml
@@ -1,37 +1,21 @@
-# Loop-health registry — the single source of truth for the universal
-# ecosystem-freshness monitor (scripts/ecosystem_freshness.py, schema
-# schemas/loop-health.schema.json).
-#
-# Every SCHEDULED workflow must be accounted for here: either as a producer
-# `loop` (declaring a proof adapter, allowed_silence, or a bounded disable) or
-# as a `monitor` (a freshness guard, not a producer — self-excluded). A new
-# scheduled workflow that appears in neither is reported as `unregistered` and
-# turns the board red, so liveness coverage can never silently regress.
-#
-# Classification was harvested from repository evidence on 2026-07-18, not
-# declared by fiat:
-#   - quality-trend: state/quality-trend/*.jsonl committed daily -> proof (fresh).
-#   - ideation: reads governance state to generate ideas but commits NO trace ->
-#     silent_green (its liveness is unprovable — the exact failure mode this
-#     monitor exists to surface; see note).
-#   - seldon-plan: committed state dead since 2026-03-23 (117d) -> intentional,
-#     bounded disable.
-#   - the remaining loops deliver value externally (Discussions / Issues /
-#     Discord / CI artifacts / Jules delegation) and by design leave no committed
-#     repo evidence -> allowed_silence, with the accepted gap recorded per entry.
+# Universal loop-health registry. Every scheduled producer must prove that it
+# ran successfully; there is no unbounded "allowed silence" state. Producers
+# whose value lands outside git use the read-only GitHub Actions workflow-run
+# adapter, which verifies the latest completed scheduled run and conclusion.
 version: 1
 default_branch: master
 
-# Freshness/health monitors — scheduled, but NOT producers. Self-excluded from
-# coverage so the monitor never flags itself (or its sibling guard).
+# Exclusion is deliberately constrained in scripts/ecosystem_freshness.py and
+# the schema to these two freshness guards. A producer cannot self-exempt merely
+# by adding its filename here.
 monitors:
   - ecosystem-freshness.yml
   - demerzel-quality-trend-freshness.yml
 
 loops:
-  # ── Proven-fresh: committed state carries a timestamp we can age ──────────
   - workflow: demerzel-quality-trend.yml
-    schedule: '0 12 * * *'
+    schedule:
+      - '0 12 * * *'
     status: active
     proof:
       adapter: state_glob
@@ -39,103 +23,94 @@ loops:
       timestamp_field: timestamp
       max_stale_days: 3
     note: >-
-      Deterministic per-artifact deltas committed nightly by scripts/quality_trend.py.
-      Feeder is daily, so >3d stale means the feeder died.
+      Deterministic evidence is committed daily. More than three days without
+      state proves the feeder has died even if its workflow looked green.
 
-  # ── Silent-green: registered & active, but leaves no discoverable evidence ─
-  - workflow: demerzel-ideation.yml
-    schedule: '47 13 * * 1,3,5'
+  - workflow: demerzel-capability-expansion.yml
+    schedule:
+      - '37 15 * * 1'
     status: active
     proof:
-      adapter: state_glob
-      glob: state/ideation/*.json
-      timestamp_field: created_at
-      max_stale_days: 7
-    note: >-
-      Ideation reads governance state to generate ideas but currently commits no
-      trace, so we cannot tell a live run from a dead one. Remediation: have the
-      workflow commit its ideation digest to state/ideation/<date>.json, OR make
-      a conscious decision to reclassify this as allowed_silence.
-
-  # ── Intentionally disabled: bounded allowlist (expiry forces re-evaluation) ─
-  - workflow: seldon-plan.yml
-    schedule: '0 6 * * *'
-    status: disabled
-    disabled:
-      reason: >-
-        Autonomous research scheduler paused; committed state
-        (state/seldon-plan/) has been dead since 2026-03-23 (verified 2026-07-18).
-      by: codex-handoff (state/handoffs/codex-option-1.md)
-      since: '2026-07-18'
-      until: '2026-10-16'
-    note: >-
-      Time-bounded allowlist. At `until`, either revive the loop (restore a proof
-      adapter) or re-authorize the pause with a fresh window.
-
-  # ── Allowed silence: value delivered externally; no committed evidence by design
-  - workflow: demerzel-capability-expansion.yml
-    schedule: '37 15 * * 1'
-    status: active
-    allowed_silence: true
-    reason: >-
-      Posts a capability-expansion Issue + Discussion; leaves no committed repo
-      evidence. Notification loop — silence is by design.
+      adapter: workflow_run
+      max_stale_days: 10
 
   - workflow: demerzel-discussion-lifecycle.yml
-    schedule: '47 14 * * 1-5'
+    schedule:
+      - '47 14 * * 1-5'
     status: active
-    allowed_silence: true
-    reason: >-
-      Event-driven (discussion / discussion_comment); the weekday cron only scans
-      for stale discussions and promotes actionable ones to Issues. No committed
-      state.
+    proof:
+      adapter: workflow_run
+      max_stale_days: 3
+
+  - workflow: demerzel-ideation.yml
+    schedule:
+      - '47 13 * * 1,3,5'
+    status: active
+    proof:
+      adapter: workflow_run
+      max_stale_days: 4
 
   - workflow: demerzel-self-improvement.yml
-    schedule: '17 15 * * 0'
+    schedule:
+      - '17 15 * * 0'
     status: active
-    allowed_silence: true
-    reason: >-
-      Posts a self-improvement Issue + Discussion harvested from the manifest;
-      leaves no committed repo evidence.
+    proof:
+      adapter: workflow_run
+      max_stale_days: 10
 
   - workflow: demerzel-showcase.yml
-    schedule: '7 14 1-7,15-21 * 1'
+    schedule:
+      - '7 14 1-7,15-21 * 1'
     status: active
-    allowed_silence: true
-    reason: >-
-      Posts a governance showcase Discussion; notification-only, no committed
-      state.
+    proof:
+      adapter: workflow_run
+      max_stale_days: 14
 
   - workflow: ga-chatbot-discussions.yml
-    schedule: '*/15 * * * *'
+    schedule:
+      - '*/15 * * * *'
     status: active
-    allowed_silence: true
-    reason: >-
-      Answers user Discussions (event-driven); the 15-min cron posts occasional
-      compounding notes. Output is external comments, not committed state.
+    proof:
+      adapter: workflow_run
+      max_stale_days: 1
 
   - workflow: jules-auto-delegate.yml
-    schedule: '*/30 * * * *'
+    schedule:
+      - '*/30 * * * *'
     status: active
-    allowed_silence: true
-    reason: >-
-      Delegates labelled work to the Jules external agent (respects
-      governance/state/afk-halt.json); its product is off-repo delegation, not
-      committed state.
+    proof:
+      adapter: workflow_run
+      max_stale_days: 1
 
   - workflow: qa-tribunal.yml
-    schedule: '0 9 * * *'
+    schedule:
+      - '0 9 * * *'
     status: active
-    allowed_silence: true
-    reason: >-
-      Emits QA verdicts as CI upload-artifacts + per-PR files; the daily sweep is
-      not committed to the default branch, so there is no committed evidence to
-      age.
+    proof:
+      adapter: workflow_run
+      max_stale_days: 3
+
+  # This workflow is actually scheduled five times per day. It is therefore
+  # active, not "intentionally disabled". Its current failed scheduled run is
+  # deliberately red. A future bounded disable must remove the cron schedule
+  # and declare disabled.verification: schedule_absent.
+  - workflow: seldon-plan.yml
+    schedule:
+      - '0 6 * * *'
+      - '0 10 * * *'
+      - '0 14 * * *'
+      - '0 18 * * *'
+      - '0 22 * * *'
+    status: active
+    proof:
+      adapter: workflow_run
+      max_stale_days: 1
 
   - workflow: streeling-daily.yml
-    schedule: '17 13 * * 5'
+    schedule:
+      - '17 13 * * 1-4'
+      - '17 13 * * 5'
     status: active
-    allowed_silence: true
-    reason: >-
-      Posts a weekly cross-repo harvest report Discussion; report is external, no
-      committed state.
+    proof:
+      adapter: workflow_run
+      max_stale_days: 3

--- a/.github/loop-health.yml
+++ b/.github/loop-health.yml
@@ -1,0 +1,141 @@
+# Loop-health registry — the single source of truth for the universal
+# ecosystem-freshness monitor (scripts/ecosystem_freshness.py, schema
+# schemas/loop-health.schema.json).
+#
+# Every SCHEDULED workflow must be accounted for here: either as a producer
+# `loop` (declaring a proof adapter, allowed_silence, or a bounded disable) or
+# as a `monitor` (a freshness guard, not a producer — self-excluded). A new
+# scheduled workflow that appears in neither is reported as `unregistered` and
+# turns the board red, so liveness coverage can never silently regress.
+#
+# Classification was harvested from repository evidence on 2026-07-18, not
+# declared by fiat:
+#   - quality-trend: state/quality-trend/*.jsonl committed daily -> proof (fresh).
+#   - ideation: reads governance state to generate ideas but commits NO trace ->
+#     silent_green (its liveness is unprovable — the exact failure mode this
+#     monitor exists to surface; see note).
+#   - seldon-plan: committed state dead since 2026-03-23 (117d) -> intentional,
+#     bounded disable.
+#   - the remaining loops deliver value externally (Discussions / Issues /
+#     Discord / CI artifacts / Jules delegation) and by design leave no committed
+#     repo evidence -> allowed_silence, with the accepted gap recorded per entry.
+version: 1
+default_branch: master
+
+# Freshness/health monitors — scheduled, but NOT producers. Self-excluded from
+# coverage so the monitor never flags itself (or its sibling guard).
+monitors:
+  - ecosystem-freshness.yml
+  - demerzel-quality-trend-freshness.yml
+
+loops:
+  # ── Proven-fresh: committed state carries a timestamp we can age ──────────
+  - workflow: demerzel-quality-trend.yml
+    schedule: '0 12 * * *'
+    status: active
+    proof:
+      adapter: state_glob
+      glob: state/quality-trend/*.jsonl
+      timestamp_field: timestamp
+      max_stale_days: 3
+    note: >-
+      Deterministic per-artifact deltas committed nightly by scripts/quality_trend.py.
+      Feeder is daily, so >3d stale means the feeder died.
+
+  # ── Silent-green: registered & active, but leaves no discoverable evidence ─
+  - workflow: demerzel-ideation.yml
+    schedule: '47 13 * * 1,3,5'
+    status: active
+    proof:
+      adapter: state_glob
+      glob: state/ideation/*.json
+      timestamp_field: created_at
+      max_stale_days: 7
+    note: >-
+      Ideation reads governance state to generate ideas but currently commits no
+      trace, so we cannot tell a live run from a dead one. Remediation: have the
+      workflow commit its ideation digest to state/ideation/<date>.json, OR make
+      a conscious decision to reclassify this as allowed_silence.
+
+  # ── Intentionally disabled: bounded allowlist (expiry forces re-evaluation) ─
+  - workflow: seldon-plan.yml
+    schedule: '0 6 * * *'
+    status: disabled
+    disabled:
+      reason: >-
+        Autonomous research scheduler paused; committed state
+        (state/seldon-plan/) has been dead since 2026-03-23 (verified 2026-07-18).
+      by: codex-handoff (state/handoffs/codex-option-1.md)
+      since: '2026-07-18'
+      until: '2026-10-16'
+    note: >-
+      Time-bounded allowlist. At `until`, either revive the loop (restore a proof
+      adapter) or re-authorize the pause with a fresh window.
+
+  # ── Allowed silence: value delivered externally; no committed evidence by design
+  - workflow: demerzel-capability-expansion.yml
+    schedule: '37 15 * * 1'
+    status: active
+    allowed_silence: true
+    reason: >-
+      Posts a capability-expansion Issue + Discussion; leaves no committed repo
+      evidence. Notification loop — silence is by design.
+
+  - workflow: demerzel-discussion-lifecycle.yml
+    schedule: '47 14 * * 1-5'
+    status: active
+    allowed_silence: true
+    reason: >-
+      Event-driven (discussion / discussion_comment); the weekday cron only scans
+      for stale discussions and promotes actionable ones to Issues. No committed
+      state.
+
+  - workflow: demerzel-self-improvement.yml
+    schedule: '17 15 * * 0'
+    status: active
+    allowed_silence: true
+    reason: >-
+      Posts a self-improvement Issue + Discussion harvested from the manifest;
+      leaves no committed repo evidence.
+
+  - workflow: demerzel-showcase.yml
+    schedule: '7 14 1-7,15-21 * 1'
+    status: active
+    allowed_silence: true
+    reason: >-
+      Posts a governance showcase Discussion; notification-only, no committed
+      state.
+
+  - workflow: ga-chatbot-discussions.yml
+    schedule: '*/15 * * * *'
+    status: active
+    allowed_silence: true
+    reason: >-
+      Answers user Discussions (event-driven); the 15-min cron posts occasional
+      compounding notes. Output is external comments, not committed state.
+
+  - workflow: jules-auto-delegate.yml
+    schedule: '*/30 * * * *'
+    status: active
+    allowed_silence: true
+    reason: >-
+      Delegates labelled work to the Jules external agent (respects
+      governance/state/afk-halt.json); its product is off-repo delegation, not
+      committed state.
+
+  - workflow: qa-tribunal.yml
+    schedule: '0 9 * * *'
+    status: active
+    allowed_silence: true
+    reason: >-
+      Emits QA verdicts as CI upload-artifacts + per-PR files; the daily sweep is
+      not committed to the default branch, so there is no committed evidence to
+      age.
+
+  - workflow: streeling-daily.yml
+    schedule: '17 13 * * 5'
+    status: active
+    allowed_silence: true
+    reason: >-
+      Posts a weekly cross-repo harvest report Discussion; report is external, no
+      committed state.

--- a/.github/workflows/ecosystem-freshness.yml
+++ b/.github/workflows/ecosystem-freshness.yml
@@ -1,66 +1,124 @@
 name: Ecosystem Freshness
 
-# Universal green != dead guard for EVERY scheduled producer loop. Generalizes
-# the per-loop quality-trend freshness guard: a silent "no news" loop is
-# indistinguishable from a dead one, which is exactly how state/quality-trend/
-# died unnoticed for 64 days. This runs INDEPENDENTLY of the producers and reads
-# .github/loop-health.yml to turn the board RED for any dead or silent-green loop
-# (and stay green + silent when all are healthy). It never remediates.
-#
-# This workflow is itself a MONITOR, not a producer: it is listed under
-# `monitors:` in the registry and self-excluded from coverage.
+# One independent daily guard for all scheduled producer loops. Evaluation is
+# read-only. A separate least-privilege job persists only the stable alert
+# artifact, so evaluated repository code never runs with contents:write.
 
 on:
   schedule:
-    # Weekly, Monday 13:15 UTC — just after the quality-trend freshness guard.
-    - cron: '15 13 * * 1'
+    - cron: '15 13 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: write
+concurrency:
+  group: ecosystem-freshness
+  cancel-in-progress: false
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  check:
+  evaluate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # Full history so git_log proof adapters see the default branch's dates.
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
-      - name: Install deps
-        run: pip install pyyaml jsonschema
+      - name: Install pinned evaluation dependencies
+        run: >-
+          python -m pip install --disable-pip-version-check
+          'PyYAML==6.0.3' 'jsonschema==4.21.1'
 
-      - name: Assert ecosystem freshness
+      - name: Evaluate every scheduled producer
         id: freshness
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          result_dir="$RUNNER_TEMP/ecosystem-freshness"
+          mkdir -p "$result_dir"
+          set +e
           python scripts/ecosystem_freshness.py \
             --json \
-            --alert-file state/loop-health/.freshness-alert.json
+            --alert-file "$result_dir/freshness-alert.json"
+          code=$?
+          set -e
+          printf '%s\n' "$code" > "$result_dir/exit-code.txt"
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
 
-      - name: Persist freshness alert state
-        if: steps.freshness.outcome == 'success' || steps.freshness.outcome == 'failure'
+      - name: Upload stable evaluation result
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ecosystem-freshness-result
+          path: ${{ runner.temp }}/ecosystem-freshness/
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Preserve red evaluation status
+        if: always()
+        env:
+          EXIT_CODE: ${{ steps.freshness.outputs.exit_code }}
         run: |
+          [[ "$EXIT_CODE" =~ ^[0-2]$ ]] || exit 2
+          exit "$EXIT_CODE"
+
+  persist:
+    if: always()
+    needs: evaluate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download evaluated result
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ecosystem-freshness-result
+          path: ${{ runner.temp }}/ecosystem-freshness-result
+
+      - name: Persist failure or verified recovery
+        if: always()
+        run: |
+          result_dir="$RUNNER_TEMP/ecosystem-freshness-result"
+          code_file="$result_dir/exit-code.txt"
+          source_alert="$result_dir/freshness-alert.json"
+          target_alert="state/loop-health/.freshness-alert.json"
+
+          test -f "$code_file"
+          code="$(tr -d '[:space:]' < "$code_file")"
+          [[ "$code" =~ ^[0-2]$ ]]
+          if [[ "$code" == "0" ]]; then
+            rm -f "$target_alert"
+          else
+            test -f "$source_alert"
+            mkdir -p "$(dirname "$target_alert")"
+            cp "$source_alert" "$target_alert"
+          fi
+
           git config user.name "Demerzel"
           git config user.email "demerzel@guitaralchemist.com"
-          git add -A state/loop-health/.freshness-alert.json || true
-          git diff --cached --quiet || {
-            if [[ -f state/loop-health/.freshness-alert.json ]]; then
-              message="alert(loop-health): dead or silent-green loop — ecosystem freshness tripped"
-            else
-              message="chore(loop-health): clear recovered ecosystem freshness alert"
-            fi
-            git commit -m "$message"
-            git pull --rebase || true
-            git push
-          }
+          git add -A "$target_alert"
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          if [[ -f "$target_alert" ]]; then
+            message="alert(loop-health): ecosystem freshness tripped"
+          else
+            message="chore(loop-health): clear recovered freshness alert"
+          fi
+          git commit -m "$message"
+          git pull --rebase
+          git push

--- a/.github/workflows/ecosystem-freshness.yml
+++ b/.github/workflows/ecosystem-freshness.yml
@@ -1,0 +1,66 @@
+name: Ecosystem Freshness
+
+# Universal green != dead guard for EVERY scheduled producer loop. Generalizes
+# the per-loop quality-trend freshness guard: a silent "no news" loop is
+# indistinguishable from a dead one, which is exactly how state/quality-trend/
+# died unnoticed for 64 days. This runs INDEPENDENTLY of the producers and reads
+# .github/loop-health.yml to turn the board RED for any dead or silent-green loop
+# (and stay green + silent when all are healthy). It never remediates.
+#
+# This workflow is itself a MONITOR, not a producer: it is listed under
+# `monitors:` in the registry and self-excluded from coverage.
+
+on:
+  schedule:
+    # Weekly, Monday 13:15 UTC — just after the quality-trend freshness guard.
+    - cron: '15 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Full history so git_log proof adapters see the default branch's dates.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: pip install pyyaml jsonschema
+
+      - name: Assert ecosystem freshness
+        id: freshness
+        run: |
+          python scripts/ecosystem_freshness.py \
+            --json \
+            --alert-file state/loop-health/.freshness-alert.json
+
+      - name: Persist freshness alert state
+        if: steps.freshness.outcome == 'success' || steps.freshness.outcome == 'failure'
+        run: |
+          git config user.name "Demerzel"
+          git config user.email "demerzel@guitaralchemist.com"
+          git add -A state/loop-health/.freshness-alert.json || true
+          git diff --cached --quiet || {
+            if [[ -f state/loop-health/.freshness-alert.json ]]; then
+              message="alert(loop-health): dead or silent-green loop — ecosystem freshness tripped"
+            else
+              message="chore(loop-health): clear recovered ecosystem freshness alert"
+            fi
+            git commit -m "$message"
+            git pull --rebase || true
+            git push
+          }

--- a/.github/workflows/governance-validate.yml
+++ b/.github/workflows/governance-validate.yml
@@ -84,8 +84,9 @@ jobs:
 
       # jsonschema enables the validate()/write_artifact() seam in demerzel_kit;
       # without it those tests skip rather than fail (graceful degradation).
+      # pyyaml is required by test_ecosystem_freshness (registry parsing).
       - name: Install deps
-        run: pip install jsonschema
+        run: pip install jsonschema pyyaml
 
       # The scripts/ emitters are the operational code; demerzel_kit makes their
       # gh/filesystem calls an injectable seam so convene() et al. are testable

--- a/.github/workflows/governance-validate.yml
+++ b/.github/workflows/governance-validate.yml
@@ -13,6 +13,9 @@ on:
       - 'README.md'
       - 'governance-manifest.json'
       - 'scripts/**'
+      - '.github/loop-health.yml'
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
       - '.github/workflows/governance-validate.yml'
   pull_request:
     paths:
@@ -26,6 +29,9 @@ on:
       - 'README.md'
       - 'governance-manifest.json'
       - 'scripts/**'
+      - '.github/loop-health.yml'
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ Demerzel/
 | Personas | 17 | `personas/*.persona.yaml` |
 | Policies | 45 | `policies/*.yaml` |
 | Grammars | 20 | `grammars/*.ebnf` |
-| Schemas | 42 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
+| Schemas | 43 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
 | Behavioral tests | 115 | `tests/behavioral/*.md` |
 | Skills | 69 | `.claude/skills/*/` |
 | Streeling departments | 23 | `state/streeling/departments/*.department.json` |
 | Course tracks | 21 | `state/streeling/courses/*/` |
 | IxQL pipelines | 23 | `pipelines/*.ixql` |
-| GitHub workflows | 26 | `.github/workflows/*.yml` |
+| GitHub workflows | 27 | `.github/workflows/*.yml` |
 
 ## Key concepts
 

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -10,11 +10,11 @@
     "persona": 17,
     "pipeline": 23,
     "policy": 45,
-    "schema": 42,
+    "schema": 43,
     "seldon_schema": 7,
     "skill": 69,
     "streeling_schema": 1,
-    "workflow": 26
+    "workflow": 27
   },
   "inventory": {
     "constitution": [
@@ -449,6 +449,10 @@
       {
         "name": "hexavalent-distribution.schema",
         "path": "schemas/hexavalent-distribution.schema.json"
+      },
+      {
+        "name": "loop-health.schema",
+        "path": "schemas/loop-health.schema.json"
       },
       {
         "name": "loop-state.schema",
@@ -1291,6 +1295,10 @@
       {
         "name": "demerzel-wiki-cross-repo",
         "path": ".github/workflows/demerzel-wiki-cross-repo.yml"
+      },
+      {
+        "name": "ecosystem-freshness",
+        "path": ".github/workflows/ecosystem-freshness.yml"
       },
       {
         "name": "ga-chatbot-discussions",

--- a/schemas/loop-health.schema.json
+++ b/schemas/loop-health.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "loop-health.schema.json",
+  "title": "Loop Health Registry",
+  "description": "Universal ecosystem-freshness registry: declares, per scheduled producer workflow, how its liveness is proven (proof adapter), that its silence is intentional (allowed_silence), or that it is deliberately disabled for a bounded window (disabled). The ecosystem-freshness monitor reads this to turn the board red for any dead or silent-green loop. See scripts/ecosystem_freshness.py.",
+  "type": "object",
+  "required": ["version", "loops"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "const": 1,
+      "description": "Registry schema version."
+    },
+    "default_branch": {
+      "type": "string",
+      "description": "Branch whose commit history is authoritative for git_log proof adapters (default-branch evidence). Defaults to 'master' when omitted.",
+      "minLength": 1
+    },
+    "monitors": {
+      "type": "array",
+      "description": "Scheduled workflows that are freshness/health MONITORS, not producers. Self-excluded from producer coverage so the monitor never flags itself as unregistered.",
+      "items": { "$ref": "#/definitions/workflowFile" },
+      "uniqueItems": true
+    },
+    "loops": {
+      "type": "array",
+      "description": "One entry per scheduled producer workflow. Each entry declares exactly one of: proof, allowed_silence, or disabled.",
+      "items": { "$ref": "#/definitions/loop" }
+    }
+  },
+  "definitions": {
+    "workflowFile": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._-]+\\.ya?ml$",
+      "description": "Bare workflow filename under .github/workflows/, e.g. demerzel-ideation.yml."
+    },
+    "loop": {
+      "type": "object",
+      "required": ["workflow", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "workflow": { "$ref": "#/definitions/workflowFile" },
+        "schedule": {
+          "type": "string",
+          "description": "Harvested cron expression (documentation/identity; not re-derived by the monitor)."
+        },
+        "status": {
+          "enum": ["active", "disabled"],
+          "description": "active loops must carry proof or allowed_silence; disabled loops must carry a disabled block."
+        },
+        "proof": { "$ref": "#/definitions/proof" },
+        "allowed_silence": {
+          "type": "boolean",
+          "description": "When true, the loop legitimately leaves no committed repo evidence (it delivers value externally, e.g. posting a Discussion). Its silence is neutral, not silent-green. Requires a reason."
+        },
+        "disabled": { "$ref": "#/definitions/disabled" },
+        "reason": {
+          "type": "string",
+          "description": "Human justification (required for allowed_silence entries; greppable acceptance of the monitoring gap)."
+        },
+        "note": {
+          "type": "string",
+          "description": "Free-form note (e.g. the remediation that would let a silent-green loop graduate to a proof adapter)."
+        }
+      }
+    },
+    "proof": {
+      "type": "object",
+      "required": ["adapter", "max_stale_days"],
+      "additionalProperties": false,
+      "description": "How the loop proves it is alive from default-branch repository evidence.",
+      "properties": {
+        "adapter": {
+          "enum": ["state_glob", "git_log"],
+          "description": "state_glob: newest timestamp inside committed JSON/JSONL state files. git_log: last commit touching a path on the default branch (for commit-only-on-change loops)."
+        },
+        "glob": {
+          "type": "string",
+          "description": "state_glob only: repo-relative glob of committed state files."
+        },
+        "timestamp_field": {
+          "type": "string",
+          "description": "state_glob only: the field carrying an ISO-8601 timestamp in each record (top-level object, array element, or JSONL line)."
+        },
+        "path": {
+          "type": "string",
+          "description": "git_log only: repo-relative path whose last commit dates the loop."
+        },
+        "max_stale_days": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Freshness threshold. Age strictly greater than this many days is stale."
+        }
+      }
+    },
+    "disabled": {
+      "type": "object",
+      "required": ["reason", "until"],
+      "additionalProperties": false,
+      "description": "Time-bounded intentional-disable allowlist. Past 'until' the entry is expired and the board turns red so the pause cannot be forgotten.",
+      "properties": {
+        "reason": { "type": "string", "minLength": 1 },
+        "by": { "type": "string", "description": "Who authorized the disable." },
+        "since": {
+          "type": "string",
+          "format": "date",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "until": {
+          "type": "string",
+          "format": "date",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "description": "Date (inclusive) the disable remains valid through. After this date the entry is an expired disable (red)."
+        }
+      }
+    }
+  }
+}

--- a/schemas/loop-health.schema.json
+++ b/schemas/loop-health.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "$id": "loop-health.schema.json",
   "title": "Loop Health Registry",
-  "description": "Universal ecosystem-freshness registry: declares, per scheduled producer workflow, how its liveness is proven (proof adapter), that its silence is intentional (allowed_silence), or that it is deliberately disabled for a bounded window (disabled). The ecosystem-freshness monitor reads this to turn the board red for any dead or silent-green loop. See scripts/ecosystem_freshness.py.",
+  "description": "Universal ecosystem-freshness registry: every scheduled producer must prove liveness or be deliberately disabled for a bounded, mechanically verified window. The monitor turns the board red for dead, failed, stale, activation-mismatched, or unregistered loops.",
   "type": "object",
   "required": ["version", "loops"],
   "additionalProperties": false,
@@ -18,13 +18,18 @@
     },
     "monitors": {
       "type": "array",
-      "description": "Scheduled workflows that are freshness/health MONITORS, not producers. Self-excluded from producer coverage so the monitor never flags itself as unregistered.",
-      "items": { "$ref": "#/definitions/workflowFile" },
+      "description": "Approved freshness monitors, not producers. Runtime validation constrains this list to the two known guard workflows so arbitrary producers cannot exempt themselves.",
+      "items": {
+        "enum": [
+          "ecosystem-freshness.yml",
+          "demerzel-quality-trend-freshness.yml"
+        ]
+      },
       "uniqueItems": true
     },
     "loops": {
       "type": "array",
-      "description": "One entry per scheduled producer workflow. Each entry declares exactly one of: proof, allowed_silence, or disabled.",
+      "description": "One entry per scheduled producer workflow. Each entry declares exactly one of proof or bounded disabled state.",
       "items": { "$ref": "#/definitions/loop" }
     }
   },
@@ -41,28 +46,40 @@
       "properties": {
         "workflow": { "$ref": "#/definitions/workflowFile" },
         "schedule": {
-          "type": "string",
-          "description": "Harvested cron expression (documentation/identity; not re-derived by the monitor)."
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Exact cron expressions expected in the workflow. Runtime validation rejects drift between declaration and live YAML."
         },
         "status": {
           "enum": ["active", "disabled"],
-          "description": "active loops must carry proof or allowed_silence; disabled loops must carry a disabled block."
+          "description": "Active loops must carry proof and matching cron declarations; disabled loops must carry a bounded block and have no live cron schedule."
         },
         "proof": { "$ref": "#/definitions/proof" },
-        "allowed_silence": {
-          "type": "boolean",
-          "description": "When true, the loop legitimately leaves no committed repo evidence (it delivers value externally, e.g. posting a Discussion). Its silence is neutral, not silent-green. Requires a reason."
-        },
         "disabled": { "$ref": "#/definitions/disabled" },
-        "reason": {
-          "type": "string",
-          "description": "Human justification (required for allowed_silence entries; greppable acceptance of the monitoring gap)."
-        },
         "note": {
           "type": "string",
           "description": "Free-form note (e.g. the remediation that would let a silent-green loop graduate to a proof adapter)."
         }
-      }
+      },
+      "oneOf": [
+        {
+          "properties": { "status": { "const": "active" } },
+          "required": ["schedule", "proof"],
+          "not": { "required": ["disabled"] }
+        },
+        {
+          "properties": { "status": { "const": "disabled" } },
+          "required": ["disabled"],
+          "not": {
+            "anyOf": [
+              { "required": ["schedule"] },
+              { "required": ["proof"] }
+            ]
+          }
+        }
+      ]
     },
     "proof": {
       "type": "object",
@@ -71,8 +88,8 @@
       "description": "How the loop proves it is alive from default-branch repository evidence.",
       "properties": {
         "adapter": {
-          "enum": ["state_glob", "git_log"],
-          "description": "state_glob: newest timestamp inside committed JSON/JSONL state files. git_log: last commit touching a path on the default branch (for commit-only-on-change loops)."
+          "enum": ["state_glob", "git_log", "workflow_run"],
+          "description": "state_glob: newest timestamp in committed JSON/JSONL. git_log: last default-branch commit touching a path. workflow_run: latest completed scheduled GitHub Actions run must be recent and successful."
         },
         "glob": {
           "type": "string",
@@ -91,15 +108,29 @@
           "minimum": 0,
           "description": "Freshness threshold. Age strictly greater than this many days is stale."
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "adapter": { "const": "state_glob" } } },
+          "then": { "required": ["glob", "timestamp_field"] }
+        },
+        {
+          "if": { "properties": { "adapter": { "const": "git_log" } } },
+          "then": { "required": ["path"] }
+        }
+      ]
     },
     "disabled": {
       "type": "object",
-      "required": ["reason", "until"],
+      "required": ["reason", "until", "verification"],
       "additionalProperties": false,
       "description": "Time-bounded intentional-disable allowlist. Past 'until' the entry is expired and the board turns red so the pause cannot be forgotten.",
       "properties": {
         "reason": { "type": "string", "minLength": 1 },
+        "verification": {
+          "const": "schedule_absent",
+          "description": "Mechanical proof that the workflow has no cron schedule while disabled."
+        },
         "by": { "type": "string", "description": "Who authorized the disable." },
         "since": {
           "type": "string",

--- a/scripts/ecosystem_freshness.py
+++ b/scripts/ecosystem_freshness.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""Universal ecosystem-freshness monitor — one guard for every scheduled loop.
+
+`state/quality-trend/` died silently for 64 days because a "no news" feeder is
+indistinguishable from a dead one (green != alive). scripts/quality_trend.py got
+a dedicated per-loop freshness guard; this generalizes that guard to EVERY
+scheduled producer workflow so the board turns red for any dead or silent-green
+loop — and stays green (and silent) when they are all healthy.
+
+The registry (.github/loop-health.yml, schema schemas/loop-health.schema.json)
+declares, per loop, exactly one of:
+
+  * proof            — how the loop proves liveness from default-branch evidence
+                       (state_glob = newest timestamp in committed JSON/JSONL;
+                        git_log    = last commit touching a path on the default
+                        branch, for commit-only-on-change loops).
+  * allowed_silence  — the loop legitimately leaves no committed evidence (it
+                       delivers value externally, e.g. posting a Discussion);
+                       its silence is neutral, not a failure.
+  * disabled         — intentionally paused for a bounded window (`until`).
+
+Findings and exit codes (a producer with a real problem must fail CI):
+
+  0  every active loop is healthy or allowed-silent; disabled entries valid.
+  1  at least one: stale, silent_green, unregistered, malformed_proof,
+     expired_disable.
+  2  configuration or evidence-adapter failure (registry unreadable / invalid /
+     internally inconsistent; a proof adapter's machinery — e.g. git — failed).
+
+This monitor is a MONITOR, not a producer: it lists itself (and the other
+freshness guards) under `monitors:` so it never flags itself for coverage.
+
+Deterministic: findings are sorted by workflow name; the committable alert
+payload carries only stable fields (no ages/timestamps) so a steady red state
+does not churn commits.
+
+stdlib + PyYAML + jsonschema only. No wall-clock is read when --now is given.
+"""
+from __future__ import annotations
+
+import argparse
+import glob as globmod
+import json
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_REGISTRY = ".github/loop-health.yml"
+DEFAULT_WORKFLOWS_DIR = ".github/workflows"
+DEFAULT_SCHEMA = "schemas/loop-health.schema.json"
+DEFAULT_BRANCH = "master"
+
+for _stream in (sys.stdout, sys.stderr):  # Windows consoles default to cp1252.
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8")
+
+# Finding kinds grouped by the exit code they contribute.
+_EXIT2_KINDS = ("config_error", "adapter_error")
+_EXIT1_KINDS = (
+    "stale",
+    "silent_green",
+    "unregistered",
+    "malformed_proof",
+    "expired_disable",
+)
+# Everything else (healthy, allowed_silence, disabled) is exit 0.
+
+
+class ConfigError(Exception):
+    """Registry unreadable/invalid/inconsistent — maps to exit 2."""
+
+
+class AdapterError(Exception):
+    """A proof adapter's underlying machinery (e.g. git) failed — exit 2."""
+
+
+# ---------------------------------------------------------------------------
+# git seam (injectable so tests can force API failure / assert the branch ref)
+# ---------------------------------------------------------------------------
+
+def default_git_runner(args: list[str], cwd: Path) -> str:
+    """Run `git <args>` in cwd, returning stdout. Raises AdapterError on failure."""
+    import subprocess
+
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise AdapterError(
+            f"git {' '.join(args)} failed ({proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    return proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# time helpers
+# ---------------------------------------------------------------------------
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _age_days(newest: datetime, now: datetime) -> float:
+    return (now - newest).total_seconds() / 86400.0
+
+
+# ---------------------------------------------------------------------------
+# workflow enumeration (which scheduled producers exist on disk)
+# ---------------------------------------------------------------------------
+
+def _schedule_block(doc: dict):
+    """`on:` parses to the YAML 1.1 boolean True under PyYAML, so look under both."""
+    if not isinstance(doc, dict):
+        return None
+    on = doc.get("on")
+    if on is None:
+        on = doc.get(True)
+    if isinstance(on, dict):
+        return on.get("schedule")
+    return None
+
+
+def scheduled_workflows(workflows_dir: Path) -> list[str]:
+    """Bare filenames of every workflow that has at least one cron schedule."""
+    found: list[str] = []
+    for path in sorted(workflows_dir.glob("*.yml")) + sorted(
+        workflows_dir.glob("*.yaml")
+    ):
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError:
+            continue
+        sched = _schedule_block(doc)
+        if isinstance(sched, list) and any(
+            isinstance(e, dict) and e.get("cron") for e in sched
+        ):
+            found.append(path.name)
+    return sorted(found)
+
+
+# ---------------------------------------------------------------------------
+# proof adapters
+# ---------------------------------------------------------------------------
+
+def _iter_timestamps(path: Path, field: str):
+    """Yield ISO timestamp strings from a committed JSON or JSONL state file.
+
+    Raises ConfigError-free; a genuinely unparseable file yields the sentinel
+    ('__malformed__',) so the caller can distinguish "bad evidence" from "no
+    timestamp field".
+    """
+    text = path.read_text(encoding="utf-8")
+    stripped = text.strip()
+    if not stripped:
+        return
+    # Try whole-file JSON first (object or array); fall back to JSONL.
+    try:
+        doc = json.loads(stripped)
+    except json.JSONDecodeError:
+        malformed = True
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            malformed = False
+            if isinstance(row, dict) and row.get(field):
+                yield row[field]
+        if malformed:
+            yield "__malformed__"
+        return
+    records = doc if isinstance(doc, list) else [doc]
+    for row in records:
+        if isinstance(row, dict) and row.get(field):
+            yield row[field]
+
+
+def _eval_state_glob(proof: dict, now: datetime, repo_root: Path) -> tuple[str, str]:
+    glob_pat = proof.get("glob")
+    field = proof.get("timestamp_field")
+    if not glob_pat or not field:
+        raise ConfigError("state_glob proof requires 'glob' and 'timestamp_field'")
+    max_days = float(proof["max_stale_days"])
+
+    matches = sorted(
+        globmod.glob(str(repo_root / glob_pat), recursive=True)
+    )
+    if not matches:
+        return ("silent_green", "no committed evidence matches "
+                f"`{glob_pat}` (loop cannot prove it is alive)")
+
+    newest: datetime | None = None
+    saw_malformed = False
+    for m in matches:
+        for raw in _iter_timestamps(Path(m), field):
+            if raw == "__malformed__":
+                saw_malformed = True
+                continue
+            dt = _parse_iso(raw)
+            if dt and (newest is None or dt > newest):
+                newest = dt
+
+    if newest is None:
+        if saw_malformed:
+            return ("malformed_proof", f"`{glob_pat}` matched files that are not "
+                    "parseable JSON/JSONL")
+        return ("malformed_proof", f"`{glob_pat}` matched files but none carry a "
+                f"parseable `{field}` timestamp")
+
+    age = _age_days(newest, now)
+    if age > max_days:
+        return ("stale", f"newest `{glob_pat}` evidence is {age:.1f}d old "
+                f"(threshold {max_days:g}d)")
+    return ("healthy", f"fresh: newest evidence {age:.1f}d old "
+            f"(threshold {max_days:g}d)")
+
+
+def _eval_git_log(
+    proof: dict,
+    now: datetime,
+    repo_root: Path,
+    default_branch: str,
+    git_runner,
+) -> tuple[str, str]:
+    path = proof.get("path")
+    if not path:
+        raise ConfigError("git_log proof requires 'path'")
+    max_days = float(proof["max_stale_days"])
+
+    # Default-branch evidence: judge freshness from the default branch's history,
+    # not the working tree, so running on any branch reflects production reality.
+    out = git_runner(
+        ["log", "-1", "--format=%cI", default_branch, "--", path], repo_root
+    )
+    iso = out.strip()
+    if not iso:
+        return ("silent_green", f"no commit on `{default_branch}` has ever "
+                f"touched `{path}` (loop cannot prove it is alive)")
+    newest = _parse_iso(iso)
+    if newest is None:
+        raise AdapterError(f"git returned an unparseable commit date: {iso!r}")
+    age = _age_days(newest, now)
+    if age > max_days:
+        return ("stale", f"last commit touching `{path}` on `{default_branch}` "
+                f"is {age:.1f}d old (threshold {max_days:g}d)")
+    return ("healthy", f"fresh: last commit {age:.1f}d old "
+            f"(threshold {max_days:g}d)")
+
+
+# ---------------------------------------------------------------------------
+# per-loop evaluation
+# ---------------------------------------------------------------------------
+
+def _evaluate_loop(
+    loop: dict,
+    now: datetime,
+    repo_root: Path,
+    default_branch: str,
+    git_runner,
+) -> tuple[str, str]:
+    wf = loop.get("workflow", "<unknown>")
+    status = loop.get("status")
+    declarations = [
+        k for k in ("proof", "allowed_silence", "disabled")
+        if (loop.get(k) is True or isinstance(loop.get(k), dict))
+    ]
+    if len(declarations) != 1:
+        raise ConfigError(
+            f"{wf}: must declare exactly one of proof/allowed_silence/disabled, "
+            f"found {declarations or 'none'}"
+        )
+    declared = declarations[0]
+
+    if declared == "disabled":
+        if status != "disabled":
+            raise ConfigError(f"{wf}: has a disabled block but status is {status!r}")
+        until_raw = loop["disabled"].get("until")
+        try:
+            until = date.fromisoformat(until_raw)
+        except (TypeError, ValueError):
+            raise ConfigError(f"{wf}: disabled.until is not a valid date: {until_raw!r}")
+        if now.date() > until:
+            return ("expired_disable", f"intentional disable expired on {until} "
+                    "(re-evaluate or re-authorize the pause)")
+        return ("disabled", f"intentionally disabled through {until}: "
+                f"{loop['disabled'].get('reason', '')}".rstrip(": "))
+
+    if status != "active":
+        raise ConfigError(
+            f"{wf}: status must be 'active' for a {declared} loop, got {status!r}"
+        )
+
+    if declared == "allowed_silence":
+        if not loop.get("reason"):
+            raise ConfigError(f"{wf}: allowed_silence requires a 'reason'")
+        return ("allowed_silence", f"silence accepted: {loop['reason']}")
+
+    # proof
+    proof = loop["proof"]
+    adapter = proof.get("adapter")
+    if adapter == "state_glob":
+        return _eval_state_glob(proof, now, repo_root)
+    if adapter == "git_log":
+        return _eval_git_log(proof, now, repo_root, default_branch, git_runner)
+    raise ConfigError(f"{wf}: unknown proof adapter {adapter!r}")
+
+
+# ---------------------------------------------------------------------------
+# top-level evaluation
+# ---------------------------------------------------------------------------
+
+def evaluate(
+    registry: dict,
+    *,
+    now: datetime,
+    workflows_dir: Path,
+    repo_root: Path,
+    git_runner=default_git_runner,
+) -> list[dict]:
+    """Return findings (one per producer/loop), sorted by workflow name.
+
+    Never reads wall-clock (caller supplies `now`). Adapter/config failures are
+    turned into config_error/adapter_error findings rather than exceptions, so a
+    single bad entry still yields a complete, deterministic report.
+    """
+    monitors = set(registry.get("monitors") or [])
+    default_branch = registry.get("default_branch") or DEFAULT_BRANCH
+    loops = registry.get("loops") or []
+
+    registered: dict[str, dict] = {}
+    findings: list[dict] = []
+    for loop in loops:
+        wf = loop.get("workflow", "<unknown>")
+        if wf in registered:
+            findings.append({
+                "workflow": wf,
+                "kind": "config_error",
+                "detail": "duplicate registry entry",
+            })
+            continue
+        registered[wf] = loop
+        try:
+            kind, detail = _evaluate_loop(
+                loop, now, repo_root, default_branch, git_runner
+            )
+        except AdapterError as exc:
+            kind, detail = "adapter_error", str(exc)
+        except ConfigError as exc:
+            kind, detail = "config_error", str(exc)
+        findings.append({"workflow": wf, "kind": kind, "detail": detail})
+
+    # Coverage: every scheduled producer (not a monitor) must be registered.
+    for wf in scheduled_workflows(workflows_dir):
+        if wf in monitors or wf in registered:
+            continue
+        findings.append({
+            "workflow": wf,
+            "kind": "unregistered",
+            "detail": "scheduled producer workflow is not in the loop-health "
+                      "registry (add a proof/allowed_silence/disabled entry)",
+        })
+
+    findings.sort(key=lambda f: (f["workflow"], f["kind"]))
+    return findings
+
+
+def exit_code(findings: list[dict]) -> int:
+    kinds = {f["kind"] for f in findings}
+    if kinds & set(_EXIT2_KINDS):
+        return 2
+    if kinds & set(_EXIT1_KINDS):
+        return 1
+    return 0
+
+
+def stable_alert(findings: list[dict]) -> list[dict]:
+    """Committable payload: only the problem findings, stripped of the volatile
+    ages/timestamps in `detail`, so a steady red state does not churn commits."""
+    problems = [
+        {"workflow": f["workflow"], "kind": f["kind"]}
+        for f in findings
+        if f["kind"] in _EXIT1_KINDS or f["kind"] in _EXIT2_KINDS
+    ]
+    problems.sort(key=lambda f: (f["workflow"], f["kind"]))
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# registry loading + schema validation
+# ---------------------------------------------------------------------------
+
+def load_registry(registry_path: Path, schema_path: Path) -> dict:
+    if not registry_path.exists():
+        raise ConfigError(f"registry not found: {registry_path}")
+    try:
+        registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"registry is not valid YAML: {exc}")
+    if not isinstance(registry, dict):
+        raise ConfigError("registry must be a mapping")
+
+    if schema_path.exists():
+        try:
+            import jsonschema
+        except ImportError:  # pragma: no cover - jsonschema is a declared dep
+            raise ConfigError("jsonschema is required to validate the registry")
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        errors = sorted(
+            jsonschema.Draft7Validator(schema).iter_errors(registry), key=str
+        )
+        if errors:
+            loc = "/".join(str(x) for x in errors[0].path) or "(root)"
+            raise ConfigError(
+                f"registry fails schema at [{loc}]: {errors[0].message}"
+            )
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _render_summary(findings: list[dict], code: int) -> str:
+    lines = []
+    problems = [f for f in findings if f["kind"] in _EXIT1_KINDS + _EXIT2_KINDS]
+    if code == 0:
+        lines.append(f"ecosystem-freshness: OK — {len(findings)} loops healthy/neutral")
+    else:
+        lines.append(f"### 🔴 ecosystem-freshness: {len(problems)} problem loop(s)")
+        for f in problems:
+            lines.append(f"- **{f['workflow']}** — {f['kind']}: {f['detail']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo-root", default=str(REPO))
+    ap.add_argument("--registry", default=None,
+                    help=f"registry path (default <repo>/{DEFAULT_REGISTRY})")
+    ap.add_argument("--schema", default=None,
+                    help=f"schema path (default <repo>/{DEFAULT_SCHEMA})")
+    ap.add_argument("--workflows-dir", default=None,
+                    help=f"workflows dir (default <repo>/{DEFAULT_WORKFLOWS_DIR})")
+    ap.add_argument("--default-branch", default=None,
+                    help="override the registry's default_branch (git_log evidence)")
+    ap.add_argument("--now", default=None,
+                    help="ISO-8601 override for the evaluation instant (testing)")
+    ap.add_argument("--json", action="store_true",
+                    help="print the full findings report as JSON to stdout")
+    ap.add_argument("--alert-file", default=None,
+                    help="write the stable problem payload here on failure, "
+                         "remove it on success (for commit-on-change guards)")
+    args = ap.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    registry_path = Path(args.registry) if args.registry else repo_root / DEFAULT_REGISTRY
+    schema_path = Path(args.schema) if args.schema else repo_root / DEFAULT_SCHEMA
+    workflows_dir = (
+        Path(args.workflows_dir) if args.workflows_dir
+        else repo_root / DEFAULT_WORKFLOWS_DIR
+    )
+    now = _parse_iso(args.now) or datetime.now(timezone.utc)
+
+    try:
+        registry = load_registry(registry_path, schema_path)
+        if args.default_branch:
+            registry = {**registry, "default_branch": args.default_branch}
+        findings = evaluate(
+            registry, now=now, workflows_dir=workflows_dir, repo_root=repo_root
+        )
+    except ConfigError as exc:
+        print(f"ecosystem-freshness: CONFIG ERROR — {exc}", file=sys.stderr)
+        return 2
+
+    code = exit_code(findings)
+
+    if args.json:
+        print(json.dumps({"exit_code": code, "findings": findings}, indent=2))
+
+    summary = _render_summary(findings, code)
+    print(summary, file=sys.stderr)
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as fh:
+            fh.write(summary + "\n")
+
+    if args.alert_file:
+        alert_path = Path(args.alert_file)
+        problems = stable_alert(findings)
+        if problems:
+            alert_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {"alert": "ecosystem-freshness", "problems": problems}
+            alert_path.write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        elif alert_path.exists():
+            alert_path.unlink()
+
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ecosystem_freshness.py
+++ b/scripts/ecosystem_freshness.py
@@ -10,20 +10,16 @@ loop — and stays green (and silent) when they are all healthy.
 The registry (.github/loop-health.yml, schema schemas/loop-health.schema.json)
 declares, per loop, exactly one of:
 
-  * proof            — how the loop proves liveness from default-branch evidence
-                       (state_glob = newest timestamp in committed JSON/JSONL;
-                        git_log    = last commit touching a path on the default
-                        branch, for commit-only-on-change loops).
-  * allowed_silence  — the loop legitimately leaves no committed evidence (it
-                       delivers value externally, e.g. posting a Discussion);
-                       its silence is neutral, not a failure.
+  * proof            — how the loop proves liveness (committed state, default-
+                       branch git history, or the latest completed scheduled
+                       GitHub Actions run and its conclusion).
   * disabled         — intentionally paused for a bounded window (`until`).
 
 Findings and exit codes (a producer with a real problem must fail CI):
 
-  0  every active loop is healthy or allowed-silent; disabled entries valid.
+  0  every active loop is healthy; disabled entries are bounded and verified.
   1  at least one: stale, silent_green, unregistered, malformed_proof,
-     expired_disable.
+     expired_disable, failed_run, activation_mismatch.
   2  configuration or evidence-adapter failure (registry unreadable / invalid /
      internally inconsistent; a proof adapter's machinery — e.g. git — failed).
 
@@ -45,6 +41,9 @@ import os
 import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
 
 import yaml
 
@@ -53,6 +52,10 @@ DEFAULT_REGISTRY = ".github/loop-health.yml"
 DEFAULT_WORKFLOWS_DIR = ".github/workflows"
 DEFAULT_SCHEMA = "schemas/loop-health.schema.json"
 DEFAULT_BRANCH = "master"
+ALLOWED_MONITORS = {
+    "ecosystem-freshness.yml",
+    "demerzel-quality-trend-freshness.yml",
+}
 
 for _stream in (sys.stdout, sys.stderr):  # Windows consoles default to cp1252.
     if hasattr(_stream, "reconfigure"):
@@ -66,8 +69,10 @@ _EXIT1_KINDS = (
     "unregistered",
     "malformed_proof",
     "expired_disable",
+    "failed_run",
+    "activation_mismatch",
 )
-# Everything else (healthy, allowed_silence, disabled) is exit 0.
+# Everything else (healthy, disabled) is exit 0.
 
 
 class ConfigError(Exception):
@@ -98,6 +103,59 @@ def default_git_runner(args: list[str], cwd: Path) -> str:
             f"{proc.stderr.strip() or proc.stdout.strip()}"
         )
     return proc.stdout
+
+
+def default_actions_runner(
+    workflow: str,
+    repository: str,
+    default_branch: str,
+    token: str,
+) -> dict | None:
+    """Return the latest completed scheduled run for a workflow.
+
+    The seam is injectable in tests. The production request is read-only and
+    authenticates only with the workflow's existing GITHUB_TOKEN.
+    """
+    if not repository or "/" not in repository:
+        raise AdapterError(
+            "workflow_run proof requires GITHUB_REPOSITORY (owner/repo)"
+        )
+    if not token:
+        raise AdapterError("workflow_run proof requires the existing GITHUB_TOKEN")
+    params = urlencode({
+        "event": "schedule",
+        "branch": default_branch,
+        "status": "completed",
+        "per_page": 1,
+    })
+    endpoint = (
+        "https://api.github.com/repos/"
+        f"{quote(repository, safe='/')}/actions/workflows/"
+        f"{quote(workflow, safe='')}/runs?{params}"
+    )
+    request = Request(endpoint, headers={
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "demerzel-ecosystem-freshness",
+    })
+    try:
+        with urlopen(request, timeout=20) as response:
+            payload = json.load(response)
+    except HTTPError as exc:
+        raise AdapterError(
+            f"GitHub Actions API returned HTTP {exc.code} for {workflow}"
+        ) from exc
+    except (URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise AdapterError(
+            f"GitHub Actions API failed for {workflow}: {type(exc).__name__}"
+        ) from exc
+    runs = payload.get("workflow_runs") if isinstance(payload, dict) else None
+    if not isinstance(runs, list):
+        raise AdapterError(
+            f"GitHub Actions API returned malformed run data for {workflow}"
+        )
+    return runs[0] if runs else None
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +210,25 @@ def scheduled_workflows(workflows_dir: Path) -> list[str]:
         ):
             found.append(path.name)
     return sorted(found)
+
+
+def workflow_crons(workflows_dir: Path, workflow: str) -> list[str] | None:
+    """Return configured cron expressions, or None when the file is absent."""
+    path = workflows_dir / workflow
+    if not path.exists():
+        return None
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"{workflow}: workflow YAML is invalid: {exc}") from exc
+    sched = _schedule_block(doc)
+    if not isinstance(sched, list):
+        return []
+    return sorted(
+        entry["cron"]
+        for entry in sched
+        if isinstance(entry, dict) and isinstance(entry.get("cron"), str)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +343,52 @@ def _eval_git_log(
             f"(threshold {max_days:g}d)")
 
 
+def _eval_workflow_run(
+    proof: dict,
+    workflow: str,
+    now: datetime,
+    repository: str,
+    default_branch: str,
+    token: str,
+    actions_runner,
+) -> tuple[str, str]:
+    """Prove a scheduled loop through its latest completed Actions run."""
+    max_days = float(proof["max_stale_days"])
+    run = actions_runner(workflow, repository, default_branch, token)
+    if run is None:
+        return (
+            "silent_green",
+            "no completed scheduled GitHub Actions run exists on the default branch",
+        )
+    if not isinstance(run, dict):
+        raise AdapterError(f"workflow-run adapter returned invalid data for {workflow}")
+    conclusion = run.get("conclusion")
+    url = run.get("html_url") or "(no run URL)"
+    if conclusion != "success":
+        return (
+            "failed_run",
+            f"latest completed scheduled run concluded {conclusion!r}: {url}",
+        )
+    newest = _parse_iso(run.get("run_started_at") or run.get("created_at"))
+    if newest is None:
+        return (
+            "malformed_proof",
+            "latest completed scheduled run has no parseable start timestamp",
+        )
+    age = _age_days(newest, now)
+    if age > max_days:
+        return (
+            "stale",
+            f"latest successful scheduled run is {age:.1f}d old "
+            f"(threshold {max_days:g}d): {url}",
+        )
+    return (
+        "healthy",
+        f"latest scheduled run succeeded {age:.1f}d ago "
+        f"(threshold {max_days:g}d): {url}",
+    )
+
+
 # ---------------------------------------------------------------------------
 # per-loop evaluation
 # ---------------------------------------------------------------------------
@@ -276,16 +399,20 @@ def _evaluate_loop(
     repo_root: Path,
     default_branch: str,
     git_runner,
+    actions_runner,
+    repository: str,
+    token: str,
+    actual_crons: list[str] | None,
 ) -> tuple[str, str]:
     wf = loop.get("workflow", "<unknown>")
     status = loop.get("status")
     declarations = [
-        k for k in ("proof", "allowed_silence", "disabled")
+        k for k in ("proof", "disabled")
         if (loop.get(k) is True or isinstance(loop.get(k), dict))
     ]
     if len(declarations) != 1:
         raise ConfigError(
-            f"{wf}: must declare exactly one of proof/allowed_silence/disabled, "
+            f"{wf}: must declare exactly one of proof/disabled, "
             f"found {declarations or 'none'}"
         )
     declared = declarations[0]
@@ -293,6 +420,19 @@ def _evaluate_loop(
     if declared == "disabled":
         if status != "disabled":
             raise ConfigError(f"{wf}: has a disabled block but status is {status!r}")
+        if actual_crons is None:
+            return ("activation_mismatch", "disabled workflow file is missing")
+        verification = loop["disabled"].get("verification")
+        if verification != "schedule_absent":
+            raise ConfigError(
+                f"{wf}: disabled.verification must be 'schedule_absent'"
+            )
+        if actual_crons:
+            return (
+                "activation_mismatch",
+                "registry says disabled but workflow still has cron schedule(s): "
+                + ", ".join(actual_crons),
+            )
         until_raw = loop["disabled"].get("until")
         try:
             until = date.fromisoformat(until_raw)
@@ -309,10 +449,20 @@ def _evaluate_loop(
             f"{wf}: status must be 'active' for a {declared} loop, got {status!r}"
         )
 
-    if declared == "allowed_silence":
-        if not loop.get("reason"):
-            raise ConfigError(f"{wf}: allowed_silence requires a 'reason'")
-        return ("allowed_silence", f"silence accepted: {loop['reason']}")
+    if actual_crons is None:
+        return ("activation_mismatch", "active workflow file is missing")
+    expected_crons = sorted(loop.get("schedule") or [])
+    if not actual_crons:
+        return (
+            "activation_mismatch",
+            "registry says active but workflow has no cron schedule",
+        )
+    if expected_crons != actual_crons:
+        return (
+            "activation_mismatch",
+            f"registry crons {expected_crons!r} do not match workflow crons "
+            f"{actual_crons!r}",
+        )
 
     # proof
     proof = loop["proof"]
@@ -321,6 +471,16 @@ def _evaluate_loop(
         return _eval_state_glob(proof, now, repo_root)
     if adapter == "git_log":
         return _eval_git_log(proof, now, repo_root, default_branch, git_runner)
+    if adapter == "workflow_run":
+        return _eval_workflow_run(
+            proof,
+            wf,
+            now,
+            repository,
+            default_branch,
+            token,
+            actions_runner,
+        )
     raise ConfigError(f"{wf}: unknown proof adapter {adapter!r}")
 
 
@@ -335,6 +495,9 @@ def evaluate(
     workflows_dir: Path,
     repo_root: Path,
     git_runner=default_git_runner,
+    actions_runner=default_actions_runner,
+    repository: str = "",
+    token: str = "",
 ) -> list[dict]:
     """Return findings (one per producer/loop), sorted by workflow name.
 
@@ -348,8 +511,39 @@ def evaluate(
 
     registered: dict[str, dict] = {}
     findings: list[dict] = []
+    for wf in sorted(monitors):
+        if wf not in ALLOWED_MONITORS:
+            findings.append({
+                "workflow": wf,
+                "kind": "config_error",
+                "detail": "workflow is not an approved freshness monitor and "
+                          "cannot be excluded from producer coverage",
+            })
+            continue
+        try:
+            crons = workflow_crons(workflows_dir, wf)
+        except ConfigError as exc:
+            findings.append({
+                "workflow": wf,
+                "kind": "config_error",
+                "detail": str(exc),
+            })
+            continue
+        if not crons:
+            findings.append({
+                "workflow": wf,
+                "kind": "activation_mismatch",
+                "detail": "registered monitor is missing or has no cron schedule",
+            })
     for loop in loops:
         wf = loop.get("workflow", "<unknown>")
+        if wf in monitors:
+            findings.append({
+                "workflow": wf,
+                "kind": "config_error",
+                "detail": "workflow cannot be both a monitor and a producer",
+            })
+            continue
         if wf in registered:
             findings.append({
                 "workflow": wf,
@@ -359,8 +553,17 @@ def evaluate(
             continue
         registered[wf] = loop
         try:
+            crons = workflow_crons(workflows_dir, wf)
             kind, detail = _evaluate_loop(
-                loop, now, repo_root, default_branch, git_runner
+                loop,
+                now,
+                repo_root,
+                default_branch,
+                git_runner,
+                actions_runner,
+                repository,
+                token,
+                crons,
             )
         except AdapterError as exc:
             kind, detail = "adapter_error", str(exc)
@@ -376,7 +579,7 @@ def evaluate(
             "workflow": wf,
             "kind": "unregistered",
             "detail": "scheduled producer workflow is not in the loop-health "
-                      "registry (add a proof/allowed_silence/disabled entry)",
+                      "registry (add a proof or bounded disabled entry)",
         })
 
     findings.sort(key=lambda f: (f["workflow"], f["kind"]))
@@ -402,6 +605,20 @@ def stable_alert(findings: list[dict]) -> list[dict]:
     ]
     problems.sort(key=lambda f: (f["workflow"], f["kind"]))
     return problems
+
+
+def sync_alert(alert_path: Path, findings: list[dict]) -> None:
+    """Persist stable red state, or remove it after verified recovery."""
+    problems = stable_alert(findings)
+    if problems:
+        alert_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"alert": "ecosystem-freshness", "problems": problems}
+        alert_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    elif alert_path.exists():
+        alert_path.unlink()
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +660,10 @@ def _render_summary(findings: list[dict], code: int) -> str:
     lines = []
     problems = [f for f in findings if f["kind"] in _EXIT1_KINDS + _EXIT2_KINDS]
     if code == 0:
-        lines.append(f"ecosystem-freshness: OK — {len(findings)} loops healthy/neutral")
+        lines.append(
+            f"ecosystem-freshness: OK — {len(findings)} loops healthy or "
+            "bounded-disabled"
+        )
     else:
         lines.append(f"### 🔴 ecosystem-freshness: {len(problems)} problem loop(s)")
         for f in problems:
@@ -485,7 +705,12 @@ def main(argv: list[str] | None = None) -> int:
         if args.default_branch:
             registry = {**registry, "default_branch": args.default_branch}
         findings = evaluate(
-            registry, now=now, workflows_dir=workflows_dir, repo_root=repo_root
+            registry,
+            now=now,
+            workflows_dir=workflows_dir,
+            repo_root=repo_root,
+            repository=os.environ.get("GITHUB_REPOSITORY", ""),
+            token=os.environ.get("GITHUB_TOKEN", ""),
         )
     except ConfigError as exc:
         print(f"ecosystem-freshness: CONFIG ERROR — {exc}", file=sys.stderr)
@@ -504,17 +729,7 @@ def main(argv: list[str] | None = None) -> int:
             fh.write(summary + "\n")
 
     if args.alert_file:
-        alert_path = Path(args.alert_file)
-        problems = stable_alert(findings)
-        if problems:
-            alert_path.parent.mkdir(parents=True, exist_ok=True)
-            payload = {"alert": "ecosystem-freshness", "problems": problems}
-            alert_path.write_text(
-                json.dumps(payload, indent=2, sort_keys=True) + "\n",
-                encoding="utf-8",
-            )
-        elif alert_path.exists():
-            alert_path.unlink()
+        sync_alert(Path(args.alert_file), findings)
 
     return code
 

--- a/scripts/test_ecosystem_freshness.py
+++ b/scripts/test_ecosystem_freshness.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Unit tests for the universal ecosystem-freshness monitor.
+
+Covers the tracer-bullet outcomes (fresh / silent-green / intentionally
+disabled) plus the boundary and failure modes the brief calls out: exact
+staleness boundaries, proof-adapter (git) API failure, deterministic ordering,
+default-branch evidence, and monitor self-exclusion.
+
+stdlib + PyYAML + jsonschema only; no network, no wall-clock (a fixed NOW is
+threaded through every evaluation).
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import ecosystem_freshness as ef
+
+NOW = datetime(2026, 7, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class _Repo:
+    """A throwaway repo root with a state/ tree and a workflows dir."""
+
+    def __init__(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.workflows = self.root / ".github" / "workflows"
+        self.workflows.mkdir(parents=True)
+
+    def close(self) -> None:
+        self._tmp.cleanup()
+
+    def write_state(self, relpath: str, content: str) -> None:
+        p = self.root / relpath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+    def write_workflow(self, name: str) -> None:
+        (self.workflows / name).write_text(
+            "name: stub\n"
+            "on:\n"
+            "  schedule:\n"
+            "    - cron: '0 0 * * *'\n"
+            "jobs: {}\n",
+            encoding="utf-8",
+        )
+
+
+class EcosystemFreshnessTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo = _Repo()
+        self.addCleanup(self.repo.close)
+
+    def _evaluate(self, registry: dict, *, git_runner=None) -> list[dict]:
+        kwargs = {}
+        if git_runner is not None:
+            kwargs["git_runner"] = git_runner
+        return ef.evaluate(
+            registry,
+            now=NOW,
+            workflows_dir=self.repo.workflows,
+            repo_root=self.repo.root,
+            **kwargs,
+        )
+
+    def _one(self, findings: list[dict], workflow: str) -> dict:
+        return next(f for f in findings if f["workflow"] == workflow)
+
+    # ── tracer-bullet outcomes ────────────────────────────────────────────
+
+    def test_state_glob_fresh(self):
+        self.repo.write_state(
+            "state/quality-trend/2026-07.jsonl",
+            json.dumps({"timestamp": _iso(NOW - timedelta(hours=6))}) + "\n",
+        )
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "demerzel-quality-trend.yml",
+                "status": "active",
+                "proof": {
+                    "adapter": "state_glob",
+                    "glob": "state/quality-trend/*.jsonl",
+                    "timestamp_field": "timestamp",
+                    "max_stale_days": 3,
+                },
+            }],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "demerzel-quality-trend.yml")["kind"],
+                         "healthy")
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_silent_green_when_no_evidence(self):
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "demerzel-ideation.yml",
+                "status": "active",
+                "proof": {
+                    "adapter": "state_glob",
+                    "glob": "state/ideation/*.json",
+                    "timestamp_field": "created_at",
+                    "max_stale_days": 7,
+                },
+            }],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "demerzel-ideation.yml")["kind"],
+                         "silent_green")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_intentionally_disabled_is_neutral(self):
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "seldon-plan.yml",
+                "status": "disabled",
+                "disabled": {"reason": "paused", "until": "2026-10-16"},
+            }],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "seldon-plan.yml")["kind"], "disabled")
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_expired_disable_turns_red(self):
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "seldon-plan.yml",
+                "status": "disabled",
+                "disabled": {"reason": "paused", "until": "2026-07-17"},
+            }],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "seldon-plan.yml")["kind"],
+                         "expired_disable")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_disable_valid_through_until_inclusive(self):
+        # `until` is inclusive: a disable expiring today is still valid today.
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "seldon-plan.yml",
+                "status": "disabled",
+                "disabled": {"reason": "paused", "until": _iso(NOW)[:10]},
+            }],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "seldon-plan.yml")["kind"], "disabled")
+
+    # ── exact boundaries ──────────────────────────────────────────────────
+
+    def test_exact_staleness_boundary(self):
+        base = {
+            "version": 1,
+            "loops": [{
+                "workflow": "q.yml",
+                "status": "active",
+                "proof": {
+                    "adapter": "state_glob",
+                    "glob": "state/q/*.jsonl",
+                    "timestamp_field": "timestamp",
+                    "max_stale_days": 3,
+                },
+            }],
+        }
+        # Exactly 3 days old -> fresh (threshold is strict >).
+        self.repo.write_state(
+            "state/q/x.jsonl",
+            json.dumps({"timestamp": _iso(NOW - timedelta(days=3))}) + "\n",
+        )
+        self.assertEqual(self._one(self._evaluate(base), "q.yml")["kind"], "healthy")
+
+        # One second past 3 days -> stale.
+        self.repo.write_state(
+            "state/q/x.jsonl",
+            json.dumps(
+                {"timestamp": _iso(NOW - timedelta(days=3, seconds=1))}
+            ) + "\n",
+        )
+        self.assertEqual(self._one(self._evaluate(base), "q.yml")["kind"], "stale")
+
+    # ── proof-adapter (git) machinery ─────────────────────────────────────
+
+    def test_git_log_default_branch_evidence(self):
+        seen = {}
+
+        def fake_git(args, cwd):
+            seen["args"] = args
+            return _iso(NOW - timedelta(days=1)) + "\n"
+
+        registry = {
+            "version": 1,
+            "default_branch": "main",
+            "loops": [{
+                "workflow": "producer.yml",
+                "status": "active",
+                "proof": {
+                    "adapter": "git_log",
+                    "path": "state/triggers/",
+                    "max_stale_days": 7,
+                },
+            }],
+        }
+        findings = self._evaluate(registry, git_runner=fake_git)
+        self.assertEqual(self._one(findings, "producer.yml")["kind"], "healthy")
+        # Freshness is judged from the DEFAULT branch, not the working tree.
+        self.assertIn("main", seen["args"])
+        self.assertIn("state/triggers/", seen["args"])
+
+    def test_git_log_api_failure_is_exit_2(self):
+        def boom(args, cwd):
+            raise ef.AdapterError("git exploded")
+
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "producer.yml",
+                "status": "active",
+                "proof": {
+                    "adapter": "git_log",
+                    "path": "state/x/",
+                    "max_stale_days": 7,
+                },
+            }],
+        }
+        findings = self._evaluate(registry, git_runner=boom)
+        self.assertEqual(self._one(findings, "producer.yml")["kind"], "adapter_error")
+        self.assertEqual(ef.exit_code(findings), 2)
+
+    def test_git_log_never_committed_is_silent_green(self):
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "producer.yml",
+                "status": "active",
+                "proof": {
+                    "adapter": "git_log",
+                    "path": "state/x/",
+                    "max_stale_days": 7,
+                },
+            }],
+        }
+        findings = self._evaluate(registry, git_runner=lambda args, cwd: "\n")
+        self.assertEqual(self._one(findings, "producer.yml")["kind"], "silent_green")
+
+    # ── deterministic ordering ────────────────────────────────────────────
+
+    def test_deterministic_ordering(self):
+        registry = {
+            "version": 1,
+            "loops": [
+                {"workflow": "z.yml", "status": "active",
+                 "allowed_silence": True, "reason": "external"},
+                {"workflow": "a.yml", "status": "active",
+                 "allowed_silence": True, "reason": "external"},
+                {"workflow": "m.yml", "status": "active",
+                 "allowed_silence": True, "reason": "external"},
+            ],
+        }
+        order1 = [f["workflow"] for f in self._evaluate(registry)]
+        order2 = [f["workflow"] for f in self._evaluate(registry)]
+        self.assertEqual(order1, ["a.yml", "m.yml", "z.yml"])
+        self.assertEqual(order1, order2)
+
+    # ── coverage: monitor self-exclusion & unregistered producers ─────────
+
+    def test_monitor_self_exclusion(self):
+        # A scheduled monitor on disk must NOT be reported as unregistered.
+        self.repo.write_workflow("ecosystem-freshness.yml")
+        registry = {
+            "version": 1,
+            "monitors": ["ecosystem-freshness.yml"],
+            "loops": [],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(findings, [])
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_unregistered_scheduled_producer_turns_red(self):
+        self.repo.write_workflow("brand-new-loop.yml")
+        registry = {"version": 1, "monitors": [], "loops": []}
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "brand-new-loop.yml")["kind"],
+                         "unregistered")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_registered_producer_not_flagged(self):
+        self.repo.write_workflow("known.yml")
+        registry = {
+            "version": 1,
+            "loops": [{"workflow": "known.yml", "status": "active",
+                       "allowed_silence": True, "reason": "external"}],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "known.yml")["kind"], "allowed_silence")
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    # ── malformed proof (exit 1) vs config error (exit 2) ─────────────────
+
+    def test_malformed_proof_unparseable_file(self):
+        self.repo.write_state("state/q/x.jsonl", "this is not json at all\n")
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "q.yml",
+                "status": "active",
+                "proof": {
+                    "adapter": "state_glob",
+                    "glob": "state/q/*.jsonl",
+                    "timestamp_field": "timestamp",
+                    "max_stale_days": 3,
+                },
+            }],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "q.yml")["kind"], "malformed_proof")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_malformed_proof_missing_timestamp_field(self):
+        self.repo.write_state("state/q/x.jsonl",
+                              json.dumps({"other": "value"}) + "\n")
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "q.yml",
+                "status": "active",
+                "proof": {
+                    "adapter": "state_glob",
+                    "glob": "state/q/*.jsonl",
+                    "timestamp_field": "timestamp",
+                    "max_stale_days": 3,
+                },
+            }],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "q.yml")["kind"], "malformed_proof")
+
+    def test_state_glob_supports_json_object_and_array(self):
+        # Whole-file JSON object.
+        self.repo.write_state(
+            "state/obj/x.json",
+            json.dumps({"timestamp": _iso(NOW - timedelta(hours=1))}),
+        )
+        # Whole-file JSON array.
+        self.repo.write_state(
+            "state/obj/y.json",
+            json.dumps([{"timestamp": _iso(NOW - timedelta(hours=2))}]),
+        )
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "obj.yml",
+                "status": "active",
+                "proof": {
+                    "adapter": "state_glob",
+                    "glob": "state/obj/*.json",
+                    "timestamp_field": "timestamp",
+                    "max_stale_days": 1,
+                },
+            }],
+        }
+        self.assertEqual(self._one(self._evaluate(registry), "obj.yml")["kind"],
+                         "healthy")
+
+    # ── declaration integrity (config errors -> exit 2) ───────────────────
+
+    def test_multiple_declarations_is_config_error(self):
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "bad.yml",
+                "status": "active",
+                "allowed_silence": True,
+                "reason": "external",
+                "proof": {"adapter": "state_glob", "glob": "state/x/*.json",
+                          "timestamp_field": "timestamp", "max_stale_days": 1},
+            }],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "bad.yml")["kind"], "config_error")
+        self.assertEqual(ef.exit_code(findings), 2)
+
+    def test_allowed_silence_requires_reason(self):
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "bad.yml",
+                "status": "active",
+                "allowed_silence": True,
+            }],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "bad.yml")["kind"], "config_error")
+
+    def test_disabled_block_with_active_status_is_config_error(self):
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "bad.yml",
+                "status": "active",
+                "disabled": {"reason": "paused", "until": "2026-10-16"},
+            }],
+        }
+        findings = self._evaluate(registry)
+        self.assertEqual(self._one(findings, "bad.yml")["kind"], "config_error")
+
+    def test_duplicate_registry_entry_is_config_error(self):
+        registry = {
+            "version": 1,
+            "loops": [
+                {"workflow": "dup.yml", "status": "active",
+                 "allowed_silence": True, "reason": "external"},
+                {"workflow": "dup.yml", "status": "active",
+                 "allowed_silence": True, "reason": "external"},
+            ],
+        }
+        findings = self._evaluate(registry)
+        self.assertTrue(any(f["kind"] == "config_error" for f in findings))
+        self.assertEqual(ef.exit_code(findings), 2)
+
+    # ── stable alert payload (idempotent commits) ─────────────────────────
+
+    def test_stable_alert_strips_volatile_fields(self):
+        findings = [
+            {"workflow": "b.yml", "kind": "stale", "detail": "17.3d old"},
+            {"workflow": "a.yml", "kind": "healthy", "detail": "fresh 0.1d"},
+            {"workflow": "c.yml", "kind": "silent_green", "detail": "no evidence"},
+        ]
+        alert = ef.stable_alert(findings)
+        self.assertEqual(alert, [
+            {"workflow": "b.yml", "kind": "stale"},
+            {"workflow": "c.yml", "kind": "silent_green"},
+        ])
+        # No ages/timestamps leak into the committable payload.
+        self.assertNotIn("detail", alert[0])
+
+    # ── registry schema validation (config failure -> exit 2) ─────────────
+
+    def test_load_registry_rejects_bad_adapter(self):
+        reg = self.repo.root / "loop-health.yml"
+        reg.write_text(
+            "version: 1\n"
+            "loops:\n"
+            "  - workflow: x.yml\n"
+            "    status: active\n"
+            "    proof:\n"
+            "      adapter: not_a_real_adapter\n"
+            "      max_stale_days: 3\n",
+            encoding="utf-8",
+        )
+        schema = Path(ef.REPO) / ef.DEFAULT_SCHEMA
+        with self.assertRaises(ef.ConfigError):
+            ef.load_registry(reg, schema)
+
+    def test_load_registry_missing_file(self):
+        with self.assertRaises(ef.ConfigError):
+            ef.load_registry(self.repo.root / "nope.yml",
+                             Path(ef.REPO) / ef.DEFAULT_SCHEMA)
+
+    # ── the shipped production registry is internally consistent ──────────
+
+    def test_shipped_registry_validates_and_covers_producers(self):
+        repo = Path(ef.REPO)
+        registry = ef.load_registry(
+            repo / ef.DEFAULT_REGISTRY, repo / ef.DEFAULT_SCHEMA
+        )
+        findings = ef.evaluate(
+            registry,
+            now=NOW,
+            workflows_dir=repo / ef.DEFAULT_WORKFLOWS_DIR,
+            repo_root=repo,
+            git_runner=lambda args, cwd: _iso(NOW) + "\n",
+        )
+        # No unregistered producers and no config/adapter errors: coverage is
+        # complete and the registry is internally consistent.
+        self.assertFalse([f for f in findings if f["kind"] == "unregistered"],
+                         "every scheduled producer must be registered")
+        self.assertFalse([f for f in findings
+                          if f["kind"] in ("config_error", "adapter_error")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ecosystem_freshness.py
+++ b/scripts/test_ecosystem_freshness.py
@@ -16,8 +16,15 @@ import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+from unittest.mock import patch
 
-import ecosystem_freshness as ef
+import yaml
+
+try:
+    from scripts import ecosystem_freshness as ef
+except ModuleNotFoundError:
+    import ecosystem_freshness as ef
 
 NOW = datetime(2026, 7, 18, 12, 0, 0, tzinfo=timezone.utc)
 
@@ -43,12 +50,18 @@ class _Repo:
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content, encoding="utf-8")
 
-    def write_workflow(self, name: str) -> None:
+    def write_workflow(self, name: str, crons=None) -> None:
+        crons = ["0 0 * * *"] if crons is None else crons
+        schedule = ""
+        if crons:
+            schedule = "  schedule:\n" + "".join(
+                f"    - cron: '{cron}'\n" for cron in crons
+            )
         (self.workflows / name).write_text(
             "name: stub\n"
             "on:\n"
-            "  schedule:\n"
-            "    - cron: '0 0 * * *'\n"
+            f"{schedule}"
+            "  workflow_dispatch:\n"
             "jobs: {}\n",
             encoding="utf-8",
         )
@@ -59,10 +72,30 @@ class EcosystemFreshnessTest(unittest.TestCase):
         self.repo = _Repo()
         self.addCleanup(self.repo.close)
 
-    def _evaluate(self, registry: dict, *, git_runner=None) -> list[dict]:
-        kwargs = {}
+    def _evaluate(self, registry: dict, *, git_runner=None,
+                  actions_runner=None, auto_workflows=True) -> list[dict]:
+        # Most unit tests exercise an adapter, not activation declarations. Give
+        # them a matching scheduled stub; activation tests opt out explicitly.
+        registry = json.loads(json.dumps(registry))
+        if auto_workflows:
+            for loop in registry.get("loops", []):
+                wf = loop.get("workflow")
+                if loop.get("status") != "disabled":
+                    loop.setdefault("schedule", ["0 0 * * *"])
+                if not wf or (self.repo.workflows / wf).exists():
+                    continue
+                if loop.get("status") == "disabled":
+                    self.repo.write_workflow(wf, crons=[])
+                else:
+                    self.repo.write_workflow(wf, crons=loop["schedule"])
+        kwargs = {
+            "repository": "GuitarAlchemist/Demerzel",
+            "token": "test-token",
+        }
         if git_runner is not None:
             kwargs["git_runner"] = git_runner
+        if actions_runner is not None:
+            kwargs["actions_runner"] = actions_runner
         return ef.evaluate(
             registry,
             now=NOW,
@@ -124,7 +157,8 @@ class EcosystemFreshnessTest(unittest.TestCase):
             "loops": [{
                 "workflow": "seldon-plan.yml",
                 "status": "disabled",
-                "disabled": {"reason": "paused", "until": "2026-10-16"},
+                "disabled": {"reason": "paused", "until": "2026-10-16",
+                             "verification": "schedule_absent"},
             }],
         }
         findings = self._evaluate(registry)
@@ -137,7 +171,8 @@ class EcosystemFreshnessTest(unittest.TestCase):
             "loops": [{
                 "workflow": "seldon-plan.yml",
                 "status": "disabled",
-                "disabled": {"reason": "paused", "until": "2026-07-17"},
+                "disabled": {"reason": "paused", "until": "2026-07-17",
+                             "verification": "schedule_absent"},
             }],
         }
         findings = self._evaluate(registry)
@@ -152,7 +187,8 @@ class EcosystemFreshnessTest(unittest.TestCase):
             "loops": [{
                 "workflow": "seldon-plan.yml",
                 "status": "disabled",
-                "disabled": {"reason": "paused", "until": _iso(NOW)[:10]},
+                "disabled": {"reason": "paused", "until": _iso(NOW)[:10],
+                             "verification": "schedule_absent"},
             }],
         }
         findings = self._evaluate(registry)
@@ -254,22 +290,190 @@ class EcosystemFreshnessTest(unittest.TestCase):
         findings = self._evaluate(registry, git_runner=lambda args, cwd: "\n")
         self.assertEqual(self._one(findings, "producer.yml")["kind"], "silent_green")
 
+    # ── live GitHub Actions proof adapter ─────────────────────────────────
+
+    def _workflow_run_registry(self, workflow="producer.yml", max_days=3):
+        return {
+            "version": 1,
+            "loops": [{
+                "workflow": workflow,
+                "status": "active",
+                "proof": {
+                    "adapter": "workflow_run",
+                    "max_stale_days": max_days,
+                },
+            }],
+        }
+
+    def test_workflow_run_success_is_live_proof(self):
+        seen = {}
+
+        def runner(workflow, repository, branch, token):
+            seen.update(workflow=workflow, repository=repository,
+                        branch=branch, token=token)
+            return {
+                "conclusion": "success",
+                "run_started_at": _iso(NOW - timedelta(hours=2)),
+                "html_url": "https://example.test/runs/1",
+            }
+
+        findings = self._evaluate(
+            self._workflow_run_registry(), actions_runner=runner
+        )
+        self.assertEqual(self._one(findings, "producer.yml")["kind"], "healthy")
+        self.assertEqual(seen, {
+            "workflow": "producer.yml",
+            "repository": "GuitarAlchemist/Demerzel",
+            "branch": "master",
+            "token": "test-token",
+        })
+
+    def test_known_failed_loop_turns_red(self):
+        findings = self._evaluate(
+            self._workflow_run_registry("demerzel-capability-expansion.yml", 10),
+            actions_runner=lambda *args: {
+                "conclusion": "failure",
+                "run_started_at": _iso(NOW - timedelta(days=5)),
+                "html_url": "https://example.test/runs/failed",
+            },
+        )
+        finding = self._one(findings, "demerzel-capability-expansion.yml")
+        self.assertEqual(finding["kind"], "failed_run")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_workflow_run_missing_or_stale_turns_red(self):
+        registry = self._workflow_run_registry(max_days=3)
+        missing = self._evaluate(registry, actions_runner=lambda *args: None)
+        self.assertEqual(self._one(missing, "producer.yml")["kind"],
+                         "silent_green")
+        stale = self._evaluate(registry, actions_runner=lambda *args: {
+            "conclusion": "success",
+            "run_started_at": _iso(NOW - timedelta(days=3, seconds=1)),
+        })
+        self.assertEqual(self._one(stale, "producer.yml")["kind"], "stale")
+
+    def test_workflow_run_adapter_failure_is_exit_2(self):
+        def boom(*args):
+            raise ef.AdapterError("Actions API unavailable")
+
+        findings = self._evaluate(
+            self._workflow_run_registry(), actions_runner=boom
+        )
+        self.assertEqual(self._one(findings, "producer.yml")["kind"],
+                         "adapter_error")
+        self.assertEqual(ef.exit_code(findings), 2)
+
+    def test_default_actions_adapter_queries_completed_scheduled_run(self):
+        seen = {}
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps({"workflow_runs": [{"id": 42}]}).encode()
+
+        def fake_urlopen(request, timeout):
+            seen["request"] = request
+            seen["timeout"] = timeout
+            return Response()
+
+        with patch.object(ef, "urlopen", fake_urlopen):
+            run = ef.default_actions_runner(
+                "qa-tribunal.yml", "GuitarAlchemist/Demerzel", "master", "secret"
+            )
+        self.assertEqual(run, {"id": 42})
+        parsed = urlparse(seen["request"].full_url)
+        self.assertEqual(parse_qs(parsed.query), {
+            "event": ["schedule"], "branch": ["master"],
+            "status": ["completed"], "per_page": ["1"],
+        })
+        self.assertNotIn("secret", seen["request"].full_url)
+        self.assertEqual(seen["request"].get_header("Authorization"),
+                         "Bearer secret")
+
+    # ── registry activation must match actual workflow YAML ───────────────
+
+    def test_active_schedule_mismatch_turns_red_before_adapter(self):
+        self.repo.write_workflow("producer.yml", crons=["0 1 * * *"])
+        registry = self._workflow_run_registry()
+        registry["loops"][0]["schedule"] = ["0 2 * * *"]
+        findings = self._evaluate(
+            registry, actions_runner=lambda *args: self.fail("must not call API"),
+            auto_workflows=False,
+        )
+        self.assertEqual(self._one(findings, "producer.yml")["kind"],
+                         "activation_mismatch")
+
+    def test_disabled_but_still_scheduled_turns_red(self):
+        self.repo.write_workflow("seldon-plan.yml", crons=["0 6 * * *"])
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "seldon-plan.yml",
+                "status": "disabled",
+                "disabled": {
+                    "reason": "paused",
+                    "until": "2026-10-16",
+                    "verification": "schedule_absent",
+                },
+            }],
+        }
+        findings = self._evaluate(registry, auto_workflows=False)
+        self.assertEqual(self._one(findings, "seldon-plan.yml")["kind"],
+                         "activation_mismatch")
+
+    def test_monitor_exclusion_is_constrained(self):
+        self.repo.write_workflow("producer.yml")
+        findings = self._evaluate({
+            "version": 1, "monitors": ["producer.yml"], "loops": [],
+        })
+        self.assertEqual(self._one(findings, "producer.yml")["kind"],
+                         "config_error")
+
+    def test_monitor_cannot_also_be_registered_as_producer(self):
+        self.repo.write_workflow("ecosystem-freshness.yml")
+        findings = self._evaluate({
+            "version": 1,
+            "monitors": ["ecosystem-freshness.yml"],
+            "loops": [{
+                "workflow": "ecosystem-freshness.yml",
+                "status": "active",
+                "schedule": ["0 0 * * *"],
+                "proof": {"adapter": "workflow_run", "max_stale_days": 1},
+            }],
+        })
+        self.assertTrue(any(
+            f["kind"] == "config_error" and "both" in f["detail"]
+            for f in findings
+        ))
+
     # ── deterministic ordering ────────────────────────────────────────────
 
     def test_deterministic_ordering(self):
+        proof = {"adapter": "workflow_run", "max_stale_days": 2}
         registry = {
             "version": 1,
             "loops": [
                 {"workflow": "z.yml", "status": "active",
-                 "allowed_silence": True, "reason": "external"},
+                 "proof": proof},
                 {"workflow": "a.yml", "status": "active",
-                 "allowed_silence": True, "reason": "external"},
+                 "proof": proof},
                 {"workflow": "m.yml", "status": "active",
-                 "allowed_silence": True, "reason": "external"},
+                 "proof": proof},
             ],
         }
-        order1 = [f["workflow"] for f in self._evaluate(registry)]
-        order2 = [f["workflow"] for f in self._evaluate(registry)]
+        good = lambda *args: {
+            "conclusion": "success", "run_started_at": _iso(NOW),
+            "html_url": "https://example.test/run",
+        }
+        order1 = [f["workflow"] for f in self._evaluate(
+            registry, actions_runner=good)]
+        order2 = [f["workflow"] for f in self._evaluate(
+            registry, actions_runner=good)]
         self.assertEqual(order1, ["a.yml", "m.yml", "z.yml"])
         self.assertEqual(order1, order2)
 
@@ -300,10 +504,14 @@ class EcosystemFreshnessTest(unittest.TestCase):
         registry = {
             "version": 1,
             "loops": [{"workflow": "known.yml", "status": "active",
-                       "allowed_silence": True, "reason": "external"}],
+                       "schedule": ["0 0 * * *"],
+                       "proof": {"adapter": "workflow_run",
+                                 "max_stale_days": 1}}],
         }
-        findings = self._evaluate(registry)
-        self.assertEqual(self._one(findings, "known.yml")["kind"], "allowed_silence")
+        findings = self._evaluate(registry, actions_runner=lambda *args: {
+            "conclusion": "success", "run_started_at": _iso(NOW),
+        })
+        self.assertEqual(self._one(findings, "known.yml")["kind"], "healthy")
         self.assertEqual(ef.exit_code(findings), 0)
 
     # ── malformed proof (exit 1) vs config error (exit 2) ─────────────────
@@ -381,23 +589,24 @@ class EcosystemFreshnessTest(unittest.TestCase):
             "loops": [{
                 "workflow": "bad.yml",
                 "status": "active",
-                "allowed_silence": True,
-                "reason": "external",
                 "proof": {"adapter": "state_glob", "glob": "state/x/*.json",
                           "timestamp_field": "timestamp", "max_stale_days": 1},
+                "disabled": {"reason": "also paused", "until": "2026-10-16",
+                             "verification": "schedule_absent"},
             }],
         }
         findings = self._evaluate(registry)
         self.assertEqual(self._one(findings, "bad.yml")["kind"], "config_error")
         self.assertEqual(ef.exit_code(findings), 2)
 
-    def test_allowed_silence_requires_reason(self):
+    def test_unbounded_allowed_silence_is_rejected(self):
         registry = {
             "version": 1,
             "loops": [{
                 "workflow": "bad.yml",
                 "status": "active",
                 "allowed_silence": True,
+                "reason": "external output is not evidence",
             }],
         }
         findings = self._evaluate(registry)
@@ -409,20 +618,23 @@ class EcosystemFreshnessTest(unittest.TestCase):
             "loops": [{
                 "workflow": "bad.yml",
                 "status": "active",
-                "disabled": {"reason": "paused", "until": "2026-10-16"},
+                "disabled": {"reason": "paused", "until": "2026-10-16",
+                             "verification": "schedule_absent"},
             }],
         }
         findings = self._evaluate(registry)
         self.assertEqual(self._one(findings, "bad.yml")["kind"], "config_error")
 
     def test_duplicate_registry_entry_is_config_error(self):
+        proof = {"adapter": "state_glob", "glob": "state/x/*.json",
+                 "timestamp_field": "timestamp", "max_stale_days": 1}
         registry = {
             "version": 1,
             "loops": [
                 {"workflow": "dup.yml", "status": "active",
-                 "allowed_silence": True, "reason": "external"},
+                 "proof": proof},
                 {"workflow": "dup.yml", "status": "active",
-                 "allowed_silence": True, "reason": "external"},
+                 "proof": proof},
             ],
         }
         findings = self._evaluate(registry)
@@ -444,6 +656,22 @@ class EcosystemFreshnessTest(unittest.TestCase):
         ])
         # No ages/timestamps leak into the committable payload.
         self.assertNotIn("detail", alert[0])
+
+    def test_fail_persist_idempotence_and_recovery(self):
+        alert_path = self.repo.root / "state/loop-health/.freshness-alert.json"
+        failed = [{
+            "workflow": "dead.yml", "kind": "failed_run", "detail": "run 1",
+        }]
+        ef.sync_alert(alert_path, failed)
+        first = alert_path.read_text(encoding="utf-8")
+        ef.sync_alert(alert_path, [{
+            "workflow": "dead.yml", "kind": "failed_run", "detail": "run 2",
+        }])
+        self.assertEqual(alert_path.read_text(encoding="utf-8"), first)
+        ef.sync_alert(alert_path, [{
+            "workflow": "dead.yml", "kind": "healthy", "detail": "recovered",
+        }])
+        self.assertFalse(alert_path.exists())
 
     # ── registry schema validation (config failure -> exit 2) ─────────────
 
@@ -481,6 +709,13 @@ class EcosystemFreshnessTest(unittest.TestCase):
             workflows_dir=repo / ef.DEFAULT_WORKFLOWS_DIR,
             repo_root=repo,
             git_runner=lambda args, cwd: _iso(NOW) + "\n",
+            actions_runner=lambda *args: {
+                "conclusion": "success",
+                "run_started_at": _iso(NOW),
+                "html_url": "https://example.test/production-proof",
+            },
+            repository="GuitarAlchemist/Demerzel",
+            token="test-token",
         )
         # No unregistered producers and no config/adapter errors: coverage is
         # complete and the registry is internally consistent.
@@ -488,6 +723,38 @@ class EcosystemFreshnessTest(unittest.TestCase):
                          "every scheduled producer must be registered")
         self.assertFalse([f for f in findings
                           if f["kind"] in ("config_error", "adapter_error")])
+        self.assertNotIn("allowed_silence", json.dumps(registry))
+        scheduled = set(ef.scheduled_workflows(
+            repo / ef.DEFAULT_WORKFLOWS_DIR
+        ))
+        self.assertEqual(
+            scheduled,
+            set(registry["monitors"]) |
+            {loop["workflow"] for loop in registry["loops"]},
+        )
+
+    def test_production_workflows_enforce_daily_always_and_ci_paths(self):
+        repo = Path(ef.REPO)
+        guard = yaml.safe_load((
+            repo / ".github/workflows/ecosystem-freshness.yml"
+        ).read_text(encoding="utf-8"))
+        on = guard.get("on") or guard.get(True)
+        self.assertEqual(on["schedule"], [{"cron": "15 13 * * *"}])
+        self.assertEqual(guard["jobs"]["persist"]["if"], "always()")
+        persist_steps = guard["jobs"]["persist"]["steps"]
+        self.assertTrue(any(step.get("if") == "always()" for step in persist_steps))
+        self.assertEqual(guard["jobs"]["evaluate"]["permissions"], {
+            "actions": "read", "contents": "read",
+        })
+        self.assertEqual(guard["jobs"]["persist"]["permissions"], {
+            "contents": "write",
+        })
+
+        ci_text = (repo / ".github/workflows/governance-validate.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertGreaterEqual(ci_text.count(".github/loop-health.yml"), 2)
+        self.assertGreaterEqual(ci_text.count(".github/workflows/*.yml"), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Outcome

Makes the universal ecosystem-freshness guard fail closed for every scheduled producer. There is no unbounded `allowed_silence` state: external-output loops prove liveness through their latest completed scheduled GitHub Actions run and its conclusion.

## Adversarial remediation

- adds an injectable, read-only `workflow_run` proof adapter using only the existing `GITHUB_TOKEN`
- turns missing, stale, or non-successful scheduled runs red
- verifies exact registry cron declarations against workflow YAML
- declares `seldon-plan` active with its five real crons; a future bounded disable must remove all crons, declare `verification: schedule_absent`, and expire
- constrains monitor exclusions to the two known freshness guards
- changes guard cadence from weekly to daily
- runs evaluation with `actions:read` / `contents:read`; persistence is a separate `contents:write` job and runs under `always()`
- pins GitHub Action SHAs and Python dependency versions
- triggers governance CI for the registry and every workflow change
- adds behavior tests for known failed loops, API failure, fail/persist/recovery, activation mismatch, bounded disable, exclusion abuse, and shipped production coverage

## Evidence

- `python -m unittest discover -s scripts -p 'test_*.py'` — 118 passed
- `python scripts/validate_governance.py` — passed, 13 evolution records valid
- `python scripts/build_manifest.py` — passed, 381 artifacts / 154 edges; no generated drift
- all 30 `.github` YAML files parse
- `git diff --check` — clean
- live GitHub Actions API evaluation — exit 1 as designed; red: capability-expansion, self-improvement, seldon-plan; other 8 producers healthy

Related: #702, #703, #704, #705

This PR is intentionally not merged.