### PR TITLE
feat: enforce AIW provider budget preflight

### DIFF
--- a/docs/workflows/aiw-budget-router.md
+++ b/docs/workflows/aiw-budget-router.md
@@ -135,7 +135,8 @@ current cycle spend, and an explicit `manual_approval` flag when needed:
 python scripts/aiw_budget_gate.py `
   --policy state/driver/aiw-budget-policy.json `
   --request .octo/aiw-request.json `
-  --ledger .octo/aiw-budget-ledger.json
+  --ledger .octo/aiw-budget-ledger.json `
+  --cycle-ledger .octo/aiw-cycle-ledger.json
 ```
 
 Exit `0` is the only allowed path to invocation. Exit `1` blocks the job before
@@ -144,6 +145,17 @@ workers (`gemini-cli`, `jules`, `notebooklm`) require explicit approval even whe
 their estimate is below the per-job cap. Claude Code CLI and Codex CLI are the
 preferred first workers for local-seat work; an `ANTHROPIC_API_KEY` fallback must
 carry the same budget block and approval rules.
+
+The cycle ledger is authoritative and reserved atomically before invocation;
+callers cannot supply their own aggregate spend or concurrency values. On
+terminal completion, release the reservation and record the provider receipt:
+
+```powershell
+python scripts/aiw_budget_gate.py --release-job aiw-0001 `
+  --actual-cost-usd 0.00 --cycle-ledger .octo/aiw-cycle-ledger.json `
+  --policy state/driver/aiw-budget-policy.json `
+  --request .octo/aiw-request.json --ledger .octo/aiw-budget-ledger.json
+```
 
 ## Non-goals
 

--- a/docs/workflows/aiw-budget-router.md
+++ b/docs/workflows/aiw-budget-router.md
@@ -127,9 +127,11 @@ See `examples/aiw-budget-ledger.example.json`.
 ## Executable preflight
 
 The policy is executable before a provider is invoked. `state/driver/aiw-budget-policy.json`
-allowlists the worker tiers and keeps local-seat tools first. Run the gate with a
-job request that contains the estimated tokens, calls, retries, runner minutes,
-current cycle spend, and an explicit `manual_approval` flag when needed:
+allowlists the worker tiers and keeps local-seat tools first. The policy, ledgers,
+approval artifact, and receipt are pinned to canonical repository paths; a caller
+may pass them explicitly but cannot redirect them to a caller-controlled file. Run
+the gate with a job request that contains the estimated tokens, calls, retries,
+runner minutes, and estimated cost:
 
 ```powershell
 python scripts/aiw_budget_gate.py `
@@ -142,19 +144,29 @@ python scripts/aiw_budget_gate.py `
 Exit `0` is the only allowed path to invocation. Exit `1` blocks the job before
 the provider call; exit `2` means the request or policy is invalid. Metered cloud
 workers (`gemini-cli`, `jules`, `notebooklm`) require explicit approval even when
-their estimate is below the per-job cap. Claude Code CLI and Codex CLI are the
-preferred first workers for local-seat work; an `ANTHROPIC_API_KEY` fallback must
-carry the same budget block and approval rules.
+their estimate is below the per-job cap. Approval is **not** a self-attested flag
+in the request: it is a separate `.octo/aiw-approval.json` artifact bound to the
+job id, provider, and exact request SHA-256; a `manual_approval` key inside the
+request is rejected. Claude Code CLI and Codex CLI are the preferred first workers
+for local-seat work; an `ANTHROPIC_API_KEY` fallback must carry the same budget
+block and approval rules.
 
 The cycle ledger is authoritative and reserved atomically before invocation;
-callers cannot supply their own aggregate spend or concurrency values. On
-terminal completion, release the reservation and record the provider receipt:
+callers cannot supply their own aggregate spend or concurrency values. A
+reservation is bound to its provider and request SHA-256, so a reused job id
+cannot inherit an old grant under a changed request. On terminal completion,
+release the reservation. Metered providers must supply a trusted
+`.octo/aiw-receipt.json` receipt whose issuer matches the policy's
+`trusted_receipt_issuer` and whose actual cost matches the released amount;
+spend over the reservation's admitted cap is recorded truthfully but returned as a
+blocking `over_budget` decision:
 
 ```powershell
 python scripts/aiw_budget_gate.py --release-job aiw-0001 `
   --actual-cost-usd 0.00 --cycle-ledger .octo/aiw-cycle-ledger.json `
   --policy state/driver/aiw-budget-policy.json `
-  --request .octo/aiw-request.json --ledger .octo/aiw-budget-ledger.json
+  --request .octo/aiw-request.json --ledger .octo/aiw-budget-ledger.json `
+  --receipt .octo/aiw-receipt.json
 ```
 
 ## Non-goals

--- a/docs/workflows/aiw-budget-router.md
+++ b/docs/workflows/aiw-budget-router.md
@@ -124,6 +124,27 @@ Each routed job should emit a budget ledger artifact with:
 
 See `examples/aiw-budget-ledger.example.json`.
 
+## Executable preflight
+
+The policy is executable before a provider is invoked. `state/driver/aiw-budget-policy.json`
+allowlists the worker tiers and keeps local-seat tools first. Run the gate with a
+job request that contains the estimated tokens, calls, retries, runner minutes,
+current cycle spend, and an explicit `manual_approval` flag when needed:
+
+```powershell
+python scripts/aiw_budget_gate.py `
+  --policy state/driver/aiw-budget-policy.json `
+  --request .octo/aiw-request.json `
+  --ledger .octo/aiw-budget-ledger.json
+```
+
+Exit `0` is the only allowed path to invocation. Exit `1` blocks the job before
+the provider call; exit `2` means the request or policy is invalid. Metered cloud
+workers (`gemini-cli`, `jules`, `notebooklm`) require explicit approval even when
+their estimate is below the per-job cap. Claude Code CLI and Codex CLI are the
+preferred first workers for local-seat work; an `ANTHROPIC_API_KEY` fallback must
+carry the same budget block and approval rules.
+
 ## Non-goals
 
 - This router does not own Demerzel policy.

--- a/scripts/aiw_budget_gate.py
+++ b/scripts/aiw_budget_gate.py
@@ -25,6 +25,17 @@ def _number(request: dict[str, Any], name: str) -> float:
     return float(value)
 
 
+def _cap(request: dict[str, Any], name: str, policy_default: Any) -> float:
+    """Allow a job to tighten policy caps, never widen them."""
+    default = _number({name: policy_default}, name)
+    if name not in request:
+        return default
+    value = _number(request, name)
+    if value > default:
+        raise ValueError(f"{name} cannot exceed policy default")
+    return value
+
+
 def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
     provider_id = request.get("provider")
     if not isinstance(provider_id, str) or not provider_id:
@@ -52,13 +63,13 @@ def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
     manual_approval = request.get("manual_approval") is True
 
     reasons: list[str] = []
-    max_cost = float(request.get("max_cost_usd", defaults["max_cost_usd"]))
-    max_tokens = float(request.get("max_total_tokens", defaults["max_total_tokens"]))
-    max_calls = float(request.get("max_model_calls", defaults["max_model_calls"]))
-    max_retries = float(request.get("max_retries", defaults["max_retries"]))
-    max_runner = float(request.get("max_runner_minutes", defaults["max_runner_minutes"]))
-    approval_threshold = float(
-        request.get("approval_required_above_usd", defaults["approval_required_above_usd"]))
+    max_cost = _cap(request, "max_cost_usd", defaults["max_cost_usd"])
+    max_tokens = _cap(request, "max_total_tokens", defaults["max_total_tokens"])
+    max_calls = _cap(request, "max_model_calls", defaults["max_model_calls"])
+    max_retries = _cap(request, "max_retries", defaults["max_retries"])
+    max_runner = _cap(request, "max_runner_minutes", defaults["max_runner_minutes"])
+    approval_threshold = _cap(
+        request, "approval_required_above_usd", defaults["approval_required_above_usd"])
 
     if estimated_cost > max_cost:
         reasons.append("job_cost_cap_exceeded")

