### PR TITLE
feat(policy): adaptive fan-out backpressure policy + architecture doc (rebased #643)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Governance framework for AI agents: constitutions, personas, hexavalent logic, alignment policies, and behavioral tests. Named after R. Daneel Olivaw from Asimov's Foundation. Consumed by **ix**, **tars**, **ga** via the Galactic Protocol.
 
-Full directory listing: see `README.md`. Source of truth for Asimov laws, Default constitution articles, and all 45 policies: `constitutions/` and `policies/`.
+Full directory listing: see `README.md`. Source of truth for Asimov laws, Default constitution articles, and all 46 policies: `constitutions/` and `policies/`.
 
 ## Key Principle
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Demerzel/
 | Constitutions | 5 (incl. epistemic + harm taxonomy) | `constitutions/` |
 | Constitutional articles | 14 (default) + 10 (epistemic) + 3 (Asimov root) | `constitutions/*.md` |
 | Personas | 17 | `personas/*.persona.yaml` |
-| Policies | 45 | `policies/*.yaml` |
+| Policies | 46 | `policies/*.yaml` |
 | Grammars | 20 | `grammars/*.ebnf` |
 | Schemas | 45 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
 | Behavioral tests | 115 | `tests/behavioral/*.md` |

--- a/docs/architecture/adaptive-fanout.md
+++ b/docs/architecture/adaptive-fanout.md
@@ -1,0 +1,64 @@
+# Adaptive Fan-out Backpressure Policy
+
+## Goal
+
+Add an adaptive fan-out policy so Demerzel can keep throughput high without overloading fan-in review.
+
+The controller should not treat fan-out as simply on/off. When fan-in blocks, it should reduce high-risk/new-work fan-out and redirect capacity toward grooming, review, draft-to-ready work, dependency analysis, and small docs-only tasks.
+
+## Problem
+
+After the first controlled fan-out, multiple draft PRs were produced (e.g., #565, #566, #567). While this proves the worker path is alive, it creates a fan-in bottleneck. If Demerzel keeps launching new work while draft PRs accumulate, human review and merge ordering become the limiting constraint.
+
+## Adaptive Modes
+
+The controller supports these modes based on backpressure thresholds:
+
+### NORMAL
+Use when the review queue is healthy.
+- **Allowed work:** docs, schemas, low-risk implementation, small architecture updates.
+
+### CONSTRAINED
+Use when open PRs or active drafts approach the threshold.
+- **Allowed work:** grooming, review, docs-only issues, dependency analysis, risk classification.
+- **Blocked or reduced work:** broad feature PRs, high-risk path changes, workflow/policy changes without human approval.
+
+### DRAINING
+Use when fan-in is saturated.
+- **Allowed work:** fan-in review, draft-to-ready work, conflict analysis, stale-marker classification, issue grooming, follow-up issue creation.
+- **Blocked work:** new feature PRs, broad architecture PRs, workflow changes, permission/policy changes.
+
+### HALTED
+Use when a hard stop condition is present.
+- **Examples:** workflow/policy block, repeated failed required checks, merge conflicts across several PRs, human halt marker, unsafe or ambiguous automation change.
+- **Allowed work:** human review only, diagnostic notes, explicit recovery plan.
+
+## Required Behavior
+
+- Compute current mode from open PR count, draft count, failed checks, path risk, merge conflicts, and human markers.
+- Reduce fan-out type before reducing fan-out to zero.
+- Prefer grooming/review/docs-only work while fan-in is blocked.
+- Pause new implementation work when the review queue is saturated.
+- Resume normal fan-out only after fan-in drains below threshold.
+- Explain why each issue is selected, delayed, or blocked.
+
+## Fan-in Interaction
+
+When fan-in blocks, the controller should generate one of:
+- review queue recommendation;
+- draft-to-ready recommendation;
+- conflict/risk analysis recommendation;
+- grooming batch recommendation;
+- halt/recovery recommendation.
+
+## Relationship to other components
+
+- **Fan-out/fan-in controller (#568):** This adaptive policy provides the intelligence for the controller to regulate its dispatcher loop instead of a simple binary on/off switch.
+- **Grooming gate (#570):** Redirects excess capacity during backpressure toward grooming the backlog.
+
+## Non-goals
+
+- Do not auto-merge PRs.
+- Do not bypass human review.
+- Do not launch additional high-risk work when review is saturated.
+- Do not treat all PRs as equal; draft PRs, workflow PRs, and policy PRs carry different risk.

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -9,7 +9,7 @@
     "grammar": 20,
     "persona": 17,
     "pipeline": 23,
-    "policy": 45,
+    "policy": 46,
     "schema": 45,
     "seldon_schema": 7,
     "skill": 69,
@@ -127,6 +127,11 @@
       }
     ],
     "policy": [
+      {
+        "name": "adaptive-fanout-policy",
+        "path": "policies/adaptive-fanout-policy.yaml",
+        "version": "1.0.0"
+      },
       {
         "name": "adversarial-resilience-policy",
         "path": "policies/adversarial-resilience-policy.yaml",
@@ -1833,6 +1838,24 @@
       "from": "personas/virtuous-leader.persona.yaml",
       "to": "tests/behavioral/virtuous-leader-cases.md",
       "kind": "has_test",
+      "resolved": true
+    },
+    {
+      "from": "policies/adaptive-fanout-policy.yaml",
+      "to": "docs/architecture/adaptive-fanout.md",
+      "kind": "reference",
+      "resolved": true
+    },
+    {
+      "from": "policies/adaptive-fanout-policy.yaml",
+      "to": "docs/workflows/aiw-composite-lanes.md",
+      "kind": "reference",
+      "resolved": true
+    },
+    {
+      "from": "policies/adaptive-fanout-policy.yaml",
+      "to": "policies/autonomous-loop-policy.yaml",
+      "kind": "reference",
       "resolved": true
     },
     {

--- a/policies/adaptive-fanout-policy.yaml
+++ b/policies/adaptive-fanout-policy.yaml
@@ -1,0 +1,59 @@
+name: adaptive-fanout-policy
+version: "1.0.0"
+effective_date: "2026-07-02"
+description: Adaptive fan-out backpressure — regulates AFK fan-out throughput by mode so fan-in review is never overloaded
+
+constitutional_basis:
+  - Article 4 (Proportionality) — fan-out volume must match available review capacity
+  - Article 6 (Escalation) — saturation and hard-stop conditions escalate to human
+  - Article 2 (Transparency) — the controller must explain why each issue is selected, delayed, or blocked
+
+principles:
+  - Fan-out is not on/off; reduce fan-out TYPE before reducing fan-out to zero
+  - When fan-in blocks, redirect capacity toward grooming, review, draft-to-ready, dependency analysis, and docs-only work
+  - Resume normal fan-out only after fan-in drains below threshold
+  - Draft PRs, workflow PRs, and policy PRs carry different risk — never treat all PRs as equal
+
+adaptive_fanout:
+  normal:
+    max_open_prs: 3
+    allowed_work:
+      - docs
+      - schema
+      - low_risk_code
+  constrained:
+    max_open_prs: 5
+    allowed_work:
+      - grooming
+      - review
+      - docs_only
+      - dependency_analysis
+  draining:
+    when:
+      open_prs_at_or_above: 5
+    allowed_work:
+      - fan_in_review
+      - draft_to_ready
+      - conflict_analysis
+      - issue_grooming
+    blocked_work:
+      - new_feature_prs
+      - workflow_changes
+      - broad_architecture_prs
+  halted:
+    when:
+      - workflow_policy_block
+      - human_halt_marker
+      - repeated_failed_checks
+    allowed_work:
+      - human_review_only
+
+non_goals:
+  - No auto-merge of PRs
+  - No bypass of human review
+  - No additional high-risk work while review is saturated
+
+references:
+  - docs/architecture/adaptive-fanout.md
+  - docs/workflows/aiw-composite-lanes.md
+  - policies/autonomous-loop-policy.yaml


### PR DESCRIPTION
Rebased #643 onto current master. The only rebase conflict was the generated `governance-manifest.json`, resolved by re-running `scripts/build_manifest.py`. Carries the two real artifacts (`docs/architecture/adaptive-fanout.md`, `policies/adaptive-fanout-policy.yaml`) plus README/CLAUDE.md count bumps (45→46 policies). Supersedes #643. Resolves #579.