### PR TITLE
fix(seldon-plan): bound scheduled loop disable

### DIFF
--- a/.github/loop-health.yml
+++ b/.github/loop-health.yml
@@ -90,21 +90,19 @@ loops:
       adapter: workflow_run
       max_stale_days: 3
 
-  # This workflow is actually scheduled five times per day. It is therefore
-  # active, not "intentionally disabled". Its current failed scheduled run is
-  # deliberately red. A future bounded disable must remove the cron schedule
-  # and declare disabled.verification: schedule_absent.
+  # Bounded disable: repeated scheduled runs failed and issue #705 gates the
+  # 2026-10-16 revive-or-retire decision on fresh evidence and an explicit cap.
   - workflow: seldon-plan.yml
-    schedule:
-      - '0 6 * * *'
-      - '0 10 * * *'
-      - '0 14 * * *'
-      - '0 18 * * *'
-      - '0 22 * * *'
-    status: active
-    proof:
-      adapter: workflow_run
-      max_stale_days: 1
+    status: disabled
+    disabled:
+      reason: >-
+        Autonomous research scheduler paused after repeated failed scheduled
+        runs; issue #705 requires a revive-or-retire decision with fresh value
+        evidence and an explicit cost cap.
+      by: issue-705 (GuitarAlchemist governance)
+      since: '2026-07-18'
+      until: '2026-10-16'
+      verification: schedule_absent
 
   - workflow: streeling-daily.yml
     schedule:

--- a/.github/workflows/seldon-plan.yml
+++ b/.github/workflows/seldon-plan.yml
@@ -1,14 +1,6 @@
 name: Seldon Plan — Autonomous Research
 
 on:
-  schedule:
-    # Every 4 hours during active window: 06, 10, 14, 18, 22 UTC
-    # Max 5 scheduled runs/day — daily cap of 6 enforced by scheduler itself
-    - cron: '0 6 * * *'
-    - cron: '0 10 * * *'
-    - cron: '0 14 * * *'
-    - cron: '0 18 * * *'
-    - cron: '0 22 * * *'
   workflow_dispatch:
     inputs:
       department:

--- a/scripts/test_ecosystem_freshness.py
+++ b/scripts/test_ecosystem_freshness.py
@@ -727,11 +727,21 @@ class EcosystemFreshnessTest(unittest.TestCase):
         scheduled = set(ef.scheduled_workflows(
             repo / ef.DEFAULT_WORKFLOWS_DIR
         ))
+        active_loops = {
+            loop["workflow"] for loop in registry["loops"]
+            if loop.get("status") == "active"
+        }
+        disabled_loops = {
+            loop["workflow"] for loop in registry["loops"]
+            if loop.get("status") == "disabled"
+        }
         self.assertEqual(
             scheduled,
             set(registry["monitors"]) |
-            {loop["workflow"] for loop in registry["loops"]},
+            active_loops,
         )
+        self.assertTrue(disabled_loops)
+        self.assertTrue(disabled_loops.isdisjoint(scheduled))
 
     def test_production_workflows_enforce_daily_always_and_ci_paths(self):
         repo = Path(ef.REPO)


### PR DESCRIPTION
## Summary
- remove all cron schedules from `seldon-plan.yml` while preserving `workflow_dispatch` and its manual actions
- mark `seldon-plan` as a bounded disabled loop through 2026-10-16 with mechanical `schedule_absent` verification and issue #705 decision gate
- update the shipped registry coverage test to distinguish active scheduled loops from disabled workflow-dispatch-only loops

## Verification
- `python -m unittest discover -s scripts -p 'test_*.py'` (118 passed)
- `python scripts/validate_governance.py` (13 valid, 0 invalid)
- `python scripts/build_manifest.py` (manifest green; no count drift)
- direct YAML assertions: workflow_dispatch preserved, schedule absent, disabled metadata exact

Fixes #705
