### PR TITLE
fix(aiw-prompt-pack): AIW prompt-pack + harness rules, CI-green (corrected #648)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Demerzel/
 | Personas | 17 | `personas/*.persona.yaml` |
 | Policies | 46 | `policies/*.yaml` |
 | Grammars | 20 | `grammars/*.ebnf` |
-| Schemas | 45 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
+| Schemas | 46 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
 | Behavioral tests | 115 | `tests/behavioral/*.md` |
 | Skills | 69 | `.claude/skills/*/` |
 | Streeling departments | 23 | `state/streeling/departments/*.department.json` |

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -10,7 +10,7 @@
     "persona": 17,
     "pipeline": 23,
     "policy": 46,
-    "schema": 45,
+    "schema": 46,
     "seldon_schema": 7,
     "skill": 69,
     "streeling_schema": 1,
@@ -374,6 +374,10 @@
       {
         "name": "ai-probe.schema",
         "path": "schemas/ai-probe.schema.json"
+      },
+      {
+        "name": "aiw-harness-result.schema",
+        "path": "schemas/aiw-harness-result.schema.json"
       },
       {
         "name": "blackboard-state.schema",

--- a/schemas/aiw-harness-result.schema.json
+++ b/schemas/aiw-harness-result.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GuitarAlchemist/Demerzel/schemas/aiw-harness-result",
+  "title": "AIW Harness Result",
+  "description": "Structured result of an AIW execution episode, ensuring the work is observable, bounded, repeatable, and reviewable.",
+  "type": "object",
+  "required": [
+    "job_id",
+    "issue",
+    "lane",
+    "autonomy_mode",
+    "provider",
+    "workspace",
+    "context_bundle_sha",
+    "prompt_pack_version",
+    "budget",
+    "commands_run",
+    "changed_files",
+    "outputs",
+    "observations",
+    "decision",
+    "stop_reason",
+    "risk_notes"
+  ],
+  "properties": {
+    "job_id": {
+      "type": "string"
+    },
+    "issue": {
+      "type": ["integer", "string"]
+    },
+    "lane": {
+      "type": "string",
+      "enum": ["explore", "shape", "loop", "verify", "govern"]
+    },
+    "autonomy_mode": {
+      "type": "string",
+      "enum": ["observe", "draft", "patch", "pr", "harvest"]
+    },
+    "provider": {
+      "type": "string"
+    },
+    "workspace": {
+      "type": "string"
+    },
+    "context_bundle_sha": {
+      "type": "string"
+    },
+    "prompt_pack_version": {
+      "type": "string"
+    },
+    "budget": {
+      "type": "object",
+      "required": [
+        "tier",
+        "max_total_tokens",
+        "max_model_calls",
+        "max_retries",
+        "max_runner_minutes",
+        "max_cost_usd",
+        "approval_required_above_usd"
+      ],
+      "properties": {
+        "tier": {
+          "type": "string",
+          "enum": ["free-local", "cheap-hosted", "paid-agent", "manual-approval"]
+        },
+        "max_total_tokens": {
+          "type": "integer"
+        },
+        "max_model_calls": {
+          "type": "integer"
+        },
+        "max_retries": {
+          "type": "integer"
+        },
+        "max_runner_minutes": {
+          "type": "integer"
+        },
+        "max_cost_usd": {
+          "type": "number"
+        },
+        "approval_required_above_usd": {
+          "type": "number"
+        }
+      }
+    },
+    "commands_run": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["command", "status"],
+        "properties": {
+          "command": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["passed", "failed", "timeout", "blocked"]
+          },
+          "log": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "changed_files": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": ["string", "null"]
+        },
+        "pr": {
+          "type": ["string", "null"]
+        },
+        "diff_summary": {
+          "type": "string"
+        },
+        "validation_log": {
+          "type": "string"
+        }
+      }
+    },
+    "observations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "decision": {
+      "type": "string"
+    },
+    "stop_reason": {
+      "type": "string"
+    },
+    "risk_notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/scripts/aiw_prompt_pack.py
+++ b/scripts/aiw_prompt_pack.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+
+import jsonschema
+
+_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schemas" / "aiw-harness-result.schema.json"
+
+class PromptPack:
+    def __init__(self, template_path):
+        with open(template_path, 'r') as f:
+            self.template = f.read()
+
+    def validate_sections(self):
+        required_sections = [
+            "## Role",
+            "## Task",
+            "## Source of truth",
+            "## Context bundle",
+            "## Allowed scope",
+            "## Non-goals",
+            "## Constraints",
+            "## Required process",
+            "## Required outputs",
+            "## Stop conditions"
+        ]
+
+        missing = []
+        for section in required_sections:
+            if section not in self.template:
+                missing.append(section)
+
+        if missing:
+            raise ValueError(f"Prompt template is missing required sections: {', '.join(missing)}")
+
+        return True
+
+def generate_prompt(template_path, **kwargs):
+    pack = PromptPack(template_path)
+    pack.validate_sections()
+
+    prompt = pack.template
+    for key, value in kwargs.items():
+        prompt = prompt.replace(f"<{key}>", str(value))
+
+    # Validation logic specific to tests
+    if "<issue-url-or-number>" in prompt:
+        raise ValueError("Generated prompt must include issue number")
+
+    if "<path>" in prompt:
+        raise ValueError("Generated prompt must include allowed paths")
+
+    # Check if context files and allowed paths are provided when trying to do broad scope
+    # For now we'll rely on the harness check, but can implement it here too if needed
+
+    return prompt
+
+def check_harness_execution_rules(job_spec, harness_result_path=None):
+    """
+    Validates rules around execution, risk, budget, retry, etc.
+    Returns (True, "success") or (False, "reason for failure")
+    """
+
+    # 1. Missing test command blocks AFK patch/pr modes
+    if job_spec.get('autonomy_mode') in ['patch', 'pr']:
+        if not job_spec.get('test_command'):
+            return False, "missing test command blocks AFK patch/pr modes"
+
+    # 2. High/critical risk blocks autonomous implementation
+    risk = job_spec.get('risk_level', 'low')
+    if risk in ['high', 'critical']:
+        return False, "high/critical risk blocks autonomous implementation"
+
+    # 3. Budget cap is enforced before provider invocation
+    budget = job_spec.get('budget', {})
+    if budget.get('estimated_cost_usd', 0) > budget.get('max_cost_usd', 0):
+        return False, "budget cap exceeded before provider invocation"
+
+    # 4. Retry count is capped
+    if job_spec.get('retry_count', 0) >= budget.get('max_retries', 0):
+        if job_spec.get('retry_count', 0) > 0:
+             return False, "retry count is capped"
+        elif budget.get('max_retries', 0) == 0 and job_spec.get('retry_count', 0) > 0:
+             return False, "retry count is capped"
+
+    # 5. NotebookLM output cannot be treated as canonical unless exported/linked back
+    if job_spec.get('source_type') == 'notebooklm' and not job_spec.get('exported_link'):
+        return False, "NotebookLM output cannot be treated as canonical unless exported/linked back"
+
+    # 6. Validate JSON schema if path provided
+    if harness_result_path:
+        with open(_SCHEMA_PATH, 'r') as f:
+            schema = json.load(f)
+        with open(harness_result_path, 'r') as f:
+            instance = json.load(f)
+        try:
+            jsonschema.validate(instance, schema)
+        except jsonschema.exceptions.ValidationError as e:
+            return False, f"harness output JSON fails schema validation: {e.message}"
+
+    return True, "success"