--- a/scripts/aiw_budget_gate.py
+++ b/scripts/aiw_budget_gate.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Fail-closed budget preflight for one AIW provider invocation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+def _load(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _number(request: dict[str, Any], name: str) -> float:
+    value = request.get(name, 0)
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise ValueError(f"{name} must be a non-negative number")
+    return float(value)
+
+
+def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
+    provider_id = request.get("provider")
+    if not isinstance(provider_id, str) or not provider_id:
+        raise ValueError("provider is required")
+    providers = policy.get("providers")
+    if not isinstance(providers, list):
+        raise ValueError("policy.providers must be a list")
+    provider = next((item for item in providers
+                     if isinstance(item, dict) and item.get("id") == provider_id), None)
+    if provider is None:
+        raise ValueError(f"provider is not allowlisted: {provider_id}")
+
+    defaults = policy.get("defaults")
+    cycle = policy.get("cycle")
+    if not isinstance(defaults, dict) or not isinstance(cycle, dict):
+        raise ValueError("policy.defaults and policy.cycle are required")
+
+    estimated_cost = _number(request, "estimated_cost_usd")
+    cycle_spend = _number(request, "cycle_spend_usd")
+    tokens = _number(request, "estimated_total_tokens")
+    calls = _number(request, "estimated_model_calls")
+    retries = _number(request, "estimated_retries")
+    runner_minutes = _number(request, "estimated_runner_minutes")
+    active_packets = _number(request, "cycle_active_packets")
+    manual_approval = request.get("manual_approval") is True
+
+    reasons: list[str] = []
+    max_cost = float(request.get("max_cost_usd", defaults["max_cost_usd"]))
+    max_tokens = float(request.get("max_total_tokens", defaults["max_total_tokens"]))
+    max_calls = float(request.get("max_model_calls", defaults["max_model_calls"]))
+    max_retries = float(request.get("max_retries", defaults["max_retries"]))
+    max_runner = float(request.get("max_runner_minutes", defaults["max_runner_minutes"]))
+    approval_threshold = float(
+        request.get("approval_required_above_usd", defaults["approval_required_above_usd"]))
+
+    if estimated_cost > max_cost:
+        reasons.append("job_cost_cap_exceeded")
+    if cycle_spend + estimated_cost > float(cycle["max_cost_usd"]):
+        reasons.append("cycle_cost_cap_exceeded")
+    if tokens > max_tokens:
+        reasons.append("token_cap_exceeded")
+    if calls > max_calls:
+        reasons.append("model_call_cap_exceeded")
+    if retries > max_retries:
+        reasons.append("retry_cap_exceeded")
+    if runner_minutes > max_runner:
+        reasons.append("runner_minutes_cap_exceeded")
+    if active_packets >= float(cycle["max_parallel_packets"]):
+        reasons.append("parallel_packet_cap_exceeded")
+    if provider.get("requires_manual_approval") is True and not manual_approval:
+        reasons.append("provider_requires_manual_approval")
+    if estimated_cost > approval_threshold and not manual_approval:
+        reasons.append("approval_threshold_exceeded")
+
+    return {
+        "schema_version": "1.0",
+        "job_id": request.get("job_id", "unidentified"),
+        "provider": provider_id,
+        "tier": provider.get("tier"),
+        "decision": "allow" if not reasons else "block",
+        "reasons": reasons,
+        "budget": {
+            "estimated_cost_usd": estimated_cost,
+            "cycle_spend_usd": cycle_spend,
+            "estimated_total_tokens": int(tokens),
+            "estimated_model_calls": int(calls),
+            "estimated_retries": int(retries),
+            "estimated_runner_minutes": runner_minutes,
+            "max_cost_usd": max_cost,
+            "max_total_tokens": max_tokens,
+            "max_model_calls": max_calls,
+            "max_retries": max_retries,
+            "max_runner_minutes": max_runner,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--policy", required=True, type=Path)
+    parser.add_argument("--request", required=True, type=Path)
+    parser.add_argument("--ledger", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        result = evaluate(_load(args.policy), _load(args.request))
+        args.ledger.parent.mkdir(parents=True, exist_ok=True)
+        args.ledger.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n",
+                               encoding="utf-8")
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"aiw budget gate: {error}", file=sys.stderr)
+        return 2
+    print(f"{result['decision'].upper()}: {args.ledger}")
+    return 0 if result["decision"] == "allow" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/aiw_budget_gate.py
+++ b/scripts/aiw_budget_gate.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime
+import hashlib
 import json
 import math
 import os
@@ -11,6 +13,14 @@ from pathlib import Path
 import sys
 import time
 from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / "state" / "driver" / "aiw-budget-policy.json"
+LEDGER_PATH = REPO_ROOT / ".octo" / "aiw-budget-ledger.json"
+CYCLE_LEDGER_PATH = REPO_ROOT / ".octo" / "aiw-cycle-ledger.json"
+APPROVAL_PATH = REPO_ROOT / ".octo" / "aiw-approval.json"
+RECEIPT_PATH = REPO_ROOT / ".octo" / "aiw-receipt.json"
 
 
 def _load(path: Path) -> dict[str, Any]:
@@ -46,9 +56,96 @@ def _required_number(value: dict[str, Any], name: str) -> float:
     return _number(value, name)
 
 
+def _required_string(value: dict[str, Any], name: str) -> str:
+    item = value.get(name)
+    if not isinstance(item, str) or not item.strip():
+        raise ValueError(f"{name} is required")
+    return item
+
+
+def _timestamp(value: dict[str, Any], name: str) -> str:
+    item = _required_string(value, name)
+    try:
+        datetime.fromisoformat(item.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{name} must be an ISO-8601 timestamp") from error
+    return item
+
+
+def _request_sha256(request: dict[str, Any]) -> str:
+    """Bind authority and receipts to the provider request, not cycle aggregates."""
+    if "manual_approval" in request:
+        raise ValueError("manual_approval is not accepted in provider requests")
+    bound = {key: value for key, value in request.items()
+             if key not in {"cycle_spend_usd", "cycle_active_packets"}}
+    payload = json.dumps(bound, sort_keys=True, separators=(",", ":"),
+                         ensure_ascii=False, allow_nan=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _provider(policy: dict[str, Any], provider_id: Any) -> dict[str, Any]:
+    if not isinstance(provider_id, str) or not provider_id:
+        raise ValueError("provider is required")
+    providers = policy.get("providers")
+    if not isinstance(providers, list):
+        raise ValueError("policy.providers must be a list")
+    provider = next((item for item in providers
+                     if isinstance(item, dict) and item.get("id") == provider_id), None)
+    if provider is None:
+        raise ValueError(f"provider is not allowlisted: {provider_id}")
+    return provider
+
+
+def _is_metered(provider: dict[str, Any]) -> bool:
+    """Metered providers bill real money and require a trusted receipt."""
+    return provider.get("tier") == "metered-cloud"
+
+
+def _validate_approval(approval: dict[str, Any] | None, request: dict[str, Any],
+                       request_sha256: str) -> bool:
+    if approval is None:
+        return False
+    expected = {
+        "schema_version": "1.0",
+        "kind": "human-approval",
+        "decision": "approve",
+        "job_id": request.get("job_id"),
+        "provider": request.get("provider"),
+        "request_sha256": request_sha256,
+    }
+    for name, value in expected.items():
+        if approval.get(name) != value:
+            raise ValueError(f"approval {name} does not match the request")
+    _required_string(approval, "approval_id")
+    _required_string(approval, "approver")
+    _timestamp(approval, "approved_at")
+    return True
+
+
+def _validate_receipt(policy: dict[str, Any], receipt: dict[str, Any],
+                      reservation: dict[str, Any]) -> tuple[str, float]:
+    provider = _provider(policy, reservation.get("provider"))
+    expected = {
+        "schema_version": "1.0",
+        "kind": "provider-receipt",
+        "job_id": reservation.get("job_id"),
+        "provider": reservation.get("provider"),
+        "request_sha256": reservation.get("request_sha256"),
+        "issuer": provider.get("trusted_receipt_issuer"),
+    }
+    for name, value in expected.items():
+        if value is None or receipt.get(name) != value:
+            raise ValueError(f"receipt {name} is not trusted for the reservation")
+    receipt_id = _required_string(receipt, "receipt_id")
+    _timestamp(receipt, "observed_at")
+    actual_cost = _required_number(receipt, "actual_cost_usd")
+    return receipt_id, actual_cost
+
+
 def _lock(path: Path):
     """Acquire a short-lived cross-process lock; fail closed if contended."""
     lock_path = Path(f"{path}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
     for _ in range(40):
         try:
             descriptor = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
@@ -81,28 +178,45 @@ def _read_cycle(path: Path) -> dict[str, Any]:
     return value
 
 
-def reserve(policy: dict[str, Any], request: dict[str, Any], cycle_path: Path) -> dict[str, Any]:
+def reserve(policy: dict[str, Any], request: dict[str, Any], cycle_path: Path,
+            approval: dict[str, Any] | None = None) -> dict[str, Any]:
     """Atomically reserve cycle capacity before the provider is invoked."""
     job_id = request.get("job_id")
     if not isinstance(job_id, str) or not job_id:
         raise ValueError("job_id is required for a cycle reservation")
+    request_sha256 = _request_sha256(request)
+    provider_id = request.get("provider")
     lock_path = _lock(cycle_path)
     try:
         cycle = _read_cycle(cycle_path)
         reservations = cycle["reservations"]
         if job_id in reservations:
             reservation = reservations[job_id]
+            # Reused job ids must carry the identical provider + request
+            # fingerprint; a changed request cannot inherit an old grant.
+            if (reservation.get("request_sha256") != request_sha256
+                    or reservation.get("provider") != provider_id):
+                raise ValueError(
+                    f"job_id {job_id} reused with a different request fingerprint")
             return {"schema_version": "1.0", "job_id": job_id,
-                    "provider": request.get("provider"), "decision": "allow",
+                    "provider": provider_id, "decision": "allow",
                     "reasons": [], "reservation_reused": True,
+                    "request_sha256": request_sha256,
                     "budget": {"estimated_cost_usd": reservation["estimated_cost_usd"]}}
         result = evaluate(policy, {**request,
                                    "cycle_spend_usd": (cycle["reserved_cost_usd"]
                                                         + cycle["actual_cost_usd"]),
-                                   "cycle_active_packets": cycle["active_packets"]})
+                                   "cycle_active_packets": cycle["active_packets"]},
+                          approval=approval)
         if result["decision"] == "allow":
             estimate = result["budget"]["estimated_cost_usd"]
-            reservations[job_id] = {"estimated_cost_usd": estimate}
+            reservations[job_id] = {
+                "estimated_cost_usd": estimate,
+                "provider": provider_id,
+                "request_sha256": request_sha256,
+                "max_cost_usd": result["budget"]["max_cost_usd"],
+                "metered": _is_metered(_provider(policy, provider_id)),
+            }
             cycle["reserved_cost_usd"] += estimate
             cycle["active_packets"] += 1
             cycle_path.parent.mkdir(parents=True, exist_ok=True)
@@ -113,49 +227,75 @@ def reserve(policy: dict[str, Any], request: dict[str, Any], cycle_path: Path) -
         lock_path.unlink(missing_ok=True)
 
 
-def release(cycle_path: Path, job_id: str, actual_cost_usd: float) -> dict[str, Any]:
-    """Release a reservation and record the provider receipt when available."""
+def release(cycle_path: Path, job_id: str, actual_cost_usd: float,
+            policy: dict[str, Any] | None = None,
+            receipt: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Release a reservation and reconcile the trusted provider receipt.
+
+    Metered providers must supply a trusted receipt whose actual cost matches
+    the released amount; spend over the reservation's admitted cap is recorded
+    truthfully but returned as a blocking ``over_budget`` decision.
+    """
     if not job_id:
         raise ValueError("job_id is required for release")
-    if not math.isfinite(actual_cost_usd) or actual_cost_usd < 0:
+    if actual_cost_usd is None or not math.isfinite(actual_cost_usd) or actual_cost_usd < 0:
         raise ValueError("actual_cost_usd must be a non-negative number")
     lock_path = _lock(cycle_path)
     try:
         cycle = _read_cycle(cycle_path)
-        reservation = cycle["reservations"].pop(job_id, None)
+        reservation = cycle["reservations"].get(job_id)
         if reservation is None:
             raise ValueError(f"no reservation for job: {job_id}")
+
+        reasons: list[str] = []
+        receipt_id: str | None = None
+        actual = actual_cost_usd
+        if reservation.get("metered"):
+            if receipt is None:
+                raise ValueError(
+                    "a trusted provider receipt is required to release a metered job")
+            if policy is None:
+                raise ValueError("policy is required to validate a metered receipt")
+            receipt_id, receipt_actual = _validate_receipt(
+                policy, receipt, {**reservation, "job_id": job_id})
+            if not math.isclose(receipt_actual, actual_cost_usd, rel_tol=0, abs_tol=1e-9):
+                raise ValueError(
+                    "receipt actual_cost_usd does not match the released amount")
+            actual = receipt_actual
+            cap = reservation.get("max_cost_usd")
+            if cap is not None and actual > cap:
+                reasons.append("actual_cost_cap_exceeded")
+
+        cycle["reservations"].pop(job_id)
         cycle["reserved_cost_usd"] -= reservation["estimated_cost_usd"]
         cycle["active_packets"] -= 1
-        cycle["actual_cost_usd"] = cycle.get("actual_cost_usd", 0) + actual_cost_usd
+        cycle["actual_cost_usd"] = cycle.get("actual_cost_usd", 0) + actual
         cycle_path.write_text(json.dumps(cycle, indent=2, sort_keys=True,
                                          allow_nan=False) + "\n", encoding="utf-8")
-        return {"decision": "released", "job_id": job_id,
-                "actual_cost_usd": actual_cost_usd}
+        result = {"decision": "over_budget" if reasons else "released",
+                  "job_id": job_id, "actual_cost_usd": actual, "reasons": reasons}
+        if receipt_id is not None:
+            result["receipt_id"] = receipt_id
+        return result
     finally:
         lock_path.unlink(missing_ok=True)
 
 
-def _canonical_cycle_path(policy_path: Path, supplied: Path) -> Path:
-    """Bind the aggregate ledger to this repository's canonical runtime path."""
-    policy_path = policy_path.resolve()
-    expected = policy_path.parents[2] / ".octo" / "aiw-cycle-ledger.json"
-    if supplied.resolve() != expected.resolve():
-        raise ValueError(f"cycle ledger must be {expected}")
-    return expected
+def _bind_canonical(name: str, supplied: Path, canonical: Path) -> Path:
+    """Pin a runtime path to this repository, never the caller's directory.
+
+    The policy and ledgers are governance state; a caller cannot redirect them
+    to an attacker-controlled file by passing a different path.
+    """
+    if supplied.resolve() != canonical.resolve():
+        raise ValueError(f"{name} must be {canonical}")
+    return canonical.resolve()
 
 
-def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
+def evaluate(policy: dict[str, Any], request: dict[str, Any],
+             approval: dict[str, Any] | None = None) -> dict[str, Any]:
     provider_id = request.get("provider")
-    if not isinstance(provider_id, str) or not provider_id:
-        raise ValueError("provider is required")
-    providers = policy.get("providers")
-    if not isinstance(providers, list):
-        raise ValueError("policy.providers must be a list")
-    provider = next((item for item in providers
-                     if isinstance(item, dict) and item.get("id") == provider_id), None)
-    if provider is None:
-        raise ValueError(f"provider is not allowlisted: {provider_id}")
+    provider = _provider(policy, provider_id)
 
     defaults = policy.get("defaults")
     cycle = policy.get("cycle")
@@ -171,7 +311,12 @@ def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
     retries = _number(request, "estimated_retries")
     runner_minutes = _number(request, "estimated_runner_minutes")
     active_packets = _number(request, "cycle_active_packets")
-    manual_approval = request.get("manual_approval") is True
+
+    # Fingerprint and approval bind authority to this exact request; compute
+    # after the numeric fields are validated so bad inputs fail with clear
+    # messages rather than a JSON-serialization error.
+    request_sha256 = _request_sha256(request)
+    manual_approval = _validate_approval(approval, request, request_sha256)
 
     reasons: list[str] = []
     max_cost = _cap(request, "max_cost_usd", defaults["max_cost_usd"])
@@ -206,6 +351,7 @@ def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
         "job_id": request.get("job_id", "unidentified"),
         "provider": provider_id,
         "tier": provider.get("tier"),
+        "request_sha256": request_sha256,
         "decision": "allow" if not reasons else "block",
         "reasons": reasons,
         "budget": {
@@ -226,30 +372,45 @@ def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--policy", required=True, type=Path)
-    parser.add_argument("--request", required=True, type=Path)
-    parser.add_argument("--ledger", required=True, type=Path)
-    parser.add_argument("--cycle-ledger", required=True, type=Path)
+    parser.add_argument("--policy", type=Path, default=POLICY_PATH)
+    parser.add_argument("--request", type=Path)
+    parser.add_argument("--ledger", type=Path, default=LEDGER_PATH)
+    parser.add_argument("--cycle-ledger", type=Path, default=CYCLE_LEDGER_PATH)
+    parser.add_argument("--approval", type=Path, default=APPROVAL_PATH)
+    parser.add_argument("--receipt", type=Path, default=RECEIPT_PATH)
     parser.add_argument("--release-job")
     parser.add_argument("--actual-cost-usd", type=float)
     args = parser.parse_args(argv)
     try:
-        cycle_path = _canonical_cycle_path(args.policy, args.cycle_ledger)
+        # Policy and ledgers are pinned to canonical repository paths; the
+        # caller may pass them explicitly but cannot redirect them elsewhere.
+        _bind_canonical("--policy", args.policy, POLICY_PATH)
+        _bind_canonical("--ledger", args.ledger, LEDGER_PATH)
+        _bind_canonical("--cycle-ledger", args.cycle_ledger, CYCLE_LEDGER_PATH)
+        _bind_canonical("--approval", args.approval, APPROVAL_PATH)
+        _bind_canonical("--receipt", args.receipt, RECEIPT_PATH)
+        policy = _load(POLICY_PATH)
         if args.release_job:
             if args.actual_cost_usd is None:
                 raise ValueError("--actual-cost-usd is required with --release-job")
-            result = release(cycle_path, args.release_job, args.actual_cost_usd)
+            receipt = _load(RECEIPT_PATH) if RECEIPT_PATH.exists() else None
+            result = release(CYCLE_LEDGER_PATH, args.release_job, args.actual_cost_usd,
+                             policy=policy, receipt=receipt)
         else:
-            result = reserve(_load(args.policy), _load(args.request), cycle_path)
-        args.ledger.parent.mkdir(parents=True, exist_ok=True)
-        args.ledger.write_text(json.dumps(result, indent=2, sort_keys=True,
+            if args.request is None:
+                raise ValueError("--request is required to reserve a job")
+            approval = _load(APPROVAL_PATH) if APPROVAL_PATH.exists() else None
+            result = reserve(policy, _load(args.request), CYCLE_LEDGER_PATH,
+                             approval=approval)
+        LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
+        LEDGER_PATH.write_text(json.dumps(result, indent=2, sort_keys=True,
                                           allow_nan=False) + "\n",
                                encoding="utf-8")
     except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
         print(f"aiw budget gate: {error}", file=sys.stderr)
         return 2
-    print(f"{result['decision'].upper()}: {args.ledger}")
-    return 0 if result["decision"] == "allow" else 1
+    print(f"{result['decision'].upper()}: {LEDGER_PATH}")
+    return 0 if result["decision"] in {"allow", "released"} else 1
 
 
 if __name__ == "__main__":

--- a/scripts/aiw_budget_gate.py
+++ b/scripts/aiw_budget_gate.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
+import os
 from pathlib import Path
 import sys
+import time
 from typing import Any
 
 
@@ -20,7 +23,8 @@ def _load(path: Path) -> dict[str, Any]:
 
 def _number(request: dict[str, Any], name: str) -> float:
     value = request.get(name, 0)
-    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+    if (isinstance(value, bool) or not isinstance(value, (int, float))
+            or not math.isfinite(value) or value < 0):
         raise ValueError(f"{name} must be a non-negative number")
     return float(value)
 
@@ -34,6 +38,85 @@ def _cap(request: dict[str, Any], name: str, policy_default: Any) -> float:
     if value > default:
         raise ValueError(f"{name} cannot exceed policy default")
     return value
+
+
+def _lock(path: Path):
+    """Acquire a short-lived cross-process lock; fail closed if contended."""
+    lock_path = Path(f"{path}.lock")
+    for _ in range(40):
+        try:
+            descriptor = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(descriptor)
+            return lock_path
+        except FileExistsError:
+            time.sleep(0.05)
+    raise ValueError("cycle ledger is busy")
+
+
+def _read_cycle(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"reserved_cost_usd": 0.0, "active_packets": 0, "reservations": {}}
+    value = _load(path)
+    for name in ("reserved_cost_usd", "active_packets"):
+        _number(value, name)
+    reservations = value.get("reservations", {})
+    if not isinstance(reservations, dict):
+        raise ValueError("cycle ledger reservations must be an object")
+    return value
+
+
+def reserve(policy: dict[str, Any], request: dict[str, Any], cycle_path: Path) -> dict[str, Any]:
+    """Atomically reserve cycle capacity before the provider is invoked."""
+    job_id = request.get("job_id")
+    if not isinstance(job_id, str) or not job_id:
+        raise ValueError("job_id is required for a cycle reservation")
+    lock_path = _lock(cycle_path)
+    try:
+        cycle = _read_cycle(cycle_path)
+        reservations = cycle["reservations"]
+        if job_id in reservations:
+            result = evaluate(policy, {**request,
+                                       "cycle_spend_usd": cycle["reserved_cost_usd"],
+                                       "cycle_active_packets": cycle["active_packets"]})
+            result["reservation_reused"] = True
+            return result
+        result = evaluate(policy, {**request,
+                                   "cycle_spend_usd": cycle["reserved_cost_usd"],
+                                   "cycle_active_packets": cycle["active_packets"]})
+        if result["decision"] == "allow":
+            estimate = result["budget"]["estimated_cost_usd"]
+            reservations[job_id] = {"estimated_cost_usd": estimate}
+            cycle["reserved_cost_usd"] += estimate
+            cycle["active_packets"] += 1
+            cycle_path.parent.mkdir(parents=True, exist_ok=True)
+            cycle_path.write_text(json.dumps(cycle, indent=2, sort_keys=True,
+                                             allow_nan=False) + "\n", encoding="utf-8")
+        return result
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+
+def release(cycle_path: Path, job_id: str, actual_cost_usd: float) -> dict[str, Any]:
+    """Release a reservation and record the provider receipt when available."""
+    if not job_id:
+        raise ValueError("job_id is required for release")
+    if not math.isfinite(actual_cost_usd) or actual_cost_usd < 0:
+        raise ValueError("actual_cost_usd must be a non-negative number")
+    lock_path = _lock(cycle_path)
+    try:
+        cycle = _read_cycle(cycle_path)
+        reservation = cycle["reservations"].pop(job_id, None)
+        if reservation is None:
+            raise ValueError(f"no reservation for job: {job_id}")
+        cycle["reserved_cost_usd"] -= reservation["estimated_cost_usd"]
+        cycle["active_packets"] -= 1
+        cycle["actual_cost_usd"] = cycle.get("actual_cost_usd", 0) + actual_cost_usd
+        cycle_path.write_text(json.dumps(cycle, indent=2, sort_keys=True,
+                                         allow_nan=False) + "\n", encoding="utf-8")
+        return {"decision": "released", "job_id": job_id,
+                "actual_cost_usd": actual_cost_usd}
+    finally:
+        lock_path.unlink(missing_ok=True)
 
 
 def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
@@ -118,11 +201,20 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--policy", required=True, type=Path)
     parser.add_argument("--request", required=True, type=Path)
     parser.add_argument("--ledger", required=True, type=Path)
+    parser.add_argument("--cycle-ledger", required=True, type=Path)
+    parser.add_argument("--release-job")
+    parser.add_argument("--actual-cost-usd", type=float)
     args = parser.parse_args(argv)
     try:
-        result = evaluate(_load(args.policy), _load(args.request))
+        if args.release_job:
+            if args.actual_cost_usd is None:
+                raise ValueError("--actual-cost-usd is required with --release-job")
+            result = release(args.cycle_ledger, args.release_job, args.actual_cost_usd)
+        else:
+            result = reserve(_load(args.policy), _load(args.request), args.cycle_ledger)
         args.ledger.parent.mkdir(parents=True, exist_ok=True)
-        args.ledger.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n",
+        args.ledger.write_text(json.dumps(result, indent=2, sort_keys=True,
+                                          allow_nan=False) + "\n",
                                encoding="utf-8")
     except (OSError, ValueError, json.JSONDecodeError) as error:
         print(f"aiw budget gate: {error}", file=sys.stderr)

--- a/scripts/aiw_budget_gate.py
+++ b/scripts/aiw_budget_gate.py
@@ -40,6 +40,12 @@ def _cap(request: dict[str, Any], name: str, policy_default: Any) -> float:
     return value
 
 
+def _required_number(value: dict[str, Any], name: str) -> float:
+    if name not in value:
+        raise ValueError(f"{name} is required")
+    return _number(value, name)
+
+
 def _lock(path: Path):
     """Acquire a short-lived cross-process lock; fail closed if contended."""
     lock_path = Path(f"{path}.lock")
@@ -55,13 +61,23 @@ def _lock(path: Path):
 
 def _read_cycle(path: Path) -> dict[str, Any]:
     if not path.exists():
-        return {"reserved_cost_usd": 0.0, "active_packets": 0, "reservations": {}}
+        return {"reserved_cost_usd": 0.0, "actual_cost_usd": 0.0,
+                "active_packets": 0, "reservations": {}}
     value = _load(path)
-    for name in ("reserved_cost_usd", "active_packets"):
-        _number(value, name)
+    for name in ("reserved_cost_usd", "actual_cost_usd", "active_packets"):
+        _required_number(value, name)
     reservations = value.get("reservations", {})
     if not isinstance(reservations, dict):
         raise ValueError("cycle ledger reservations must be an object")
+    reserved = sum(_required_number(item, "estimated_cost_usd")
+                   for item in reservations.values()
+                   if isinstance(item, dict))
+    if len(reservations) != sum(isinstance(item, dict) for item in reservations.values()):
+        raise ValueError("cycle ledger reservation entries must be objects")
+    if not math.isclose(reserved, value["reserved_cost_usd"], rel_tol=0, abs_tol=1e-9):
+        raise ValueError("cycle ledger reserved cost does not match reservations")
+    if value["active_packets"] != len(reservations):
+        raise ValueError("cycle ledger active packet count does not match reservations")
     return value
 
 
@@ -75,13 +91,14 @@ def reserve(policy: dict[str, Any], request: dict[str, Any], cycle_path: Path) -
         cycle = _read_cycle(cycle_path)
         reservations = cycle["reservations"]
         if job_id in reservations:
-            result = evaluate(policy, {**request,
-                                       "cycle_spend_usd": cycle["reserved_cost_usd"],
-                                       "cycle_active_packets": cycle["active_packets"]})
-            result["reservation_reused"] = True
-            return result
+            reservation = reservations[job_id]
+            return {"schema_version": "1.0", "job_id": job_id,
+                    "provider": request.get("provider"), "decision": "allow",
+                    "reasons": [], "reservation_reused": True,
+                    "budget": {"estimated_cost_usd": reservation["estimated_cost_usd"]}}
         result = evaluate(policy, {**request,
-                                   "cycle_spend_usd": cycle["reserved_cost_usd"],
+                                   "cycle_spend_usd": (cycle["reserved_cost_usd"]
+                                                        + cycle["actual_cost_usd"]),
                                    "cycle_active_packets": cycle["active_packets"]})
         if result["decision"] == "allow":
             estimate = result["budget"]["estimated_cost_usd"]
@@ -119,6 +136,15 @@ def release(cycle_path: Path, job_id: str, actual_cost_usd: float) -> dict[str, 
         lock_path.unlink(missing_ok=True)
 
 
+def _canonical_cycle_path(policy_path: Path, supplied: Path) -> Path:
+    """Bind the aggregate ledger to this repository's canonical runtime path."""
+    policy_path = policy_path.resolve()
+    expected = policy_path.parents[2] / ".octo" / "aiw-cycle-ledger.json"
+    if supplied.resolve() != expected.resolve():
+        raise ValueError(f"cycle ledger must be {expected}")
+    return expected
+
+
 def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
     provider_id = request.get("provider")
     if not isinstance(provider_id, str) or not provider_id:
@@ -135,6 +161,8 @@ def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
     cycle = policy.get("cycle")
     if not isinstance(defaults, dict) or not isinstance(cycle, dict):
         raise ValueError("policy.defaults and policy.cycle are required")
+    cycle_max_cost = _required_number(cycle, "max_cost_usd")
+    cycle_max_parallel = _required_number(cycle, "max_parallel_packets")
 
     estimated_cost = _number(request, "estimated_cost_usd")
     cycle_spend = _number(request, "cycle_spend_usd")
@@ -156,7 +184,7 @@ def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
 
     if estimated_cost > max_cost:
         reasons.append("job_cost_cap_exceeded")
-    if cycle_spend + estimated_cost > float(cycle["max_cost_usd"]):
+    if cycle_spend + estimated_cost > cycle_max_cost:
         reasons.append("cycle_cost_cap_exceeded")
     if tokens > max_tokens:
         reasons.append("token_cap_exceeded")
@@ -166,7 +194,7 @@ def evaluate(policy: dict[str, Any], request: dict[str, Any]) -> dict[str, Any]:
         reasons.append("retry_cap_exceeded")
     if runner_minutes > max_runner:
         reasons.append("runner_minutes_cap_exceeded")
-    if active_packets >= float(cycle["max_parallel_packets"]):
+    if active_packets >= cycle_max_parallel:
         reasons.append("parallel_packet_cap_exceeded")
     if provider.get("requires_manual_approval") is True and not manual_approval:
         reasons.append("provider_requires_manual_approval")
@@ -206,17 +234,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--actual-cost-usd", type=float)
     args = parser.parse_args(argv)
     try:
+        cycle_path = _canonical_cycle_path(args.policy, args.cycle_ledger)
         if args.release_job:
             if args.actual_cost_usd is None:
                 raise ValueError("--actual-cost-usd is required with --release-job")
-            result = release(args.cycle_ledger, args.release_job, args.actual_cost_usd)
+            result = release(cycle_path, args.release_job, args.actual_cost_usd)
         else:
-            result = reserve(_load(args.policy), _load(args.request), args.cycle_ledger)
+            result = reserve(_load(args.policy), _load(args.request), cycle_path)
         args.ledger.parent.mkdir(parents=True, exist_ok=True)
         args.ledger.write_text(json.dumps(result, indent=2, sort_keys=True,
                                           allow_nan=False) + "\n",
                                encoding="utf-8")
-    except (OSError, ValueError, json.JSONDecodeError) as error:
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
         print(f"aiw budget gate: {error}", file=sys.stderr)
         return 2
     print(f"{result['decision'].upper()}: {args.ledger}")

--- a/scripts/test_aiw_budget_gate.py
+++ b/scripts/test_aiw_budget_gate.py
@@ -72,6 +72,12 @@ class BudgetGateTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "non-negative number"):
             evaluate(POLICY, request(estimated_cost_usd=float("nan")))
 
+    def test_nan_policy_cycle_cap_is_rejected(self):
+        policy = json.loads(json.dumps(POLICY))
+        policy["cycle"]["max_cost_usd"] = float("nan")
+        with self.assertRaisesRegex(ValueError, "non-negative number"):
+            evaluate(policy, request())
+
     def test_cycle_reservation_blocks_aggregate_overrun(self):
         from aiw_budget_gate import reserve
         policy = json.loads(json.dumps(POLICY))
@@ -94,6 +100,17 @@ class BudgetGateTests(unittest.TestCase):
             state = json.loads(cycle.read_text())
             self.assertEqual(0, state["active_packets"])
             self.assertEqual(0.25, state["actual_cost_usd"])
+
+    def test_actual_receipts_count_against_next_reservation(self):
+        from aiw_budget_gate import release, reserve
+        policy = json.loads(json.dumps(POLICY))
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            reserve(policy, request(job_id="one"), cycle)
+            release(cycle, "one", 10.0)
+            result = reserve(policy, request(job_id="two", estimated_cost_usd=1), cycle)
+            self.assertEqual("block", result["decision"])
+            self.assertIn("cycle_cost_cap_exceeded", result["reasons"])
 
     def test_cli_ledger_shape_is_json_serializable(self):
         result = evaluate(POLICY, request())

--- a/scripts/test_aiw_budget_gate.py
+++ b/scripts/test_aiw_budget_gate.py
@@ -1,0 +1,76 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from aiw_budget_gate import evaluate
+
+
+ROOT = Path(__file__).parents[1]
+POLICY = json.loads((ROOT / "state/driver/aiw-budget-policy.json").read_text())
+
+
+def request(**overrides):
+    value = {
+        "job_id": "aiw-test",
+        "provider": "claude-code-cli",
+        "estimated_cost_usd": 0,
+        "cycle_spend_usd": 0,
+        "estimated_total_tokens": 10000,
+        "estimated_model_calls": 1,
+        "estimated_retries": 0,
+        "estimated_runner_minutes": 5,
+        "cycle_active_packets": 0,
+    }
+    value.update(overrides)
+    return value
+
+
+class BudgetGateTests(unittest.TestCase):
+    def test_local_cli_is_allowed_without_paid_approval(self):
+        result = evaluate(POLICY, request())
+        self.assertEqual("allow", result["decision"])
+
+    def test_cloud_provider_requires_explicit_approval(self):
+        result = evaluate(POLICY, request(provider="gemini-cli"))
+        self.assertEqual("block", result["decision"])
+        self.assertIn("provider_requires_manual_approval", result["reasons"])
+
+    def test_approved_cloud_job_is_allowed_under_caps(self):
+        result = evaluate(POLICY, request(
+            provider="jules", manual_approval=True, estimated_cost_usd=1.5))
+        self.assertEqual("allow", result["decision"])
+
+    def test_cost_cap_blocks_before_invocation(self):
+        result = evaluate(POLICY, request(estimated_cost_usd=2.01))
+        self.assertEqual("block", result["decision"])
+        self.assertIn("job_cost_cap_exceeded", result["reasons"])
+
+    def test_cycle_cap_blocks_before_invocation(self):
+        result = evaluate(POLICY, request(cycle_spend_usd=9, estimated_cost_usd=2))
+        self.assertIn("cycle_cost_cap_exceeded", result["reasons"])
+
+    def test_token_and_retry_caps_block(self):
+        result = evaluate(POLICY, request(
+            estimated_total_tokens=200001, estimated_retries=2))
+        self.assertIn("token_cap_exceeded", result["reasons"])
+        self.assertIn("retry_cap_exceeded", result["reasons"])
+
+    def test_parallel_cap_blocks(self):
+        result = evaluate(POLICY, request(cycle_active_packets=4))
+        self.assertIn("parallel_packet_cap_exceeded", result["reasons"])
+
+    def test_unknown_provider_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "not allowlisted"):
+            evaluate(POLICY, request(provider="unknown"))
+
+    def test_cli_ledger_shape_is_json_serializable(self):
+        result = evaluate(POLICY, request())
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ledger.json"
+            path.write_text(json.dumps(result), encoding="utf-8")
+            self.assertEqual("allow", json.loads(path.read_text())["decision"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_aiw_budget_gate.py
+++ b/scripts/test_aiw_budget_gate.py
@@ -68,6 +68,33 @@ class BudgetGateTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "cannot exceed policy default"):
             evaluate(POLICY, request(max_cost_usd=200))
 
+    def test_nan_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "non-negative number"):
+            evaluate(POLICY, request(estimated_cost_usd=float("nan")))
+
+    def test_cycle_reservation_blocks_aggregate_overrun(self):
+        from aiw_budget_gate import reserve
+        policy = json.loads(json.dumps(POLICY))
+        policy["cycle"]["max_cost_usd"] = 2
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            first = reserve(policy, request(job_id="one", estimated_cost_usd=2), cycle)
+            second = reserve(policy, request(job_id="two", estimated_cost_usd=1), cycle)
+            self.assertEqual("allow", first["decision"])
+            self.assertEqual("block", second["decision"])
+            self.assertIn("cycle_cost_cap_exceeded", second["reasons"])
+
+    def test_release_records_actual_cost_and_frees_capacity(self):
+        from aiw_budget_gate import release, reserve
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            reserve(POLICY, request(job_id="one"), cycle)
+            result = release(cycle, "one", 0.25)
+            self.assertEqual("released", result["decision"])
+            state = json.loads(cycle.read_text())
+            self.assertEqual(0, state["active_packets"])
+            self.assertEqual(0.25, state["actual_cost_usd"])
+
     def test_cli_ledger_shape_is_json_serializable(self):
         result = evaluate(POLICY, request())
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_aiw_budget_gate.py
+++ b/scripts/test_aiw_budget_gate.py
@@ -64,6 +64,10 @@ class BudgetGateTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "not allowlisted"):
             evaluate(POLICY, request(provider="unknown"))
 
+    def test_job_cannot_widen_policy_cap(self):
+        with self.assertRaisesRegex(ValueError, "cannot exceed policy default"):
+            evaluate(POLICY, request(max_cost_usd=200))
+
     def test_cli_ledger_shape_is_json_serializable(self):
         result = evaluate(POLICY, request())
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_aiw_budget_gate.py
+++ b/scripts/test_aiw_budget_gate.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from aiw_budget_gate import evaluate
+from aiw_budget_gate import _request_sha256, evaluate
 
 
 ROOT = Path(__file__).parents[1]
@@ -26,6 +26,40 @@ def request(**overrides):
     return value
 
 
+def receipt(req, issuer, actual_cost_usd, **overrides):
+    """Build a trusted provider receipt bound to a reserved request."""
+    value = {
+        "schema_version": "1.0",
+        "kind": "provider-receipt",
+        "job_id": req["job_id"],
+        "provider": req["provider"],
+        "request_sha256": _request_sha256(req),
+        "issuer": issuer,
+        "receipt_id": "rcpt-0001",
+        "observed_at": "2026-07-18T01:00:00Z",
+        "actual_cost_usd": actual_cost_usd,
+    }
+    value.update(overrides)
+    return value
+
+
+def approval(req, **overrides):
+    """Build a separate approval artifact bound to a request's fingerprint."""
+    value = {
+        "schema_version": "1.0",
+        "kind": "human-approval",
+        "decision": "approve",
+        "job_id": req["job_id"],
+        "provider": req["provider"],
+        "request_sha256": _request_sha256(req),
+        "approval_id": "appr-0001",
+        "approver": "sol",
+        "approved_at": "2026-07-18T00:00:00Z",
+    }
+    value.update(overrides)
+    return value
+
+
 class BudgetGateTests(unittest.TestCase):
     def test_local_cli_is_allowed_without_paid_approval(self):
         result = evaluate(POLICY, request())
@@ -36,10 +70,32 @@ class BudgetGateTests(unittest.TestCase):
         self.assertEqual("block", result["decision"])
         self.assertIn("provider_requires_manual_approval", result["reasons"])
 
+    def test_self_attested_manual_approval_in_request_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "manual_approval is not accepted"):
+            evaluate(POLICY, request(
+                provider="jules", manual_approval=True, estimated_cost_usd=1.5))
+
+    def test_metered_provider_blocked_without_approval_artifact(self):
+        result = evaluate(POLICY, request(provider="jules", estimated_cost_usd=1.5))
+        self.assertEqual("block", result["decision"])
+        self.assertIn("provider_requires_manual_approval", result["reasons"])
+
     def test_approved_cloud_job_is_allowed_under_caps(self):
-        result = evaluate(POLICY, request(
-            provider="jules", manual_approval=True, estimated_cost_usd=1.5))
+        req = request(provider="jules", estimated_cost_usd=1.5)
+        result = evaluate(POLICY, req, approval=approval(req))
         self.assertEqual("allow", result["decision"])
+
+    def test_approval_bound_to_wrong_request_is_rejected(self):
+        req = request(provider="jules", estimated_cost_usd=1.5)
+        stale = approval(req, request_sha256="0" * 64)
+        with self.assertRaisesRegex(ValueError, "approval request_sha256 does not match"):
+            evaluate(POLICY, req, approval=stale)
+
+    def test_approval_for_wrong_provider_is_rejected(self):
+        req = request(provider="jules", estimated_cost_usd=1.5)
+        wrong = approval(req, provider="gemini-cli")
+        with self.assertRaisesRegex(ValueError, "approval provider does not match"):
+            evaluate(POLICY, req, approval=wrong)
 
     def test_cost_cap_blocks_before_invocation(self):
         result = evaluate(POLICY, request(estimated_cost_usd=2.01))
@@ -90,6 +146,42 @@ class BudgetGateTests(unittest.TestCase):
             self.assertEqual("block", second["decision"])
             self.assertIn("cycle_cost_cap_exceeded", second["reasons"])
 
+    def test_reservation_records_provider_and_request_sha(self):
+        from aiw_budget_gate import _request_sha256, reserve
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            req = request(job_id="one")
+            reserve(POLICY, req, cycle)
+            entry = json.loads(cycle.read_text())["reservations"]["one"]
+            self.assertEqual("claude-code-cli", entry["provider"])
+            self.assertEqual(_request_sha256(req), entry["request_sha256"])
+
+    def test_reservation_reuse_with_identical_request_is_idempotent(self):
+        from aiw_budget_gate import reserve
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            req = request(job_id="one", estimated_cost_usd=0.5)
+            reserve(POLICY, req, cycle)
+            second = reserve(POLICY, req, cycle)
+            self.assertTrue(second["reservation_reused"])
+            self.assertEqual(0.5, second["budget"]["estimated_cost_usd"])
+
+    def test_reservation_reuse_with_changed_request_fails_closed(self):
+        from aiw_budget_gate import reserve
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            reserve(POLICY, request(job_id="one", estimated_cost_usd=0.1), cycle)
+            with self.assertRaisesRegex(ValueError, "fingerprint"):
+                reserve(POLICY, request(job_id="one", estimated_cost_usd=1.9), cycle)
+
+    def test_reservation_reuse_cannot_switch_provider(self):
+        from aiw_budget_gate import reserve
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            reserve(POLICY, request(job_id="one"), cycle)
+            with self.assertRaisesRegex(ValueError, "fingerprint"):
+                reserve(POLICY, request(job_id="one", provider="codex-cli"), cycle)
+
     def test_release_records_actual_cost_and_frees_capacity(self):
         from aiw_budget_gate import release, reserve
         with tempfile.TemporaryDirectory() as directory:
@@ -101,6 +193,61 @@ class BudgetGateTests(unittest.TestCase):
             self.assertEqual(0, state["active_packets"])
             self.assertEqual(0.25, state["actual_cost_usd"])
 
+    def test_metered_release_requires_trusted_receipt(self):
+        from aiw_budget_gate import release, reserve
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            req = request(job_id="j1", provider="jules", estimated_cost_usd=1.5)
+            reserve(POLICY, req, cycle, approval=approval(req))
+            with self.assertRaisesRegex(ValueError, "receipt"):
+                release(cycle, "j1", 1.5, policy=POLICY)
+
+    def test_metered_release_rejects_untrusted_issuer(self):
+        from aiw_budget_gate import release, reserve
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            req = request(job_id="j1", provider="jules", estimated_cost_usd=1.5)
+            reserve(POLICY, req, cycle, approval=approval(req))
+            forged = receipt(req, "attacker.example.com", 1.5)
+            with self.assertRaisesRegex(ValueError, "not trusted"):
+                release(cycle, "j1", 1.5, policy=POLICY, receipt=forged)
+
+    def test_metered_release_with_trusted_receipt_records_actual(self):
+        from aiw_budget_gate import release, reserve
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            req = request(job_id="j1", provider="jules", estimated_cost_usd=1.5)
+            reserve(POLICY, req, cycle, approval=approval(req))
+            good = receipt(req, "jules.googleapis.com", 1.25)
+            result = release(cycle, "j1", 1.25, policy=POLICY, receipt=good)
+            self.assertEqual("released", result["decision"])
+            state = json.loads(cycle.read_text())
+            self.assertEqual(0, state["active_packets"])
+            self.assertEqual(1.25, state["actual_cost_usd"])
+
+    def test_metered_release_blocks_over_budget_actual(self):
+        from aiw_budget_gate import release, reserve
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            req = request(job_id="j1", provider="jules", estimated_cost_usd=1.5)
+            reserve(POLICY, req, cycle, approval=approval(req))
+            overrun = receipt(req, "jules.googleapis.com", 9.99)
+            result = release(cycle, "j1", 9.99, policy=POLICY, receipt=overrun)
+            self.assertEqual("over_budget", result["decision"])
+            self.assertIn("actual_cost_cap_exceeded", result["reasons"])
+            # Real spend is still recorded truthfully even when it is blocked.
+            self.assertEqual(9.99, json.loads(cycle.read_text())["actual_cost_usd"])
+
+    def test_metered_receipt_actual_must_match_release_amount(self):
+        from aiw_budget_gate import release, reserve
+        with tempfile.TemporaryDirectory() as directory:
+            cycle = Path(directory) / "cycle.json"
+            req = request(job_id="j1", provider="jules", estimated_cost_usd=1.5)
+            reserve(POLICY, req, cycle, approval=approval(req))
+            mismatch = receipt(req, "jules.googleapis.com", 1.25)
+            with self.assertRaisesRegex(ValueError, "actual_cost_usd"):
+                release(cycle, "j1", 0.01, policy=POLICY, receipt=mismatch)
+
     def test_actual_receipts_count_against_next_reservation(self):
         from aiw_budget_gate import release, reserve
         policy = json.loads(json.dumps(POLICY))
@@ -111,6 +258,28 @@ class BudgetGateTests(unittest.TestCase):
             result = reserve(policy, request(job_id="two", estimated_cost_usd=1), cycle)
             self.assertEqual("block", result["decision"])
             self.assertIn("cycle_cost_cap_exceeded", result["reasons"])
+
+    def test_noncanonical_runtime_path_is_rejected(self):
+        from aiw_budget_gate import LEDGER_PATH, _bind_canonical
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ValueError, "must be"):
+                _bind_canonical("--ledger", Path(directory) / "ledger.json", LEDGER_PATH)
+
+    def test_canonical_runtime_path_is_accepted(self):
+        from aiw_budget_gate import LEDGER_PATH, _bind_canonical
+        self.assertEqual(LEDGER_PATH.resolve(),
+                         _bind_canonical("--ledger", LEDGER_PATH, LEDGER_PATH))
+
+    def test_local_seat_providers_route_without_approval(self):
+        for provider in ("claude-code-cli", "codex-cli", "antigravity", "augment-code"):
+            result = evaluate(POLICY, request(provider=provider))
+            self.assertEqual("allow", result["decision"], provider)
+
+    def test_metered_providers_require_approval(self):
+        for provider in ("gemini-cli", "jules", "notebooklm"):
+            result = evaluate(POLICY, request(provider=provider))
+            self.assertEqual("block", result["decision"], provider)
+            self.assertIn("provider_requires_manual_approval", result["reasons"])
 
     def test_cli_ledger_shape_is_json_serializable(self):
         result = evaluate(POLICY, request())

--- a/state/driver/aiw-budget-policy.json
+++ b/state/driver/aiw-budget-policy.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "1.0",
+  "cycle": {
+    "max_cost_usd": 10.0,
+    "max_parallel_packets": 4
+  },
+  "defaults": {
+    "max_cost_usd": 2.0,
+    "max_total_tokens": 200000,
+    "max_model_calls": 6,
+    "max_retries": 1,
+    "max_runner_minutes": 30,
+    "approval_required_above_usd": 5.0
+  },
+  "providers": [
+    {
+      "id": "claude-code-cli",
+      "tier": "local-seat",
+      "cost_model": "subscription-or-local",
+      "requires_manual_approval": false
+    },
+    {
+      "id": "codex-cli",
+      "tier": "local-seat",
+      "cost_model": "subscription-or-local",
+      "requires_manual_approval": false
+    },
+    {
+      "id": "antigravity",
+      "tier": "local-seat",
+      "cost_model": "subscription-or-local",
+      "requires_manual_approval": false
+    },
+    {
+      "id": "augment-code",
+      "tier": "local-seat",
+      "cost_model": "subscription-or-local",
+      "requires_manual_approval": false
+    },
+    {
+      "id": "gemini-cli",
+      "tier": "metered-cloud",
+      "cost_model": "provider-billing",
+      "requires_manual_approval": true
+    },
+    {
+      "id": "jules",
+      "tier": "metered-cloud",
+      "cost_model": "provider-billing",
+      "requires_manual_approval": true
+    },
+    {
+      "id": "notebooklm",
+      "tier": "metered-cloud",
+      "cost_model": "provider-billing",
+      "requires_manual_approval": true
+    }
+  ],
+  "selection_order": [
+    "claude-code-cli",
+    "codex-cli",
+    "antigravity",
+    "augment-code",
+    "gemini-cli",
+    "jules",
+    "notebooklm"
+  ]
+}

--- a/state/driver/aiw-budget-policy.json
+++ b/state/driver/aiw-budget-policy.json
@@ -41,19 +41,22 @@
       "id": "gemini-cli",
       "tier": "metered-cloud",
       "cost_model": "provider-billing",
-      "requires_manual_approval": true
+      "requires_manual_approval": true,
+      "trusted_receipt_issuer": "generativelanguage.googleapis.com"
     },
     {
       "id": "jules",
       "tier": "metered-cloud",
       "cost_model": "provider-billing",
-      "requires_manual_approval": true
+      "requires_manual_approval": true,
+      "trusted_receipt_issuer": "jules.googleapis.com"
     },
     {
       "id": "notebooklm",
       "tier": "metered-cloud",
       "cost_model": "provider-billing",
-      "requires_manual_approval": true
+      "requires_manual_approval": true,
+      "trusted_receipt_issuer": "notebooklm.google.com"
     }
   ],
   "selection_order": [


### PR DESCRIPTION
## Summary
- add an executable fail-closed budget preflight before provider invocation
- prefer local-seat Claude Code CLI, Codex CLI, Antigravity and Augment; meter Gemini/Jules/NotebookLM behind explicit approval
- emit a structured ledger and enforce per-job, per-cycle, token, call, retry, runner-minute and parallel-packet caps

## Authority hardening (bypasses closed)
- **Canonical paths**: policy + runtime ledgers (and the approval/receipt artifacts) are pinned to canonical repo paths; a caller cannot redirect them to a caller-controlled file.
- **Reservation binding**: each reservation is bound to provider + exact request SHA-256; a reused job id under a changed request or switched provider fails closed.
- **Approval artifact**: the self-attested `manual_approval` flag is replaced by a separate `.octo/aiw-approval.json` artifact bound to job/provider/request hash; `manual_approval` inside the request is rejected.
- **Trusted receipts**: releasing a metered job requires a trusted provider receipt (matching policy `trusted_receipt_issuer`) whose actual cost matches the released amount; over-budget actual spend is recorded truthfully but returned as a blocking `over_budget` decision.
- **Local-first routing**: local-seat Claude Code / Codex stay first; all metered cloud providers require the approval artifact.

## Verification
- python -m unittest discover -s scripts -p test_aiw_budget_gate.py (32 passed)
- python -m unittest discover -s scripts -p "test_*.py" (156 passed)
- python scripts/validate_governance.py (13 valid, 0 invalid)
- python scripts/build_manifest.py (383 artifacts, 154 edges, no drift)
- CLI smoke: local-seat reserve -> ALLOW/exit 0; metered without approval -> BLOCK/exit 1; non-canonical ledger path -> exit 2 (fail-closed)

Provider/API usage: none (local Claude Code CLI seat only). Not merged; awaiting adversarial review before `agent-blackbox-reviewed`.

Refs #471