### PR TITLE
feat(aiw-budget-gate): wire the metered budget gate into jules-auto-delegate (closes #716)

### DIFF
--- a/.github/workflows/jules-auto-delegate.yml
+++ b/.github/workflows/jules-auto-delegate.yml
@@ -166,6 +166,36 @@ jobs:
             exit 0
           fi
 
+          # ── AIW budget preflight: jules is a metered-cloud provider ─────────
+          # scripts/aiw_budget_gate.py fails closed. Jules requires manual
+          # approval, so absent a committed .octo/aiw-approval.json bound to this
+          # job_id/provider/request SHA-256 the reservation BLOCKS here. We run
+          # this BEFORE writing the delegation marker so a blocked job stays
+          # re-runnable after a human commits the approval artifact.
+          #   exit 0 → allow, fall through to delegate
+          #   exit 1 → block (governed outcome): comment, proceed=false, run stays green
+          #   exit 2 → invalid request/policy: fail the job closed
+          req="$RUNNER_TEMP/aiw-jules-request.json"
+          job_id="jules-issue-${issue}-run-${GITHUB_RUN_ID}"
+          printf '{"job_id":"%s","provider":"jules","estimated_cost_usd":1.0,"estimated_total_tokens":150000,"estimated_model_calls":4,"estimated_retries":1,"estimated_runner_minutes":10}\n' "$job_id" > "$req"
+          set +e
+          python3 scripts/aiw_budget_gate.py --request "$req"
+          budget_rc=$?
+          set -e
+          if [ "$budget_rc" -eq 2 ]; then
+            echo "::error::AIW budget gate could not evaluate the request (exit 2) — failing closed for issue #$issue"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          if [ "$budget_rc" -ne 0 ]; then
+            reasons=$(jq -r '.reasons | join(", ")' .octo/aiw-budget-ledger.json 2>/dev/null || echo "budget policy")
+            gh issue comment "$issue" --repo "$REPO" --body "⛔ Delegation to **Jules** is **blocked by the AIW budget gate** (\`$reasons\`). Jules is a metered-cloud provider that requires explicit approval before any paid invocation. To authorize *this* delegation, commit a \`.octo/aiw-approval.json\` artifact bound to job_id \`$job_id\`, provider \`jules\`, and this request's SHA-256, then re-run. The \`ready-for-agent\`/\`worker:jules\` labels are kept and no delegation was performed."
+            echo "::notice::AIW budget gate blocked jules delegation for issue #$issue ($reasons)"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::notice::AIW budget gate allowed jules delegation for issue #$issue"
+
           gh issue comment "$issue" --repo "$REPO" --body "🤖 Delegating this \`ready-for-agent\` + \`worker:jules\` issue to Jules via governed AFK workflow. $marker\n\nJules should open a PR targeting \`master\`. Human/Demerzel review is still required before merge."
 
           echo "issue=$issue" >> "$GITHUB_OUTPUT"

--- a/docs/workflows/aiw-budget-router.md
+++ b/docs/workflows/aiw-budget-router.md
@@ -169,6 +169,22 @@ python scripts/aiw_budget_gate.py --release-job aiw-0001 `
   --receipt .octo/aiw-receipt.json
 ```
 
+### Live consumer
+
+`.github/workflows/jules-auto-delegate.yml` is the first live consumer of the gate.
+Jules is a `metered-cloud` provider, so the delegation job runs the reserve
+preflight before invoking `google-labs-code/jules-action`:
+
+- **allow (exit 0)** → delegation proceeds;
+- **block (exit 1)** → the job comments on the issue that a committed
+  `.octo/aiw-approval.json` (bound to the job id, provider, and request SHA-256)
+  is required, keeps the labels, writes no delegation marker, and stays green so
+  the issue remains re-runnable after approval;
+- **invalid (exit 2)** → the job fails closed.
+
+`scripts/test_aiw_budget_consumer.py` guards this wiring so the gate cannot be
+silently unwired back into a declared-but-unconsumed artifact.
+
 ## Non-goals
 
 - This router does not own Demerzel policy.

--- a/scripts/test_aiw_budget_consumer.py
+++ b/scripts/test_aiw_budget_consumer.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Regression guard: the AIW budget gate must stay wired into a live consumer.
+
+The budget gate (scripts/aiw_budget_gate.py) is only worth its weight if a real
+provider-invocation path calls it. jules-auto-delegate.yml delegates to `jules`,
+a metered-cloud provider, so it must run the gate BEFORE the Jules action and must
+not silently proceed when the gate blocks. This test fails closed if that wiring
+is removed or reordered, so the "declared-but-unconsumed" gap cannot silently
+return.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = (Path(__file__).resolve().parents[1]
+            / ".github" / "workflows" / "jules-auto-delegate.yml")
+GATE_INVOKE = "python3 scripts/aiw_budget_gate.py"
+JULES_ACTION = "uses: google-labs-code/jules-action"
+
+
+class AiwBudgetConsumerWiringTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.text = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_gate_is_invoked(self) -> None:
+        self.assertIn(GATE_INVOKE, self.text,
+                      "jules-auto-delegate.yml must invoke the AIW budget gate")
+
+    def test_gate_runs_before_jules_delegation(self) -> None:
+        gate_at = self.text.find(GATE_INVOKE)
+        action_at = self.text.find(JULES_ACTION)
+        self.assertNotEqual(gate_at, -1, "budget gate invocation is missing")
+        self.assertNotEqual(action_at, -1, "jules-action step is missing")
+        self.assertLess(gate_at, action_at,
+                        "the budget gate must run before delegating to Jules")
+
+    def test_block_is_a_governed_stop_not_a_silent_proceed(self) -> None:
+        # A blocked reservation must set proceed=false so the existing
+        # `if: steps.gate.outputs.proceed == 'true'` guard skips delegation.
+        self.assertIn("AIW budget gate blocked jules", self.text)
+        self.assertIn('echo "proceed=false" >> "$GITHUB_OUTPUT"', self.text)
+
+    def test_invalid_request_fails_closed(self) -> None:
+        # exit 2 (invalid request/policy or non-canonical path) fails the job.
+        self.assertIn("failing closed", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replaces #720 (auto-closed when its base branch `codex/aiw-budget-router` was deleted on #715's merge). Same content, retargeted to `master`.

Now that #715 has merged the gate (`scripts/aiw_budget_gate.py` + policy) into master, this adds its first **live consumer**, closing the anti-LOLLI gap from the #715 review (Residual 1 / #716).

## What
`jules-auto-delegate.yml` delegates to `jules`, a `metered-cloud` provider. The delegation job now runs `scripts/aiw_budget_gate.py` **before** invoking `google-labs-code/jules-action`, inside the existing governance `gate` step and before the delegation marker is written, reusing the step's `proceed` output:

| Gate result | Behavior |
|---|---|
| allow (exit 0) | delegation proceeds |
| block (exit 1) | comments that a committed `.octo/aiw-approval.json` (bound to job_id/provider/request-SHA) is required; keeps labels; **no marker**; job stays green |
| invalid (exit 2) | job **fails closed** |

`scripts/test_aiw_budget_consumer.py` guards the wiring so it can't silently regress.

## Verification
Gate driven locally against `state/driver/aiw-budget-policy.json`: local-seat → ALLOW/0; metered jules no-approval → BLOCK/1; metered jules + matching approval → ALLOW/0; non-canonical path → exit 2. Consumer test: 4 passed.

Closes #716
Refs #715, #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)