--- a/scripts/test_aiw_prompt_pack.py
+++ b/scripts/test_aiw_prompt_pack.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Unittest suite for the AIW prompt-pack + harness execution rules (issue #648).
+
+Runs under the repo's `python -m unittest discover -s scripts` harness (no pytest).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+from aiw_prompt_pack import PromptPack, generate_prompt, check_harness_execution_rules
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = REPO_ROOT / "examples" / "aiw-harness-result.example.json"
+
+VALID_TEMPLATE = """
+## Role
+## Task
+## Source of truth
+## Context bundle
+## Allowed scope
+## Non-goals
+## Constraints
+## Required process
+## Required outputs
+## Stop conditions
+
+You are acting as: <provider-role>.
+Issue: <issue-url-or-number>
+Allowed paths: <path>
+"""
+
+INVALID_TEMPLATE = """
+## Role
+## Task
+## Source of truth
+## Context bundle
+## Allowed scope
+## Non-goals
+## Required process
+## Required outputs
+## Stop conditions
+
+Missing Constraints
+"""
+
+
+def _tempfile(text: str, suffix: str = "") -> str:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=suffix, encoding="utf-8") as f:
+        f.write(text)
+        return f.name
+
+
+class PromptPackTests(unittest.TestCase):
+    def test_contains_required_sections(self):
+        path = _tempfile(VALID_TEMPLATE)
+        try:
+            self.assertTrue(PromptPack(path).validate_sections())
+        finally:
+            os.unlink(path)
+
+    def test_missing_sections_raises(self):
+        path = _tempfile(INVALID_TEMPLATE)
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                PromptPack(path).validate_sections()
+            self.assertIn("## Constraints", str(ctx.exception))
+        finally:
+            os.unlink(path)
+
+    def test_generated_prompt_requires_issue_and_paths(self):
+        path = _tempfile(VALID_TEMPLATE)
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                generate_prompt(path, **{"provider-role": "docs-worker", "issue-url-or-number": "123"})
+            self.assertIn("allowed paths", str(ctx.exception))
+
+            with self.assertRaises(ValueError) as ctx:
+                generate_prompt(path, **{"provider-role": "docs-worker", "path": "docs/"})
+            self.assertIn("issue number", str(ctx.exception))
+
+            prompt = generate_prompt(path, **{
+                "provider-role": "docs-worker", "issue-url-or-number": "123", "path": "docs/"})
+            self.assertIn("Issue: 123", prompt)
+            self.assertIn("Allowed paths: docs/", prompt)
+        finally:
+            os.unlink(path)
+
+
+class HarnessRuleTests(unittest.TestCase):
+    def test_missing_test_command_blocks_patch_and_pr(self):
+        for mode in ("patch", "pr"):
+            ok, reason = check_harness_execution_rules({"autonomy_mode": mode, "test_command": ""})
+            self.assertFalse(ok)
+            self.assertIn("missing test command", reason)
+        ok, _ = check_harness_execution_rules({"autonomy_mode": "patch", "test_command": "pytest"})
+        self.assertTrue(ok)
+        ok, _ = check_harness_execution_rules({"autonomy_mode": "draft", "test_command": ""})
+        self.assertTrue(ok)
+
+    def test_high_critical_risk_blocks(self):
+        for risk in ("high", "critical"):
+            ok, reason = check_harness_execution_rules({"risk_level": risk})
+            self.assertFalse(ok)
+            self.assertIn("high/critical risk", reason)
+        ok, _ = check_harness_execution_rules({"risk_level": "low"})
+        self.assertTrue(ok)
+
+    def test_budget_cap_enforced(self):
+        ok, reason = check_harness_execution_rules(
+            {"budget": {"estimated_cost_usd": 10.0, "max_cost_usd": 5.0}})
+        self.assertFalse(ok)
+        self.assertIn("budget cap exceeded", reason)
+        ok, _ = check_harness_execution_rules(
+            {"budget": {"estimated_cost_usd": 2.0, "max_cost_usd": 5.0}})
+        self.assertTrue(ok)
+
+    def test_retry_count_capped(self):
+        ok, reason = check_harness_execution_rules({"retry_count": 3, "budget": {"max_retries": 2}})
+        self.assertFalse(ok)
+        self.assertIn("retry count is capped", reason)
+        ok, _ = check_harness_execution_rules({"retry_count": 1, "budget": {"max_retries": 2}})
+        self.assertTrue(ok)
+
+    def test_notebooklm_needs_export(self):
+        ok, reason = check_harness_execution_rules({"source_type": "notebooklm"})
+        self.assertFalse(ok)
+        self.assertIn("NotebookLM output cannot be treated as canonical", reason)
+        ok, _ = check_harness_execution_rules(
+            {"source_type": "notebooklm", "exported_link": "https://example.com"})
+        self.assertTrue(ok)
+
+    def test_harness_output_validates_against_schema(self):
+        ok, reason = check_harness_execution_rules({}, harness_result_path=str(EXAMPLE))
+        self.assertTrue(ok, reason)
+
+        bad = _tempfile(json.dumps({"job_id": "123"}), suffix=".json")
+        try:
+            ok, reason = check_harness_execution_rules({}, harness_result_path=bad)
+            self.assertFalse(ok)
+            self.assertIn("schema validation", reason)
+        finally:
+            os.unlink(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Corrected rebuild of #648 onto current master. Original failed because its test was **pytest**-style but the repo runs `unittest discover` (pytest not installed), and the branch was stale/conflicting.

- test converted to unittest (9 tests, no pytest/regex)
- `aiw_prompt_pack.py` schema path resolved from repo root (was cwd-fragile)
- carries only the real artifacts (module + test + `schemas/aiw-harness-result.schema.json`); manifest regenerated; README schema count bumped

**Evidence:** full suite **173 passed**; example validates against schema; governance + manifest green.

Supersedes #648. Refs #461