### PR TITLE
fix(harness): fail closed on stale Octopus evidence

### DIFF
--- a/.claude/skills/demerzel-cross-review/SKILL.md
+++ b/.claude/skills/demerzel-cross-review/SKILL.md
@@ -18,6 +18,56 @@ No model reviews its own work. When one AI generates code, a different model rev
 /demerzel cross-review --configure              # Edit review matrix for this repo
 ```
 
+## Repo-scoped fail-closed gate
+
+Every Demerzel Octopus/cross-review run must be isolated and certified before
+it can report `COMPLETE`, update governance confidence, or post an approving PR
+comment. The plugin's global `~/.claude-octopus/results` directory is not an
+evidence source: it may contain results from unrelated or older runs.
+
+Create the run contract from the exact Git diff before dispatch:
+
+```powershell
+$runId = "review-$(Get-Date -Format yyyyMMddHHmmss)"
+$taskId = if ($env:PR_NUMBER) { "pr-$env:PR_NUMBER" } else { "diff-$runId" }
+python scripts/octopus_delivery_gate.py init `
+  --repo . `
+  --runs-dir .octo/runs `
+  --run-id $runId `
+  --task-id $taskId `
+  --commit-range "$env:BASE_SHA..$env:HEAD_SHA" `
+  --required-provider claude-sonnet `
+  --required-provider gemini
+```
+
+Each provider adapter writes one JSON result under
+`.octo/runs/<run-id>/providers/`, conforming to
+`schemas/octopus-review-result.schema.json`. It must copy the run ID, task ID,
+commit range, and SHA-256 diff fingerprint from that run's `request.json`.
+Never search another run or a global results directory as fallback.
+
+Before dispatch, adapters record a process-scoped preflight in the result:
+
+- Claude: CLI availability and auth-precedence compatibility.
+- Gemini: CLI/client eligibility and workspace trust.
+- All providers: no secret values in output; a preflight failure records
+  `status: preflight_failed` and `preflight.status: failed` without dispatch.
+
+After every required provider reaches a terminal status, certify the exact run:
+
+```powershell
+python scripts/octopus_delivery_gate.py certify `
+  --request ".octo/runs/$runId/request.json" `
+  --providers-dir ".octo/runs/$runId/providers" `
+  --output ".octo/runs/$runId/certification.json"
+```
+
+Exit code `0` is the only path to `COMPLETE`. Exit code `1` means the run is
+`BLOCKED`; exit code `2` means its evidence contract is invalid. Required
+provider failures/timeouts/skips, stale identities, missing diff evidence, and
+empty commit ranges all fail closed. Scorecard categories remain `unknown`
+unless their scores cite finding IDs from accepted current-run evidence.
+
 ## Review Matrix
 
 The core invariant: `reviewer != author`. The matrix encodes which model reviews which and why.

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ state/governance/dev-process-overseer.json
 
 # Local tooling / editor / per-session scratch (machine-specific, not repo content)
 .claude-octopus/
+.octo/runs/
 .claude/*.local.md
 .claude/scheduled_tasks.lock
 .claude/session-intent.md

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Demerzel/
 | Personas | 17 | `personas/*.persona.yaml` |
 | Policies | 45 | `policies/*.yaml` |
 | Grammars | 20 | `grammars/*.ebnf` |
-| Schemas | 43 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
+| Schemas | 45 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
 | Behavioral tests | 115 | `tests/behavioral/*.md` |
 | Skills | 69 | `.claude/skills/*/` |
 | Streeling departments | 23 | `state/streeling/departments/*.department.json` |

--- a/fixtures/octopus-delivery/irrelevant-no-diff/run-no-diff/providers/claude-sonnet.json
+++ b/fixtures/octopus-delivery/irrelevant-no-diff/run-no-diff/providers/claude-sonnet.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "provider": "claude-sonnet",
+  "status": "success",
+  "run_id": "run-no-diff",
+  "task_id": "review-no-diff",
+  "commit_range": "base..head",
+  "commit_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "preflight": {
+    "status": "passed",
+    "checks": [
+      "claude auth precedence"
+    ]
+  },
+  "evidence": {
+    "diff_received": false,
+    "files_reviewed": [],
+    "findings": [],
+    "summary": "No diff was provided."
+  },
+  "scorecard": {
+    "security": {
+      "score": 5,
+      "finding_ids": []
+    }
+  }
+}

--- a/fixtures/octopus-delivery/irrelevant-no-diff/run-no-diff/request.json
+++ b/fixtures/octopus-delivery/irrelevant-no-diff/run-no-diff/request.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "1.0",
+  "run_id": "run-no-diff",
+  "task_id": "review-no-diff",
+  "commit_range": "base..head",
+  "commit_fingerprint": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "required_providers": [
+    "claude-sonnet"
+  ]
+}

--- a/fixtures/octopus-delivery/success-current/run-current/providers/claude-sonnet.json
+++ b/fixtures/octopus-delivery/success-current/run-current/providers/claude-sonnet.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "1.0",
+  "provider": "claude-sonnet",
+  "status": "success",
+  "run_id": "run-current",
+  "task_id": "review-current-diff",
+  "commit_range": "base..head",
+  "commit_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "preflight": {
+    "status": "passed",
+    "checks": [
+      "claude auth precedence"
+    ]
+  },
+  "evidence": {
+    "diff_received": true,
+    "files_reviewed": [
+      "scripts/example.py"
+    ],
+    "findings": [
+      {
+        "id": "SEC-1",
+        "category": "security",
+        "summary": "Example current-run finding"
+      }
+    ]
+  },
+  "scorecard": {
+    "security": {
+      "score": 8,
+      "finding_ids": [
+        "SEC-1"
+      ]
+    },
+    "reliability": {
+      "score": 5,
+      "finding_ids": []
+    }
+  }
+}

--- a/fixtures/octopus-delivery/success-current/run-current/providers/gemini.json
+++ b/fixtures/octopus-delivery/success-current/run-current/providers/gemini.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0",
+  "provider": "gemini",
+  "status": "success",
+  "run_id": "run-current",
+  "task_id": "review-current-diff",
+  "commit_range": "base..head",
+  "commit_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "preflight": {
+    "status": "passed",
+    "checks": [
+      "gemini client eligibility",
+      "workspace trust"
+    ]
+  },
+  "evidence": {
+    "diff_received": true,
+    "files_reviewed": [
+      "scripts/example.py"
+    ],
+    "findings": []
+  }
+}

--- a/fixtures/octopus-delivery/success-current/run-current/request.json
+++ b/fixtures/octopus-delivery/success-current/run-current/request.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "run_id": "run-current",
+  "task_id": "review-current-diff",
+  "commit_range": "base..head",
+  "commit_fingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "required_providers": [
+    "claude-sonnet",
+    "gemini"
+  ]
+}

--- a/fixtures/octopus-delivery/timeout-stale/run-20260718/providers/claude-sonnet.json
+++ b/fixtures/octopus-delivery/timeout-stale/run-20260718/providers/claude-sonnet.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.0",
+  "provider": "claude-sonnet",
+  "status": "timeout",
+  "run_id": "run-20260718",
+  "task_id": "review-universal-freshness",
+  "commit_range": "96d960c..cb59ecd",
+  "commit_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "preflight": {
+    "status": "passed",
+    "checks": [
+      "claude auth precedence"
+    ]
+  },
+  "evidence": {
+    "diff_received": false,
+    "files_reviewed": [],
+    "findings": []
+  }
+}

--- a/fixtures/octopus-delivery/timeout-stale/run-20260718/providers/gemini.json
+++ b/fixtures/octopus-delivery/timeout-stale/run-20260718/providers/gemini.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0",
+  "provider": "gemini",
+  "status": "success",
+  "run_id": "run-20260429",
+  "task_id": "grasp-1777503661-0",
+  "commit_range": "old-base..old-head",
+  "commit_fingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "preflight": {
+    "status": "passed",
+    "checks": [
+      "gemini client eligibility",
+      "workspace trust"
+    ]
+  },
+  "evidence": {
+    "diff_received": true,
+    "files_reviewed": [
+      "old-file.md"
+    ],
+    "findings": []
+  }
+}

--- a/fixtures/octopus-delivery/timeout-stale/run-20260718/request.json
+++ b/fixtures/octopus-delivery/timeout-stale/run-20260718/request.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "run_id": "run-20260718",
+  "task_id": "review-universal-freshness",
+  "commit_range": "96d960c..cb59ecd",
+  "commit_fingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "required_providers": [
+    "claude-sonnet",
+    "gemini"
+  ]
+}

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -10,7 +10,7 @@
     "persona": 17,
     "pipeline": 23,
     "policy": 45,
-    "schema": 43,
+    "schema": 45,
     "seldon_schema": 7,
     "skill": 69,
     "streeling_schema": 1,
@@ -461,6 +461,14 @@
       {
         "name": "meta-audit.schema",
         "path": "schemas/meta-audit.schema.json"
+      },
+      {
+        "name": "octopus-review-request.schema",
+        "path": "schemas/octopus-review-request.schema.json"
+      },
+      {
+        "name": "octopus-review-result.schema",
+        "path": "schemas/octopus-review-result.schema.json"
       },
       {
         "name": "persona.schema",

--- a/schemas/octopus-review-request.schema.json
+++ b/schemas/octopus-review-request.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "octopus-review-request.schema.json",
+  "title": "Repo-scoped Octopus review request",
+  "description": "Identity and required-provider contract for one exact Git diff review run.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "task_id",
+    "commit_range",
+    "commit_fingerprint",
+    "required_providers"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0"
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "task_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+    },
+    "commit_range": {
+      "type": "string",
+      "minLength": 3
+    },
+    "commit_fingerprint": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "required_providers": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/octopus-review-result.schema.json
+++ b/schemas/octopus-review-result.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "octopus-review-result.schema.json",
+  "title": "Repo-scoped Octopus provider result",
+  "description": "Current-run provider outcome and evidence consumed by the fail-closed delivery gate.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "provider",
+    "status",
+    "run_id",
+    "task_id",
+    "commit_range",
+    "commit_fingerprint",
+    "preflight",
+    "evidence"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0"
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "enum": [
+        "success",
+        "failed",
+        "timeout",
+        "skipped",
+        "preflight_failed"
+      ]
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "task_id": {
+      "type": "string"
+    },
+    "commit_range": {
+      "type": "string"
+    },
+    "commit_fingerprint": {
+      "type": "string"
+    },
+    "preflight": {
+      "type": "object",
+      "required": [
+        "status",
+        "checks"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "passed",
+            "failed",
+            "not_run"
+          ]
+        },
+        "checks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "evidence": {
+      "type": "object",
+      "required": [
+        "diff_received",
+        "files_reviewed",
+        "findings"
+      ],
+      "properties": {
+        "diff_received": {
+          "type": "boolean"
+        },
+        "files_reviewed": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "category",
+              "summary"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "category": {
+                "type": "string",
+                "minLength": 1
+              },
+              "summary": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "summary": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "scorecard": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "score",
+          "finding_ids"
+        ],
+        "properties": {
+          "score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+          },
+          "finding_ids": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/octopus_delivery_gate.py
+++ b/scripts/octopus_delivery_gate.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Fail-closed certification for repo-scoped Octopus review evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+IDENTITY_FIELDS = (
+    "run_id",
+    "task_id",
+    "commit_range",
+    "commit_fingerprint",
+)
+SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def create_request(repo_root: Path | str,
+                   runs_dir: Path | str,
+                   run_id: str,
+                   task_id: str,
+                   commit_range: str,
+                   required_providers: list[str]) -> Path:
+    """Create a unique run request bound to the exact binary git diff."""
+    if not SAFE_ID.fullmatch(run_id) or not SAFE_ID.fullmatch(task_id):
+        raise ValueError("run_id and task_id must be filesystem-safe identifiers")
+    if not required_providers or not all(
+            isinstance(provider, str) and provider for provider in required_providers):
+        raise ValueError("at least one required provider is required")
+
+    repo_root = Path(repo_root).resolve()
+    runs_dir = Path(runs_dir).resolve()
+    expected_runs_dir = (repo_root / ".octo" / "runs").resolve()
+    if runs_dir != expected_runs_dir:
+        raise ValueError("runs_dir must be the repository's .octo/runs directory")
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "diff",
+            "--binary",
+            "--no-ext-diff",
+            commit_range,
+            "--",
+        ],
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        message = completed.stderr.decode(errors="replace").strip()
+        raise ValueError(f"cannot fingerprint commit range: {message}")
+    if not completed.stdout:
+        raise ValueError("commit range produced an empty diff")
+
+    run_dir = runs_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=False)
+    (run_dir / "providers").mkdir()
+    request = {
+        "schema_version": "1.0",
+        "run_id": run_id,
+        "task_id": task_id,
+        "commit_range": commit_range,
+        "commit_fingerprint": (
+            "sha256:" + hashlib.sha256(completed.stdout).hexdigest()),
+        "required_providers": sorted(set(required_providers)),
+    }
+    request_path = run_dir / "request.json"
+    request_path.write_text(
+        json.dumps(request, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return request_path
+
+
+def certify(request_path: Path | str,
+            providers_dir: Path | str) -> dict[str, Any]:
+    """Certify only evidence from the request's exact repo-scoped run directory."""
+    request_path = Path(request_path).resolve()
+    providers_dir = Path(providers_dir).resolve()
+    request = _load_json(request_path)
+
+    expected_dir = request_path.parent / "providers"
+    if providers_dir != expected_dir.resolve():
+        raise ValueError("provider evidence must come from the request run directory")
+    if request_path.parent.name != request.get("run_id"):
+        raise ValueError("request run_id must match its run directory name")
+
+    required = request.get("required_providers")
+    if not isinstance(required, list) or not required or not all(
+            isinstance(provider, str) and provider for provider in required):
+        raise ValueError("required_providers must be a non-empty string list")
+
+    successful: list[str] = []
+    failed: list[str] = []
+    skipped: list[str] = []
+    stale_rejected: list[str] = []
+    irrelevant_rejected: list[str] = []
+    scorecard: dict[str, Any] = {}
+
+    for result_path in sorted(providers_dir.glob("*.json")):
+        result = _load_json(result_path)
+        provider = result.get("provider")
+        if not isinstance(provider, str) or not provider:
+            irrelevant_rejected.append(result_path.stem)
+            continue
+
+        if any(result.get(field) != request.get(field)
+               for field in IDENTITY_FIELDS):
+            stale_rejected.append(provider)
+            continue
+
+        status = result.get("status")
+        preflight = result.get("preflight")
+        if status == "skipped":
+            skipped.append(provider)
+        elif (not isinstance(preflight, dict)
+              or preflight.get("status") != "passed"):
+            failed.append(provider)
+        elif status == "success":
+            evidence = result.get("evidence")
+            if (not isinstance(evidence, dict)
+                    or evidence.get("diff_received") is not True
+                    or not evidence.get("files_reviewed")):
+                irrelevant_rejected.append(provider)
+                continue
+            successful.append(provider)
+            findings = evidence.get("findings", [])
+            finding_ids = {
+                finding.get("id")
+                for finding in findings
+                if isinstance(finding, dict) and finding.get("id")
+            }
+            provider_scorecard = result.get("scorecard", {})
+            if isinstance(provider_scorecard, dict):
+                for category, entry in provider_scorecard.items():
+                    if not isinstance(category, str) or not isinstance(entry, dict):
+                        continue
+                    score = entry.get("score")
+                    references = entry.get("finding_ids")
+                    backed = (
+                        isinstance(score, (int, float))
+                        and not isinstance(score, bool)
+                        and 0 <= score <= 10
+                        and isinstance(references, list)
+                        and bool(references)
+                        and all(reference in finding_ids for reference in references)
+                    )
+                    if backed:
+                        if scorecard.get(category) == "unknown":
+                            scorecard[category] = {}
+                        scorecard.setdefault(category, {})[provider] = {
+                            "score": score,
+                            "finding_ids": references,
+                        }
+                    else:
+                        scorecard.setdefault(category, "unknown")
+        else:
+            failed.append(provider)
+
+    missing_required = sorted(set(required) - set(successful))
+    blocked = bool(missing_required or stale_rejected or irrelevant_rejected)
+    return {
+        "schema_version": "1.0",
+        "run_id": request["run_id"],
+        "task_id": request["task_id"],
+        "commit_range": request["commit_range"],
+        "commit_fingerprint": request["commit_fingerprint"],
+        "certification": "BLOCKED" if blocked else "COMPLETE",
+        "successful": sorted(successful),
+        "failed": sorted(failed),
+        "skipped": sorted(skipped),
+        "stale_rejected": sorted(stale_rejected),
+        "irrelevant_rejected": sorted(irrelevant_rejected),
+        "missing_required": missing_required,
+        "scorecard": dict(sorted(scorecard.items())),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Create and certify repo-scoped Octopus review runs")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = commands.add_parser(
+        "init", help="create a run request bound to a git diff")
+    init_parser.add_argument("--repo", required=True, type=Path)
+    init_parser.add_argument("--runs-dir", required=True, type=Path)
+    init_parser.add_argument("--run-id", required=True)
+    init_parser.add_argument("--task-id", required=True)
+    init_parser.add_argument("--commit-range", required=True)
+    init_parser.add_argument(
+        "--required-provider", action="append", required=True,
+        dest="required_providers")
+
+    certify_parser = commands.add_parser(
+        "certify", help="certify current-run provider evidence")
+    certify_parser.add_argument("--request", required=True, type=Path)
+    certify_parser.add_argument("--providers-dir", required=True, type=Path)
+    certify_parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "init":
+            request_path = create_request(
+                args.repo,
+                args.runs_dir,
+                args.run_id,
+                args.task_id,
+                args.commit_range,
+                args.required_providers,
+            )
+            print(request_path)
+            return 0
+        report = certify(args.request, args.providers_dir)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"octopus delivery gate: {error}", file=sys.stderr)
+        return 2
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"{report['certification']}: {args.output}")
+    return 0 if report["certification"] == "COMPLETE" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_octopus_delivery_gate.py
+++ b/scripts/test_octopus_delivery_gate.py
@@ -1,0 +1,165 @@
+import json
+import hashlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from scripts.octopus_delivery_gate import certify, create_request
+except ModuleNotFoundError:  # `unittest discover -s scripts` imports top-level tests.
+    from octopus_delivery_gate import certify, create_request
+
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "octopus-delivery"
+
+
+class OctopusDeliveryGateTests(unittest.TestCase):
+    def test_request_fingerprint_is_bound_to_exact_git_diff(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir) / "repo"
+            repo.mkdir()
+            subprocess.run(["git", "init", "-q", str(repo)], check=True)
+            subprocess.run(
+                ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(repo), "config", "user.name", "Test"],
+                check=True,
+            )
+            tracked = repo / "reviewed.txt"
+            tracked.write_text("before\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", "reviewed.txt"], check=True)
+            subprocess.run(["git", "-C", str(repo), "commit", "-qm", "base"], check=True)
+            base = subprocess.run(
+                ["git", "-C", str(repo), "rev-parse", "HEAD"],
+                capture_output=True,
+                check=True,
+                text=True,
+            ).stdout.strip()
+            tracked.write_text("after\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "commit", "-qam", "head"], check=True)
+            head = subprocess.run(
+                ["git", "-C", str(repo), "rev-parse", "HEAD"],
+                capture_output=True,
+                check=True,
+                text=True,
+            ).stdout.strip()
+            commit_range = f"{base}..{head}"
+
+            request_path = create_request(
+                repo,
+                repo / ".octo" / "runs",
+                "run-test",
+                "task-test",
+                commit_range,
+                ["claude-sonnet"],
+            )
+
+            diff = subprocess.run(
+                ["git", "-C", str(repo), "diff", "--binary", "--no-ext-diff",
+                 commit_range, "--"],
+                capture_output=True,
+                check=True,
+            ).stdout
+            request = json.loads(request_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                "sha256:" + hashlib.sha256(diff).hexdigest(),
+                request["commit_fingerprint"],
+            )
+            self.assertTrue((request_path.parent / "providers").is_dir())
+
+    def test_timeout_and_stale_global_results_fail_closed(self):
+        run_dir = FIXTURES / "timeout-stale" / "run-20260718"
+
+        report = certify(run_dir / "request.json", run_dir / "providers")
+
+        self.assertEqual("BLOCKED", report["certification"])
+        self.assertEqual(["claude-sonnet"], report["failed"])
+        self.assertEqual(["gemini"], report["stale_rejected"])
+        self.assertEqual([], report["successful"])
+        self.assertEqual(
+            ["claude-sonnet", "gemini"], report["missing_required"])
+        self.assertEqual({}, report["scorecard"])
+
+    def test_current_evidence_completes_without_default_scorecards(self):
+        run_dir = FIXTURES / "success-current" / "run-current"
+
+        report = certify(run_dir / "request.json", run_dir / "providers")
+
+        self.assertEqual("COMPLETE", report["certification"])
+        self.assertEqual(
+            ["claude-sonnet", "gemini"], report["successful"])
+        self.assertEqual({
+            "reliability": "unknown",
+            "security": {
+                "claude-sonnet": {
+                    "score": 8,
+                    "finding_ids": ["SEC-1"],
+                }
+            },
+        }, report["scorecard"])
+
+    def test_no_diff_result_is_rejected_as_irrelevant(self):
+        run_dir = FIXTURES / "irrelevant-no-diff" / "run-no-diff"
+
+        report = certify(run_dir / "request.json", run_dir / "providers")
+
+        self.assertEqual("BLOCKED", report["certification"])
+        self.assertEqual(["claude-sonnet"], report["irrelevant_rejected"])
+        self.assertEqual(["claude-sonnet"], report["missing_required"])
+        self.assertEqual({}, report["scorecard"])
+
+    def test_failed_provider_preflight_cannot_be_certified(self):
+        source = FIXTURES / "success-current" / "run-current"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            run_dir = Path(temp_dir) / "run-current"
+            shutil.copytree(source, run_dir)
+            result_path = run_dir / "providers" / "claude-sonnet.json"
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+            result["preflight"] = {
+                "status": "failed",
+                "checks": ["claude auth precedence"],
+            }
+            result_path.write_text(json.dumps(result), encoding="utf-8")
+
+            report = certify(run_dir / "request.json", run_dir / "providers")
+
+            self.assertEqual("BLOCKED", report["certification"])
+            self.assertEqual(["claude-sonnet"], report["failed"])
+            self.assertEqual(["gemini"], report["successful"])
+
+    def test_cli_writes_blocked_report_and_returns_nonzero(self):
+        run_dir = FIXTURES / "timeout-stale" / "run-20260718"
+        script = Path(__file__).with_name("octopus_delivery_gate.py")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "certification.json"
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "certify",
+                    "--request",
+                    str(run_dir / "request.json"),
+                    "--providers-dir",
+                    str(run_dir / "providers"),
+                    "--output",
+                    str(output),
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+
+            self.assertEqual(1, completed.returncode)
+            self.assertEqual(
+                "BLOCKED", json.loads(output.read_text(encoding="utf-8"))[
+                    "certification"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a repo-scoped Octopus review run contract bound to the SHA-256 of the exact binary Git diff
- accept provider evidence only from that run and require matching run ID, task ID, commit range, and fingerprint
- fail closed on required provider failure/timeout/skip, failed preflight, stale identity, and missing/no-diff evidence
- keep scorecard categories unknown unless they cite current-run finding IDs
- report successful, failed, skipped, stale-rejected, irrelevant-rejected, and missing providers separately
- wire the gate into the Demerzel cross-review skill and ignore transient `.octo/runs/` evidence

## Why

The observed Octopus delivery read old files from the global results directory and reported `COMPLETE` after current providers failed and synthesis fell back to stale April/May/June task headers. This tracer establishes the fail-closed certification seam without modifying the global Claude plugin cache or invoking provider APIs.

## Verification

- `python -m unittest discover -s scripts -p 'test_*.py'` — 124 tests passed
- `python scripts/validate_governance.py` — passed
- `python scripts/build_manifest.py` — 383 artifacts, 154 edges, no drift
- timeout + stale-results fixture — exit 1 / `BLOCKED`
- current evidence fixture — exit 0 / `COMPLETE`
- request/result fixtures validated against both new Draft 7 schemas

## Scope

This is the repo-scoped enforcement tracer for #700. Provider adapters still need to perform their provider-specific Claude auth and Gemini eligibility/trust checks, then write the required preflight/result envelopes; until they do, the gate blocks certification.

Refs #700