### PR TITLE
feat(aiw): executable advisory consumer for worker-lane defs (#737)

### DIFF
--- a/docs/workflows/aiw-composite-lanes.md
+++ b/docs/workflows/aiw-composite-lanes.md
@@ -32,6 +32,11 @@ Each worker should have:
 
 ### Definitions
 
+> **Canonical machine-readable form:** `state/driver/aiw-worker-lanes.json`. The YAML
+> below is human-readable illustration; the JSON is the single source of truth the
+> advisory selector (`scripts/aiw_lane_selector.py`, #737) reads. Keep the two in
+> sync — edit the JSON first.
+
 ```yaml
 composite_lanes:
   jules:
@@ -84,6 +89,27 @@ composite_lanes:
       - merge_decider
       - policy_override_actor
 ```
+
+### Terminology reconciliation (roles ↔ work classes)
+
+Roles and adaptive-mode rules use one shared vocabulary in
+`state/driver/aiw-worker-lanes.json`: every role maps to a `work_class`, and each
+mode blocks a set of work classes (`mode_blocks`). This is what lets the selector
+gate a named role (`builder_fixer`) by a mode rule phrased about a category
+(`net-new feature work`).
+
+- `net_new_feature` — `builder_fixer`
+- `broad_architecture` — `broad_architecture_owner` *(forbidden)*
+- `workflow_policy_change` — `high_risk_workflow_editor_without_human_review`, `policy_override_actor` *(forbidden)*
+- `fix` — `draft_to_ready_helper`, `test_author`, `review_feedback_applier`, `focused_patch_helper`
+- `groom` — `docs_first_researcher`, `issue_groomer`, `process_drafter`, `lightweight_groomer`
+- `navigate` — `navigator`, `impact_mapper`, `dependency_mapper`, `path_collision_checker`, `stale_marker_investigator`
+- `review` — `read_only_critic`, `architecture_reviewer`, `policy_ambiguity_reviewer`, `risk_classifier`, `architecture_summarizer`, `test_suggester`, `code_review_helper`, `alternative_implementation_proposer`
+
+The three merge-forbidding tokens (`merge_decider`, `final_merge_decider`,
+`autonomous_merge_actor`) are **aliases for the same `merge` work class** — different
+lanes named it differently; `merge_action_aliases` in the JSON records the equivalence
+without renaming the per-lane tokens.
 
 ## Adaptive use by mode
 

--- a/examples/aiw/augment-navigation-report.example.md
+++ b/examples/aiw/augment-navigation-report.example.md
@@ -1,0 +1,14 @@
+# Example AIW job — Augment navigation report
+
+Augment's primary lane is `navigator` (`navigate`-class): read-only repo
+intelligence that informs grooming and fan-in decisions. Under `NORMAL` fan-out
+the selector should **allow** it.
+
+```json
+{ "worker": "augment", "requested_role": "navigator", "fan_out_mode": "NORMAL", "subject": "issue" }
+```
+
+Expected decision: allow
+
+Augment primarily *informs* decisions; `merge_decider` and `policy_override_actor`
+are **forbidden** for this lane.

--- a/examples/aiw/claude-draft-to-ready-job.example.md
+++ b/examples/aiw/claude-draft-to-ready-job.example.md
@@ -1,0 +1,15 @@
+# Example AIW job — Claude draft-to-ready under DRAINING
+
+Claude's primary lane is `builder_fixer` (net-new build), which is **blocked** while
+fan-out is `DRAINING`. But its secondary `draft_to_ready_helper` role is `fix`-class
+work, which stays allowed in DRAINING — so the selector should **recommend** the
+fallback rather than block Claude entirely.
+
+```json
+{ "worker": "claude", "requested_role": "draft_to_ready_helper", "fan_out_mode": "DRAINING", "subject": "pull_request" }
+```
+
+Expected decision: recommend
+
+Contrast: `builder_fixer` in `DRAINING` is **blocked** (`SYSTEM.BACKPRESSURE_HIGH`) —
+net-new feature work must wait for fan-out to recover.

--- a/examples/aiw/codex-focused-fix.example.md
+++ b/examples/aiw/codex-focused-fix.example.md
@@ -1,0 +1,14 @@
+# Example AIW job — Codex focused fix under CONSTRAINED
+
+Codex's primary lane is `focused_patch_helper` (`fix`-class). Under `CONSTRAINED`
+fan-out only net-new feature and broad-architecture work are reduced, so a focused
+fix is still allowed. The selector should **allow** it.
+
+```json
+{ "worker": "codex", "requested_role": "focused_patch_helper", "fan_out_mode": "CONSTRAINED", "subject": "worker_task" }
+```
+
+Expected decision: allow
+
+Codex runs inside explicit issue/job constraints; `broad_architecture_owner` is a
+**forbidden** role for this lane.

--- a/examples/aiw/gemini-critic-review.example.md
+++ b/examples/aiw/gemini-critic-review.example.md
@@ -1,0 +1,14 @@
+# Example AIW job — Gemini read-only Critic review
+
+Gemini's primary lane is `read_only_critic` (see `docs/workflows/aiw-composite-lanes.md`).
+This request asks it to review a pull request while fan-out is `NORMAL`. The advisory
+lane selector (`scripts/aiw_lane_selector.py`) should **allow** it.
+
+```json
+{ "worker": "gemini", "requested_role": "read_only_critic", "fan_out_mode": "NORMAL", "subject": "pull_request" }
+```
+
+Expected decision: allow
+
+Note: requesting `code_pusher` from Gemini is **blocked** (`CAPABILITY.FORBIDDEN_ROLE`) —
+the Critic lane is read-only and may not push commits, aligning with #485.

--- a/scripts/aiw_lane_selector.py
+++ b/scripts/aiw_lane_selector.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""AIW advisory lane selector (#737).
+
+The executable consumer for the worker-lane definitions documented in
+`docs/workflows/aiw-composite-lanes.md` and made canonical in
+`state/driver/aiw-worker-lanes.json`. Given a proposed
+{worker, requested_role, fan_out_mode, subject}, it emits a schema-valid
+`advisory-decision` (schemas/advisory-decision.schema.json) answering:
+
+  * is `worker` a defined lane?
+  * is `requested_role` forbidden for that worker? (the governance boundary)
+  * does `requested_role` belong to that worker's lane at all?
+  * is the role's work_class allowed in the current fan-out mode?
+
+This is ADVISORY / DRY-RUN. It never mutates any GitHub or filesystem state.
+The allow/block outcome is carried in the decision payload, not the exit code:
+exit 0 = evaluated (read the decision), exit 2 = could not evaluate (bad input
+or missing/invalid lane policy). Stdlib only — no third-party imports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_LANES_PATH = Path(__file__).resolve().parents[1] / "state" / "driver" / "aiw-worker-lanes.json"
+
+# Subjects permitted by schemas/advisory-decision.schema.json.
+_VALID_SUBJECTS = ("issue", "pull_request", "batch", "worker_task", "execution_episode")
+
+RULE_ID = "LANE-SEL-001"
+
+
+def load_lanes(path=None):
+    """Load and minimally validate the canonical lane policy."""
+    lanes_path = Path(path) if path else _LANES_PATH
+    with open(lanes_path, "r", encoding="utf-8") as f:
+        policy = json.load(f)
+    for key in ("roles", "workers", "mode_blocks"):
+        if key not in policy:
+            raise ValueError(f"lane policy is missing required key '{key}'")
+    return policy
+
+
+def _decision(subject, decision, reason_codes, evidence_refs, next_actions, confidence):
+    return {
+        "rule_result": {
+            "rule_id": RULE_ID,
+            "subject": subject,
+            "decision": decision,
+            "reason_codes": list(reason_codes),
+            "evidence_refs": list(evidence_refs),
+            "next_actions": list(next_actions),
+            "confidence": confidence,
+        }
+    }
+
+
+def select_lane(request, policy):
+    """Evaluate a lane-assignment request. Returns an advisory-decision dict.
+
+    request keys: worker, requested_role, fan_out_mode, subject.
+    """
+    worker = request.get("worker")
+    role = request.get("requested_role")
+    mode = request.get("fan_out_mode")
+    subject = request.get("subject", "worker_task")
+
+    # Normalize subject to the schema enum; anything else is a caller error we
+    # surface as an escalate rather than silently emitting an invalid decision.
+    if subject not in _VALID_SUBJECTS:
+        return _decision(
+            "worker_task", "escalate",
+            ["SCOPE.UNDEFINED"],
+            [f"subject={subject!r}"],
+            [f"use one of {', '.join(_VALID_SUBJECTS)}"],
+            "high",
+        )
+
+    workers = policy["workers"]
+    roles = policy["roles"]
+    mode_blocks = policy["mode_blocks"]
+
+    # 1. Unknown worker lane.
+    if worker not in workers:
+        return _decision(
+            subject, "block",
+            ["CAPABILITY.UNAVAILABLE"],
+            [f"worker={worker!r}"],
+            ["route the task to a defined worker lane (jules, claude, gemini, codex, augment)"],
+            "high",
+        )
+    lane = workers[worker]
+
+    # 2. Unknown fan-out mode.
+    if mode not in mode_blocks:
+        return _decision(
+            subject, "escalate",
+            ["SCOPE.UNDEFINED"],
+            [f"fan_out_mode={mode!r}"],
+            [f"supply a defined mode ({', '.join(mode_blocks.keys())})"],
+            "high",
+        )
+
+    # 3. Forbidden role for this worker — the governance boundary. Checked before
+    #    membership so a forbidden request is always blocked, never merely warned.
+    if role in lane.get("forbidden", []):
+        return _decision(
+            subject, "block",
+            ["CAPABILITY.FORBIDDEN_ROLE"],
+            [f"worker={worker}", f"forbidden={lane['forbidden']}"],
+            [f"reassign to a worker whose lane permits '{role}'; this lane forbids it"],
+            "high",
+        )
+
+    # 4. Role not part of this worker's lane (neither primary nor secondary).
+    lane_roles = [lane["primary"]] + list(lane.get("secondary", []))
+    if role not in lane_roles:
+        return _decision(
+            subject, "warn",
+            ["CAPABILITY.MISMATCH"],
+            [f"worker={worker}", f"lane_roles={lane_roles}"],
+            [f"confirm '{role}' belongs to this worker's lane, or pick a lane role"],
+            "medium",
+        )
+
+    # 5. Mode gating by the role's work_class.
+    role_def = roles.get(role, {})
+    work_class = role_def.get("work_class")
+    blocked_classes = mode_blocks[mode]
+    if work_class in blocked_classes:
+        return _decision(
+            subject, "block",
+            ["SYSTEM.BACKPRESSURE_HIGH", f"WORK_CLASS.{str(work_class).upper()}"],
+            [f"fan_out_mode={mode}", f"work_class={work_class}", f"mode_blocks={blocked_classes}"],
+            [
+                f"defer '{role}' until fan-out returns to a mode that allows '{work_class}' work, "
+                "or fall back to a mode-safe secondary role in this lane",
+            ],
+            "high",
+        )
+
+    # 6. Allowed. Primary is a direct match; a secondary role is an advisory fallback.
+    is_primary = role == lane["primary"]
+    reason = "LANE.PRIMARY_MATCH" if is_primary else "LANE.SECONDARY_FALLBACK"
+    outcome = "allow" if is_primary else "recommend"
+    expected = role_def.get("expected_output") or "see lane definition"
+    return _decision(
+        subject, outcome,
+        [reason],
+        [f"worker={worker}", f"role={role}", f"work_class={work_class}", f"fan_out_mode={mode}"],
+        [f"proceed under advisory lane; expected output: {expected}"],
+        "high",
+    )
+
+
+def _read_request(args):
+    if args.request:
+        with open(args.request, "r", encoding="utf-8") as f:
+            return json.load(f)
+    if not sys.stdin.isatty():
+        data = sys.stdin.read().strip()
+        if data:
+            return json.loads(data)
+    raise ValueError("no request provided: pass --request <path> or pipe JSON on stdin")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="AIW advisory lane selector (dry-run, #737)")
+    parser.add_argument("--request", help="path to a JSON request {worker, requested_role, fan_out_mode, subject}")
+    parser.add_argument("--lanes", help="path to the canonical lane policy JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        policy = load_lanes(args.lanes)
+        request = _read_request(args)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 2
+
+    decision = select_lane(request, policy)
+    print(json.dumps(decision, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_aiw_lane_selector.py
+++ b/scripts/test_aiw_lane_selector.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Regression guard for the AIW advisory lane selector (#737).
+
+Runs under `python -m unittest discover -s scripts` (no pytest). Asserts:
+  * forbidden roles are blocked (the governance boundary);
+  * mode gating honors work_class (net-new blocked in DRAINING, fix survives);
+  * HALTED collapses to read-only review;
+  * every emitted decision validates against advisory-decision.schema.json;
+  * the committed examples/aiw/*.example.md fixtures each resolve to their
+    documented "Expected decision" — so the examples cannot silently rot and the
+    selector cannot be unwired from its canonical policy.
+
+String-based parsing only (no regex), per repo convention.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+import jsonschema
+
+from aiw_lane_selector import load_lanes, select_lane
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "schemas" / "advisory-decision.schema.json"
+EXAMPLES_DIR = REPO_ROOT / "examples" / "aiw"
+
+
+def _extract_json_block(text):
+    """Return the first ```json ... ``` fenced block in `text`, parsed."""
+    marker = "```json"
+    start = text.find(marker)
+    if start == -1:
+        raise AssertionError("no ```json block found")
+    body_start = start + len(marker)
+    end = text.find("```", body_start)
+    if end == -1:
+        raise AssertionError("unterminated ```json block")
+    return json.loads(text[body_start:end])
+
+
+def _extract_expected_decision(text):
+    """Return the value after the 'Expected decision:' line."""
+    key = "Expected decision:"
+    idx = text.find(key)
+    if idx == -1:
+        raise AssertionError("no 'Expected decision:' line found")
+    line_end = text.find("\n", idx)
+    if line_end == -1:
+        line_end = len(text)
+    return text[idx + len(key):line_end].strip()
+
+
+class LaneSelectorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.policy = load_lanes()
+        with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+            cls.schema = json.load(f)
+
+    def _decide(self, **request):
+        result = select_lane(request, self.policy)
+        # Every decision must be schema-valid, always.
+        jsonschema.validate(result, self.schema)
+        return result["rule_result"]
+
+    def test_forbidden_role_is_blocked(self):
+        # Gemini is read-only; pushing code is a forbidden governance boundary.
+        r = self._decide(worker="gemini", requested_role="code_pusher",
+                         fan_out_mode="NORMAL", subject="pull_request")
+        self.assertEqual(r["decision"], "block")
+        self.assertIn("CAPABILITY.FORBIDDEN_ROLE", r["reason_codes"])
+
+    def test_forbidden_checked_before_mode(self):
+        # Forbidden must win even when the mode would otherwise allow the class.
+        r = self._decide(worker="claude", requested_role="final_merge_decider",
+                         fan_out_mode="NORMAL", subject="pull_request")
+        self.assertEqual(r["decision"], "block")
+        self.assertIn("CAPABILITY.FORBIDDEN_ROLE", r["reason_codes"])
+
+    def test_unknown_worker_blocked(self):
+        r = self._decide(worker="skynet", requested_role="builder_fixer",
+                         fan_out_mode="NORMAL", subject="worker_task")
+        self.assertEqual(r["decision"], "block")
+        self.assertIn("CAPABILITY.UNAVAILABLE", r["reason_codes"])
+
+    def test_role_not_in_lane_warns(self):
+        # navigator belongs to augment, not claude.
+        r = self._decide(worker="claude", requested_role="navigator",
+                         fan_out_mode="NORMAL", subject="worker_task")
+        self.assertEqual(r["decision"], "warn")
+        self.assertIn("CAPABILITY.MISMATCH", r["reason_codes"])
+
+    def test_net_new_feature_blocked_in_draining(self):
+        r = self._decide(worker="claude", requested_role="builder_fixer",
+                         fan_out_mode="DRAINING", subject="pull_request")
+        self.assertEqual(r["decision"], "block")
+        self.assertIn("SYSTEM.BACKPRESSURE_HIGH", r["reason_codes"])
+
+    def test_fix_survives_draining_as_fallback(self):
+        r = self._decide(worker="claude", requested_role="draft_to_ready_helper",
+                         fan_out_mode="DRAINING", subject="pull_request")
+        self.assertEqual(r["decision"], "recommend")
+        self.assertIn("LANE.SECONDARY_FALLBACK", r["reason_codes"])
+
+    def test_primary_match_allows(self):
+        r = self._decide(worker="gemini", requested_role="read_only_critic",
+                         fan_out_mode="NORMAL", subject="pull_request")
+        self.assertEqual(r["decision"], "allow")
+        self.assertIn("LANE.PRIMARY_MATCH", r["reason_codes"])
+
+    def test_halted_collapses_to_read_only_review(self):
+        # A review role survives HALTED...
+        r = self._decide(worker="gemini", requested_role="read_only_critic",
+                         fan_out_mode="HALTED", subject="pull_request")
+        self.assertEqual(r["decision"], "allow")
+        # ...but navigation (mutation-adjacent read work) does not.
+        r2 = self._decide(worker="augment", requested_role="navigator",
+                          fan_out_mode="HALTED", subject="issue")
+        self.assertEqual(r2["decision"], "block")
+
+    def test_unknown_mode_escalates(self):
+        r = self._decide(worker="claude", requested_role="builder_fixer",
+                         fan_out_mode="TURBO", subject="worker_task")
+        self.assertEqual(r["decision"], "escalate")
+
+    def test_invalid_subject_escalates(self):
+        r = self._decide(worker="claude", requested_role="builder_fixer",
+                         fan_out_mode="NORMAL", subject="galaxy")
+        self.assertEqual(r["decision"], "escalate")
+        self.assertIn("SCOPE.UNDEFINED", r["reason_codes"])
+
+    def test_every_lane_role_has_a_registry_entry(self):
+        # Terminology reconciliation guard: every role a worker references must be
+        # defined once in `roles` with a work_class the mode_blocks vocabulary knows.
+        roles = self.policy["roles"]
+        known_classes = set(self.policy.get("work_classes", {}))
+        for name, lane in self.policy["workers"].items():
+            for role in [lane["primary"]] + lane.get("secondary", []) + lane.get("forbidden", []):
+                self.assertIn(role, roles, f"{name} references undefined role {role}")
+                self.assertIn(roles[role]["work_class"], known_classes,
+                              f"role {role} has unknown work_class")
+
+    def test_example_fixtures_match_documented_decisions(self):
+        fixtures = sorted(EXAMPLES_DIR.glob("*.example.md"))
+        self.assertTrue(fixtures, "no example fixtures found — the selector would have no live consumer")
+        for path in fixtures:
+            text = path.read_text(encoding="utf-8")
+            request = _extract_json_block(text)
+            expected = _extract_expected_decision(text)
+            result = self._decide(**request)
+            self.assertEqual(result["decision"], expected,
+                             f"{path.name}: expected {expected}, got {result['decision']}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/state/driver/aiw-worker-lanes.json
+++ b/state/driver/aiw-worker-lanes.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": "1.0",
+  "description": "Canonical machine-readable worker-lane definitions for the AIW advisory lane selector (scripts/aiw_lane_selector.py). Single source of truth reconciling the two vocabularies in docs/workflows/aiw-composite-lanes.md: per-worker role tokens (defined once in `roles`) and per-mode work categories (expressed in the shared `work_class` vocabulary used by `mode_blocks`). Advisory/dry-run only — no state mutation. See #584, #586, #600, #737.",
+  "work_classes": {
+    "net_new_feature": "Build/implement net-new functionality.",
+    "broad_architecture": "Broad structural or architecture change.",
+    "workflow_policy_change": "Edit CI workflows, policy, or governance config.",
+    "fix": "Targeted fix, draft-to-ready, tests, or applying review feedback.",
+    "groom": "Issue grooming, process/docs drafting, readiness shaping.",
+    "navigate": "Read-only repo navigation, impact/dependency/path/stale analysis.",
+    "review": "Read-only review, critique, risk classification, summarization.",
+    "diagnostic": "Read-only diagnostics and recovery-plan authoring.",
+    "merge": "Deciding or performing a merge (forbidden action).",
+    "secret": "Handling secrets or credentials (forbidden action).",
+    "push": "Pushing commits directly (forbidden action).",
+    "state_mutation": "Mutating issue/PR labels or state (forbidden action).",
+    "review_approval": "Approving one's own or peer review (forbidden action)."
+  },
+  "roles": {
+    "docs_first_researcher": { "work_class": "groom", "expected_output": "source-grounded research pack or docs-first draft" },
+    "issue_groomer": { "work_class": "groom", "expected_output": "groomed issue with allowed paths, non-goals, and acceptance criteria" },
+    "process_drafter": { "work_class": "groom", "expected_output": "process / operating-model draft" },
+    "architecture_summarizer": { "work_class": "review", "expected_output": "read-only architecture summary" },
+    "builder_fixer": { "work_class": "net_new_feature", "expected_output": "branch + PR implementing or refactoring the change" },
+    "draft_to_ready_helper": { "work_class": "fix", "expected_output": "draft PR advanced to ready-for-review" },
+    "test_author": { "work_class": "fix", "expected_output": "added or updated tests" },
+    "review_feedback_applier": { "work_class": "fix", "expected_output": "commits applying review feedback" },
+    "lightweight_groomer": { "work_class": "groom", "expected_output": "lightly groomed issue" },
+    "read_only_critic": { "work_class": "review", "expected_output": "structured adversarial review findings" },
+    "architecture_reviewer": { "work_class": "review", "expected_output": "architecture critique" },
+    "policy_ambiguity_reviewer": { "work_class": "review", "expected_output": "policy / governance ambiguity findings" },
+    "risk_classifier": { "work_class": "review", "expected_output": "risk-tier classification" },
+    "focused_patch_helper": { "work_class": "fix", "expected_output": "focused fix PR or patch within explicit constraints" },
+    "test_suggester": { "work_class": "review", "expected_output": "suggested test cases (advisory)" },
+    "code_review_helper": { "work_class": "review", "expected_output": "low-risk code-review notes" },
+    "alternative_implementation_proposer": { "work_class": "review", "expected_output": "alternative patch proposal (advisory)" },
+    "navigator": { "work_class": "navigate", "expected_output": "repo navigation report" },
+    "impact_mapper": { "work_class": "navigate", "expected_output": "impact analysis" },
+    "dependency_mapper": { "work_class": "navigate", "expected_output": "dependency map" },
+    "path_collision_checker": { "work_class": "navigate", "expected_output": "path-collision report" },
+    "stale_marker_investigator": { "work_class": "navigate", "expected_output": "stale-marker investigation" },
+    "merge_decider": { "work_class": "merge", "expected_output": null },
+    "final_merge_decider": { "work_class": "merge", "expected_output": null },
+    "autonomous_merge_actor": { "work_class": "merge", "expected_output": null },
+    "secret_handler": { "work_class": "secret", "expected_output": null },
+    "high_risk_workflow_editor_without_human_review": { "work_class": "workflow_policy_change", "expected_output": null },
+    "self_review_approver": { "work_class": "review_approval", "expected_output": null },
+    "code_pusher": { "work_class": "push", "expected_output": null },
+    "label_mutator": { "work_class": "state_mutation", "expected_output": null },
+    "broad_architecture_owner": { "work_class": "broad_architecture", "expected_output": null },
+    "policy_override_actor": { "work_class": "workflow_policy_change", "expected_output": null }
+  },
+  "merge_action_aliases": ["merge_decider", "final_merge_decider", "autonomous_merge_actor"],
+  "workers": {
+    "jules": {
+      "primary": "docs_first_researcher",
+      "secondary": ["issue_groomer", "process_drafter", "architecture_summarizer"],
+      "forbidden": ["merge_decider", "secret_handler", "high_risk_workflow_editor_without_human_review"]
+    },
+    "claude": {
+      "primary": "builder_fixer",
+      "secondary": ["draft_to_ready_helper", "test_author", "review_feedback_applier", "lightweight_groomer"],
+      "forbidden": ["final_merge_decider", "self_review_approver"]
+    },
+    "gemini": {
+      "primary": "read_only_critic",
+      "secondary": ["architecture_reviewer", "policy_ambiguity_reviewer", "risk_classifier"],
+      "forbidden": ["code_pusher", "label_mutator", "merge_decider"]
+    },
+    "codex": {
+      "primary": "focused_patch_helper",
+      "secondary": ["test_suggester", "code_review_helper", "alternative_implementation_proposer"],
+      "forbidden": ["broad_architecture_owner", "autonomous_merge_actor"]
+    },
+    "augment": {
+      "primary": "navigator",
+      "secondary": ["impact_mapper", "dependency_mapper", "path_collision_checker", "stale_marker_investigator"],
+      "forbidden": ["merge_decider", "policy_override_actor"]
+    }
+  },
+  "mode_blocks": {
+    "NORMAL": [],
+    "CONSTRAINED": ["net_new_feature", "broad_architecture"],
+    "DRAINING": ["net_new_feature", "broad_architecture", "workflow_policy_change"],
+    "HALTED": ["net_new_feature", "broad_architecture", "workflow_policy_change", "fix", "groom", "navigate", "merge", "secret", "push", "state_mutation", "review_approval"]
+  }
+}


### PR DESCRIPTION
Closes #737. Gives the AIW worker-lane governance an **executable consumer**, closing the LOLLI gap surfaced while verifying #584.

## Problem
The composite worker-lane docs (`aiw-composite-lanes.md`, #600), the 12 rule packs (#589), and `schemas/advisory-decision.schema.json` had **zero consumers** — `grep` across `scripts/` and `.github/workflows/` found nothing. Documentation, not enforcement. The budget gate got a live consumer (#721); the lane routing never did.

## What this adds (tracer-bullet, mirrors the budget-gate pattern)
- **`state/driver/aiw-worker-lanes.json`** — canonical machine-readable lane defs. **Reconciles the two vocabularies** the doc used disconnectedly: every role token is defined once with a shared `work_class`, and `mode_blocks` gate by that class. Adds per-role `expected_output` (a gap #584 carried over) and records the `merge_decider`/`final_merge_decider`/`autonomous_merge_actor` alias equivalence.
- **`scripts/aiw_lane_selector.py`** — stdlib-only advisory selector. Emits a schema-valid `advisory-decision`: forbidden-role `block` (the governance boundary), lane `warn` on mismatch, mode-gating `block`, primary `allow` / secondary `recommend`. **Dry-run — never mutates state.** Allow/block lives in the payload, not the exit code (exit 2 only on un-evaluable input).
- **`scripts/test_aiw_lane_selector.py`** — regression guard (unittest, string-based, no regex): forbidden-before-mode, DRAINING blocks net-new but `fix` survives, HALTED collapses to read-only review, every decision validates against the schema, and it **drives the example fixtures** so they can't silently rot.
- **`examples/aiw/*.example.md`** — the four job examples #584 listed (Claude draft-to-ready, Gemini critic, Codex fix, Augment navigation), now **live fixtures** the guard consumes.
- **`aiw-composite-lanes.md`** — points at the canonical JSON + a roles↔work-classes reconciliation table.

## Guardrails honored
Advisory/dry-run MVP per the composite-lane + rule-pack constraints. No auto-merge, no new worker permissions, no self-review approval, no state mutation.

## Verification
- `python -m unittest discover -s scripts -p 'test_*.py'` → **189 passed** (12 new).
- `python scripts/build_manifest.py` → **green** (no drift, schemas valid).
- CLI smoke: `echo '{...code_pusher...}' | python scripts/aiw_lane_selector.py` → `block` / `CAPABILITY.FORBIDDEN_ROLE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)