### PR TITLE
feat(assets): ComfyUI Slice 0 — governed generative-asset pipeline (scaffolding)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ state/oversight/ml-feedback-cycle-*.json
 state/oversight/ml-feedback-audit.json
 state/.cache/
 dist/
+assets/generated/*.png

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Demerzel/
 | Personas | 17 | `personas/*.persona.yaml` |
 | Policies | 46 | `policies/*.yaml` |
 | Grammars | 20 | `grammars/*.ebnf` |
-| Schemas | 47 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
+| Schemas | 48 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
 | Behavioral tests | 115 | `tests/behavioral/*.md` |
 | Skills | 69 | `.claude/skills/*/` |
 | Streeling departments | 23 | `state/streeling/departments/*.department.json` |
@@ -111,7 +111,7 @@ Most artifacts today are **Defined** or **Loaded**. Full **Enforcement** (consti
 
 | Resilience score | LOLLI detection | Policies | Personas | Tests |
 |:---:|:---:|:---:|:---:|:---:|
-| 82% (2 gaps) | L0–L4 + Policy + Schema | 45 | 17 | 115 |
+| 82% (2 gaps) | L0–L4 + Policy + Schema | 46 | 17 | 115 |
 
 **Governance Resilience Score (R)** measures how well the system detects injected poisons — dead bindings, orphaned branches, BS descriptions, unconsumed artifacts, dead computations. Inspired by [Netflix's Chaos Monkey](https://netflix.github.io/chaosmonkey/) (2011) and [Chaos Engineering](https://www.oreilly.com/library/view/chaos-engineering/9781492043850/) (Rosenthal et al., O'Reilly 2020): if Demerzel can't catch deliberate poison, she can't catch accidental LOLLI.
 

--- a/assets/comfyui/workflows/tileable-gasgiant.json
+++ b/assets/comfyui/workflows/tileable-gasgiant.json
@@ -1,0 +1,41 @@
+{
+  "4": {
+    "class_type": "CheckpointLoaderSimple",
+    "inputs": { "ckpt_name": "sd_xl_base_1.0.safetensors" }
+  },
+  "6": {
+    "class_type": "CLIPTextEncode",
+    "inputs": { "text": "{{PROMPT}}", "clip": ["4", 1] }
+  },
+  "7": {
+    "class_type": "CLIPTextEncode",
+    "inputs": { "text": "{{NEGATIVE_PROMPT}}", "clip": ["4", 1] }
+  },
+  "5": {
+    "class_type": "EmptyLatentImage",
+    "inputs": { "width": 1024, "height": 1024, "batch_size": 1 }
+  },
+  "3": {
+    "class_type": "KSampler",
+    "inputs": {
+      "seed": "{{SEED}}",
+      "steps": 30,
+      "cfg": 7.0,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1.0,
+      "model": ["4", 0],
+      "positive": ["6", 0],
+      "negative": ["7", 0],
+      "latent_image": ["5", 0]
+    }
+  },
+  "8": {
+    "class_type": "VAEDecode",
+    "inputs": { "samples": ["3", 0], "vae": ["4", 2] }
+  },
+  "9": {
+    "class_type": "SaveImage",
+    "inputs": { "images": ["8", 0], "filename_prefix": "demerzel-asset" }
+  }
+}

--- a/assets/specs/gasgiant-example.json
+++ b/assets/specs/gasgiant-example.json
@@ -1,0 +1,11 @@
+{
+  "id": "gasgiant-jovian-01",
+  "provider": "comfyui-local",
+  "workflow": "assets/comfyui/workflows/tileable-gasgiant.json",
+  "model": "sd_xl_base_1.0.safetensors",
+  "sampler": "euler",
+  "seed": 424242,
+  "prompt": "seamless tileable texture of a jovian gas giant's cloud bands, horizontal turbulent belts and zones, ochre cream and rust, subtle storm eddies, high detail, equirectangular, no seams",
+  "negative_prompt": "seams, borders, frame, watermark, text, stars, background, vignette",
+  "consumer_ref": "prime-radiant/solar-system: gas-giant surface material (#726 tracer-bullet render proof; scales into #727)"
+}

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -10,7 +10,7 @@
     "persona": 17,
     "pipeline": 23,
     "policy": 46,
-    "schema": 47,
+    "schema": 48,
     "seldon_schema": 7,
     "skill": 69,
     "streeling_schema": 1,
@@ -378,6 +378,10 @@
       {
         "name": "aiw-harness-result.schema",
         "path": "schemas/aiw-harness-result.schema.json"
+      },
+      {
+        "name": "asset-provenance.schema",
+        "path": "schemas/asset-provenance.schema.json"
       },
       {
         "name": "blackboard-state.schema",

--- a/schemas/asset-provenance.schema.json
+++ b/schemas/asset-provenance.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://guitaralchemist.dev/demerzel/schemas/asset-provenance.schema.json",
+  "title": "Generated Asset Provenance",
+  "description": "Auditable, reproducible record for one asset produced by the governed local generative-asset pipeline (ComfyUI, epic #724). Every file under assets/generated/ MUST have a sibling <id>.provenance.json validating against this schema, and consumer_ref MUST name something that references the asset (anti-LOLLI).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "provider",
+    "workflow",
+    "workflow_sha256",
+    "seed",
+    "prompt",
+    "created_at",
+    "consumer_ref"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0" },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable asset id; the generated file is assets/generated/<id>.png"
+    },
+    "provider": {
+      "type": "string",
+      "const": "comfyui-local",
+      "description": "Must be the AIW provider that produced it; matches state/driver/aiw-budget-policy.json"
+    },
+    "workflow": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Repo-relative path to the ComfyUI API workflow used"
+    },
+    "workflow_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "SHA-256 of the workflow file at generation time (reproducibility)"
+    },
+    "model": {
+      "type": "string",
+      "description": "Checkpoint / model id used by the workflow"
+    },
+    "sampler": {
+      "type": "string",
+      "description": "Sampler name (e.g. euler, dpmpp_2m)"
+    },
+    "seed": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Fixed seed — same spec + workflow + seed reproduces the asset"
+    },
+    "prompt": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Positive prompt driving the generation"
+    },
+    "negative_prompt": {
+      "type": "string",
+      "description": "Optional negative prompt"
+    },
+    "created_at": {
+      "type": "string",
+      "description": "ISO-8601 UTC timestamp of generation"
+    },
+    "consumer_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What renders/uses this asset (a repo path, component, or issue ref). Anti-LOLLI: an asset with no live consumer is a violation."
+    },
+    "dry_run": {
+      "type": "boolean",
+      "description": "True when produced by --dry-run (stub image, no GPU); such assets are never committed as real deliverables"
+    }
+  }
+}

--- a/scripts/asset_consumer_guard.py
+++ b/scripts/asset_consumer_guard.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Anti-LOLLI guard for generated assets (epic #724).
+
+An asset with no consumer is exactly the LOLLI failure mode this ecosystem exists
+to prevent. This guard fails if anything under assets/generated/ is orphaned:
+- a <id>.png with no sibling <id>.provenance.json, or
+- a <id>.provenance.json whose consumer_ref is missing/empty.
+
+Green when clean (including when the directory does not exist). Its logic is proven
+by scripts/test_asset_consumer_guard.py via fixtures, so a vacuously-green CI run is
+not the only evidence it works.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ASSETS_DIR = REPO_ROOT / "assets" / "generated"
+
+
+def find_orphans(assets_dir: Path) -> list[str]:
+    """Return a list of human-readable orphan reasons; empty means clean."""
+    if not assets_dir.exists():
+        return []
+    orphans: list[str] = []
+
+    for png in sorted(assets_dir.glob("*.png")):
+        prov = png.with_suffix("").with_suffix(".provenance.json")
+        # png "<id>.png" -> provenance "<id>.provenance.json"
+        prov = assets_dir / f"{png.stem}.provenance.json"
+        if not prov.exists():
+            orphans.append(f"{png.name}: no provenance manifest")
+
+    for prov in sorted(assets_dir.glob("*.provenance.json")):
+        try:
+            data = json.loads(prov.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as error:
+            orphans.append(f"{prov.name}: unreadable ({error})")
+            continue
+        ref = data.get("consumer_ref") if isinstance(data, dict) else None
+        if not isinstance(ref, str) or not ref.strip():
+            orphans.append(f"{prov.name}: missing/empty consumer_ref")
+
+    return orphans
+
+
+def main(argv: list[str] | None = None) -> int:
+    assets_dir = DEFAULT_ASSETS_DIR
+    if argv:
+        assets_dir = Path(argv[0])
+    orphans = find_orphans(assets_dir)
+    if orphans:
+        print("anti-LOLLI guard: orphaned generated assets found:", file=sys.stderr)
+        for reason in orphans:
+            print(f"  - {reason}", file=sys.stderr)
+        return 1
+    print(f"anti-LOLLI guard: clean ({assets_dir})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_asset.py
+++ b/scripts/generate_asset.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Deterministic driver for the governed local generative-asset pipeline (epic #724).
+
+Takes an asset spec (JSON), drives a ComfyUI workflow through ComfyUI's HTTP API,
+and writes the image plus an auditable provenance manifest that validates against
+schemas/asset-provenance.schema.json.
+
+Design notes:
+- stdlib only (urllib) — no third-party runtime dependency;
+- the network layer is a small ComfyClient injected into generate(), so the logic
+  is fully testable offline; `--dry-run` bypasses the network entirely and emits a
+  stub image + provenance so CI can prove the pipeline without a GPU;
+- fails closed: any unreachable/timeout/malformed response in a real run raises,
+  so a caller can never mistake a dead ComfyUI for a produced asset.
+
+This driver is the AIW provider `comfyui-local` (see state/driver/aiw-budget-policy.json);
+real asset jobs should be reserved through scripts/aiw_budget_gate.py first.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import sys
+import time
+from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUT_DIR = REPO_ROOT / "assets" / "generated"
+DEFAULT_COMFY_URL = "http://127.0.0.1:8188"
+
+# Minimal valid 1x1 PNG used as the --dry-run stub (no GPU needed).
+_STUB_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+    "0000000a49444154789c6300010000050001"
+    "0d0a2db40000000049454e44ae426082"
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _require(spec: dict[str, Any], name: str) -> Any:
+    if name not in spec or spec[name] in (None, ""):
+        raise ValueError(f"spec is missing required field: {name}")
+    return spec[name]
+
+
+def _render_workflow(workflow_text: str, prompt: str, negative: str, seed: int) -> dict[str, Any]:
+    """Substitute placeholders in the workflow text, then parse as JSON.
+
+    Placeholders (string-based, no regex): {{PROMPT}}, {{NEGATIVE_PROMPT}}, {{SEED}}.
+    JSON-encoding the substituted values keeps the workflow valid and injection-safe.
+    """
+    rendered = (
+        workflow_text
+        .replace('"{{PROMPT}}"', json.dumps(prompt))
+        .replace('"{{NEGATIVE_PROMPT}}"', json.dumps(negative))
+        .replace('"{{SEED}}"', json.dumps(seed))
+    )
+    parsed = json.loads(rendered)
+    if not isinstance(parsed, dict):
+        raise ValueError("workflow must be a ComfyUI API object (node-id -> node)")
+    return parsed
+
+
+class ComfyClient:
+    """Thin ComfyUI HTTP API client. Injectable so tests never touch the network."""
+
+    def __init__(self, base_url: str, timeout_s: float = 300.0, poll_s: float = 1.0):
+        self.base_url = base_url.rstrip("/")
+        self.timeout_s = timeout_s
+        self.poll_s = poll_s
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            f"{self.base_url}{path}", data=data,
+            headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+
+    def _get_json(self, path: str) -> dict[str, Any]:
+        with urllib.request.urlopen(f"{self.base_url}{path}", timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+
+    def queue_prompt(self, workflow: dict[str, Any]) -> str:
+        result = self._post("/prompt", {"prompt": workflow})
+        prompt_id = result.get("prompt_id")
+        if not isinstance(prompt_id, str) or not prompt_id:
+            raise ValueError("ComfyUI did not return a prompt_id")
+        return prompt_id
+
+    def wait_for_image(self, prompt_id: str) -> tuple[str, str, str]:
+        """Poll /history until the prompt produces an image; return (filename, subfolder, type)."""
+        deadline = time.monotonic() + self.timeout_s
+        while time.monotonic() < deadline:
+            history = self._get_json(f"/history/{prompt_id}")
+            entry = history.get(prompt_id)
+            if isinstance(entry, dict):
+                for node_out in (entry.get("outputs") or {}).values():
+                    images = node_out.get("images") if isinstance(node_out, dict) else None
+                    if images:
+                        img = images[0]
+                        return img["filename"], img.get("subfolder", ""), img.get("type", "output")
+            time.sleep(self.poll_s)
+        raise TimeoutError(f"ComfyUI did not produce an image for {prompt_id} within {self.timeout_s}s")
+
+    def fetch_image(self, filename: str, subfolder: str, type_: str) -> bytes:
+        query = urllib.parse.urlencode({"filename": filename, "subfolder": subfolder, "type": type_})
+        with urllib.request.urlopen(f"{self.base_url}/view?{query}", timeout=60) as resp:
+            return resp.read()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def build_provenance(spec: dict[str, Any], workflow_sha256: str,
+                     seed: int, prompt: str, negative: str, dry_run: bool,
+                     now: str | None = None) -> dict[str, Any]:
+    prov: dict[str, Any] = {
+        "schema_version": "1.0",
+        "id": spec["id"],
+        "provider": "comfyui-local",
+        "workflow": str(spec["workflow"]).replace("\\", "/"),
+        "workflow_sha256": workflow_sha256,
+        "seed": seed,
+        "prompt": prompt,
+        "created_at": now or _now_iso(),
+        "consumer_ref": _require(spec, "consumer_ref"),
+        "dry_run": dry_run,
+    }
+    if spec.get("model"):
+        prov["model"] = spec["model"]
+    if spec.get("sampler"):
+        prov["sampler"] = spec["sampler"]
+    if negative:
+        prov["negative_prompt"] = negative
+    return prov
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def generate(spec: dict[str, Any], out_dir: Path, dry_run: bool,
+             client: ComfyClient | None = None, now: str | None = None) -> dict[str, Any]:
+    """Produce one asset from a spec; return the provenance dict. Deterministic given the spec."""
+    asset_id = _require(spec, "id")
+    prompt = _require(spec, "prompt")
+    _require(spec, "consumer_ref")
+    negative = spec.get("negative_prompt", "")
+    seed = spec.get("seed", 0)
+    if not isinstance(seed, int) or isinstance(seed, bool) or seed < 0:
+        raise ValueError("seed must be a non-negative integer")
+    if spec.get("provider", "comfyui-local") != "comfyui-local":
+        raise ValueError("spec.provider must be comfyui-local")
+
+    workflow_path = (REPO_ROOT / _require(spec, "workflow")).resolve()
+    if not _is_relative_to(workflow_path, REPO_ROOT):
+        raise ValueError("spec.workflow must be a repo-relative path")
+    workflow_bytes = workflow_path.read_bytes()
+    workflow_sha256 = hashlib.sha256(workflow_bytes).hexdigest()
+    workflow = _render_workflow(workflow_bytes.decode("utf-8"), prompt, negative, seed)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    image_path = out_dir / f"{asset_id}.png"
+    prov_path = out_dir / f"{asset_id}.provenance.json"
+
+    if dry_run:
+        image_bytes = _STUB_PNG
+    else:
+        active = client or ComfyClient(DEFAULT_COMFY_URL)
+        try:
+            prompt_id = active.queue_prompt(workflow)
+            filename, subfolder, type_ = active.wait_for_image(prompt_id)
+            image_bytes = active.fetch_image(filename, subfolder, type_)
+        except (urllib.error.URLError, OSError, TimeoutError, ValueError, KeyError) as error:
+            raise RuntimeError(f"ComfyUI generation failed (fail-closed): {error}") from error
+        if not image_bytes:
+            raise RuntimeError("ComfyUI returned an empty image (fail-closed)")
+
+    image_path.write_bytes(image_bytes)
+    prov = build_provenance(spec, workflow_sha256, seed, prompt, negative, dry_run, now)
+    prov_path.write_text(json.dumps(prov, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return prov
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", type=Path, required=True, help="asset spec JSON")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--comfy-url", default=DEFAULT_COMFY_URL)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="emit a stub image + provenance without contacting ComfyUI (CI/offline)")
+    args = parser.parse_args(argv)
+    try:
+        spec = _load_json(args.spec)
+        client = None if args.dry_run else ComfyClient(args.comfy_url)
+        prov = generate(spec, args.out_dir, args.dry_run, client=client)
+    except (OSError, ValueError, KeyError, RuntimeError, TimeoutError, json.JSONDecodeError) as error:
+        print(f"generate_asset: {error}", file=sys.stderr)
+        return 2
+    kind = "DRY-RUN" if args.dry_run else "GENERATED"
+    print(f"{kind}: {args.out_dir / (prov['id'] + '.png')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_asset_consumer_guard.py
+++ b/scripts/test_asset_consumer_guard.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Proof that the anti-LOLLI asset guard actually detects orphans (epic #724).
+
+Fixture-based so the guard's logic is verified even when the repo commits no
+generated assets (which would make a live scan vacuously green).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+import asset_consumer_guard as guard
+
+
+def _write(dir_: Path, asset_id: str, consumer_ref, with_png=True):
+    if with_png:
+        (dir_ / f"{asset_id}.png").write_bytes(b"\x89PNG")
+    prov = {"schema_version": "1.0", "id": asset_id, "provider": "comfyui-local",
+            "consumer_ref": consumer_ref}
+    (dir_ / f"{asset_id}.provenance.json").write_text(json.dumps(prov), encoding="utf-8")
+
+
+class AssetGuardTests(unittest.TestCase):
+    def test_missing_dir_is_clean(self):
+        self.assertEqual(guard.find_orphans(Path("/no/such/dir")), [])
+
+    def test_asset_with_consumer_ref_is_clean(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(Path(d), "ok", "solar-system viz: gas giant")
+            self.assertEqual(guard.find_orphans(Path(d)), [])
+
+    def test_png_without_provenance_is_orphan(self):
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "loose.png").write_bytes(b"\x89PNG")
+            orphans = guard.find_orphans(Path(d))
+            self.assertTrue(any("loose.png" in o for o in orphans))
+
+    def test_empty_consumer_ref_is_orphan(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(Path(d), "empty", "")
+            orphans = guard.find_orphans(Path(d))
+            self.assertTrue(any("consumer_ref" in o for o in orphans))
+
+    def test_repo_generated_dir_is_clean(self):
+        # The committed repo must never carry an orphaned asset.
+        self.assertEqual(guard.find_orphans(guard.DEFAULT_ASSETS_DIR), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_generate_asset.py
+++ b/scripts/test_generate_asset.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Offline proof of the generative-asset driver (epic #724, Slice 0 #726).
+
+Exercises every LLM-testable layer without a GPU: placeholder injection, dry-run
+stub, a real run through an injected fake ComfyUI client, fail-closed behavior, the
+anti-LOLLI consumer requirement, and provenance shape against the schema. The
+physical generation + render proof is out of scope here — it runs on local ComfyUI.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+import generate_asset as ga
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = "assets/comfyui/workflows/tileable-gasgiant.json"
+
+
+def _spec(**over):
+    spec = {
+        "id": "test-asset-1",
+        "provider": "comfyui-local",
+        "workflow": WORKFLOW,
+        "model": "sd_xl_base_1.0.safetensors",
+        "sampler": "euler",
+        "seed": 424242,
+        "prompt": "seamless tileable gas giant bands",
+        "negative_prompt": "seams, text",
+        "consumer_ref": "solar-system viz: gas giant material",
+    }
+    spec.update(over)
+    return spec
+
+
+class FakeClient:
+    """Stands in for ComfyClient; records the workflow it was queued with."""
+
+    def __init__(self, image=b"\x89PNGFAKE", fail=False):
+        self.image = image
+        self.fail = fail
+        self.queued = None
+
+    def queue_prompt(self, workflow):
+        if self.fail:
+            raise TimeoutError("comfy down")
+        self.queued = workflow
+        return "pid-1"
+
+    def wait_for_image(self, prompt_id):
+        return ("demerzel-asset_00001_.png", "", "output")
+
+    def fetch_image(self, filename, subfolder, type_):
+        return self.image
+
+
+class RenderWorkflowTests(unittest.TestCase):
+    def test_placeholders_are_injected_and_valid_json(self):
+        text = (REPO_ROOT / WORKFLOW).read_text(encoding="utf-8")
+        wf = ga._render_workflow(text, "a prompt", "a negative", 777)
+        self.assertEqual(wf["6"]["inputs"]["text"], "a prompt")
+        self.assertEqual(wf["7"]["inputs"]["text"], "a negative")
+        self.assertEqual(wf["3"]["inputs"]["seed"], 777)  # int, not string
+
+    def test_prompt_with_quotes_stays_injection_safe(self):
+        text = (REPO_ROOT / WORKFLOW).read_text(encoding="utf-8")
+        wf = ga._render_workflow(text, 'quote " and \\ backslash', "", 1)
+        self.assertEqual(wf["6"]["inputs"]["text"], 'quote " and \\ backslash')
+
+
+class GenerateTests(unittest.TestCase):
+    def test_dry_run_writes_stub_and_provenance(self):
+        with tempfile.TemporaryDirectory() as d:
+            prov = ga.generate(_spec(), Path(d), dry_run=True, now="2026-07-18T00:00:00Z")
+            png = Path(d) / "test-asset-1.png"
+            pj = Path(d) / "test-asset-1.provenance.json"
+            self.assertTrue(png.exists() and pj.exists())
+            self.assertEqual(png.read_bytes(), ga._STUB_PNG)
+            self.assertTrue(prov["dry_run"])
+            self.assertEqual(prov["provider"], "comfyui-local")
+            self.assertEqual(len(prov["workflow_sha256"]), 64)
+
+    def test_real_run_uses_injected_client(self):
+        client = FakeClient(image=b"IMGBYTES")
+        with tempfile.TemporaryDirectory() as d:
+            prov = ga.generate(_spec(), Path(d), dry_run=False, client=client,
+                               now="2026-07-18T00:00:00Z")
+            self.assertEqual((Path(d) / "test-asset-1.png").read_bytes(), b"IMGBYTES")
+            self.assertFalse(prov["dry_run"])
+            # the fake client received the injected workflow with our prompt/seed
+            self.assertEqual(client.queued["3"]["inputs"]["seed"], 424242)
+
+    def test_fail_closed_when_comfy_unreachable(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(RuntimeError):
+                ga.generate(_spec(), Path(d), dry_run=False, client=FakeClient(fail=True))
+
+    def test_missing_consumer_ref_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(ValueError):
+                ga.generate(_spec(consumer_ref=""), Path(d), dry_run=True)
+
+    def test_provider_must_be_comfyui_local(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(ValueError):
+                ga.generate(_spec(provider="jules"), Path(d), dry_run=True)
+
+    def test_negative_seed_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(ValueError):
+                ga.generate(_spec(seed=-1), Path(d), dry_run=True)
+
+
+class ProvenanceSchemaTests(unittest.TestCase):
+    def test_dry_run_provenance_matches_schema_shape(self):
+        schema = json.loads((REPO_ROOT / "schemas" / "asset-provenance.schema.json")
+                            .read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory() as d:
+            prov = ga.generate(_spec(), Path(d), dry_run=True, now="2026-07-18T00:00:00Z")
+        for field in schema["required"]:
+            self.assertIn(field, prov, f"provenance missing required field {field}")
+        # optional jsonschema validation when the lib is present
+        try:
+            import jsonschema  # type: ignore
+        except ImportError:
+            return
+        jsonschema.validate(instance=prov, schema=schema)
+
+    def test_example_spec_is_valid_and_drives_a_dry_run(self):
+        spec = json.loads((REPO_ROOT / "assets" / "specs" / "gasgiant-example.json")
+                          .read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory() as d:
+            prov = ga.generate(spec, Path(d), dry_run=True, now="2026-07-18T00:00:00Z")
+            self.assertEqual(prov["id"], "gasgiant-jovian-01")
+            self.assertTrue(prov["consumer_ref"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/state/driver/aiw-budget-policy.json
+++ b/state/driver/aiw-budget-policy.json
@@ -38,6 +38,13 @@
       "requires_manual_approval": false
     },
     {
+      "id": "comfyui-local",
+      "tier": "local-seat",
+      "cost_model": "local-gpu",
+      "lane": "asset-generation",
+      "requires_manual_approval": false
+    },
+    {
       "id": "gemini-cli",
       "tier": "metered-cloud",
       "cost_model": "provider-billing",
@@ -64,6 +71,7 @@
     "codex-cli",
     "antigravity",
     "augment-code",
+    "comfyui-local",
     "gemini-cli",
     "jules",
     "notebooklm"


### PR DESCRIPTION
Implements the offline-provable layers of **Slice 0 #726** (epic #724). No workflow files touched.

## Proven here (offline, no GPU)
- `scripts/generate_asset.py` — deterministic stdlib driver; injectable ComfyUI client; `--dry-run`; fails closed.
- `schemas/asset-provenance.schema.json` — reproducible provenance record.
- `comfyui-local` registered as an AIW **local-seat** provider → budget-gated + HALT-aware.
- `scripts/asset_consumer_guard.py` — anti-LOLLI guard (fixture-proven, not vacuously green).
- SDXL workflow + example spec.

**Evidence:** 15 new tests (full suite **179 passed**); `--dry-run` emits valid provenance; AIW gate reserves a `comfyui-local` job → ALLOW/0; governance + manifest green.

## ⛔ Not done — the one local step (Slice 0 acceptance)
Per our render-verification + harness-before-harvest rules, this is **not a completed tracer-bullet** until a real texture is generated and rendered. That step needs local ComfyUI on the 5080:
```
python scripts/generate_asset.py --spec assets/specs/gasgiant-example.json
# then load assets/generated/gasgiant-jovian-01.png tiled on a gas giant, screenshot
```

**Merge recommendation:** hold until that screenshot is attached, or merge now as dormant, tested scaffolding if you prefer to unblock Slices 1–3. Your call.

Refs #724, #726