### PR TITLE
feat(planner): Epic-to-DAG compiler prototype (#533)

### DIFF
--- a/docs/contracts/epic-input.schema.json
+++ b/docs/contracts/epic-input.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "epic-input.schema.json",
+  "title": "Planner Epic Input",
+  "description": "Structured epic/story metadata consumed by the Epic-to-DAG compiler (scripts/epic_to_dag_compiler.py, #533) to produce an execution graph conforming to execution-graph.schema.json. Each work package declares its dependency edges per kind; the compiler transcribes them into DependencyEdges and validates the resulting DAG.",
+  "type": "object",
+  "required": ["graph_id", "work_packages"],
+  "additionalProperties": false,
+  "properties": {
+    "graph_id": { "type": "string", "description": "Unique identifier for the compiled execution graph" },
+    "epic_id": { "type": "string", "description": "Optional identifier of the source epic" },
+    "work_packages": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/WorkPackage" }
+    },
+    "review_stages": { "type": "array", "description": "Passed through to the execution graph verbatim" },
+    "merge_stages": { "type": "array", "description": "Passed through to the execution graph verbatim" },
+    "metadata": { "type": "object", "additionalProperties": true }
+  },
+  "definitions": {
+    "WorkPackage": {
+      "type": "object",
+      "required": ["id", "type", "repo", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "description": "Node id (e.g., #517)" },
+        "type": { "type": "string", "enum": ["doc", "code", "test", "review", "merge"] },
+        "repo": { "type": "string", "enum": ["demerzel", "ix", "tars", "ga"] },
+        "description": { "type": "string" },
+        "status": { "type": "string", "enum": ["pending", "running", "completed", "failed", "blocked"] },
+        "blocks": { "type": "array", "items": { "type": "string" }, "description": "Ids this package blocks" },
+        "depends_on": { "type": "array", "items": { "type": "string" }, "description": "Ids this package depends on" },
+        "reviews": { "type": "array", "items": { "type": "string" }, "description": "Ids this package reviews" },
+        "should_merge_after": { "type": "array", "items": { "type": "string" }, "description": "Ids this package should merge after" },
+        "evidence": { "type": "array" },
+        "metadata": { "type": "object", "additionalProperties": true }
+      }
+    }
+  }
+}

--- a/examples/execution-graph-sprint-0-input.json
+++ b/examples/execution-graph-sprint-0-input.json
@@ -1,0 +1,68 @@
+{
+  "epic_id": "sprint-0",
+  "graph_id": "sprint-0-execution-graph",
+  "work_packages": [
+    {
+      "id": "#517",
+      "type": "code",
+      "repo": "ga",
+      "description": "Infrastructure bootstrap - ga-react-components",
+      "blocks": ["#519"]
+    },
+    {
+      "id": "#519",
+      "type": "code",
+      "repo": "tars",
+      "description": "API Integration layer - tars to ga",
+      "should_merge_after": ["#527"]
+    },
+    {
+      "id": "#520",
+      "type": "code",
+      "repo": "ix",
+      "description": "Core ML pipelines - ix",
+      "depends_on": ["#523"]
+    },
+    {
+      "id": "#523",
+      "type": "test",
+      "repo": "ix",
+      "description": "E2E Integration tests for ML pipelines",
+      "blocks": ["#525"]
+    },
+    {
+      "id": "#525",
+      "type": "doc",
+      "repo": "demerzel",
+      "description": "Sprint 0 completion report",
+      "reviews": ["#527"]
+    },
+    {
+      "id": "#527",
+      "type": "review",
+      "repo": "demerzel",
+      "description": "Final governance review for Sprint 0"
+    }
+  ],
+  "review_stages": [
+    {
+      "stage_id": "governance-final-review",
+      "target_nodes": ["#527"],
+      "reviewers": ["Demerzel", "Skeptical-Auditor"],
+      "verdict": "pending"
+    }
+  ],
+  "merge_stages": [
+    {
+      "stage_id": "sprint-0-main-merge",
+      "order": 1,
+      "target_nodes": ["#517", "#519", "#520", "#523"],
+      "target_branch": "main"
+    }
+  ],
+  "metadata": {
+    "sprint": "Sprint 0",
+    "owner": "Jules",
+    "created_at": "2026-06-22T12:00:00Z"
+  }
+}

--- a/scripts/epic_to_dag_compiler.py
+++ b/scripts/epic_to_dag_compiler.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Epic-to-DAG compiler prototype (#533, parent #529).
+
+Converts structured epic/story metadata (epic-input.schema.json) into a Planner
+execution graph (execution-graph.schema.json). Dry-run: it validates and emits
+machine-readable JSON, and never mutates GitHub or repository state.
+
+Pipeline:
+  1. validate the epic input against its contract schema;
+  2. extract work packages into WorkNodes;
+  3. infer DependencyEdges from each package's per-kind edge fields
+     (blocks / depends_on / reviews / should_merge_after);
+  4. validate the compiled graph — schema-valid, no dangling edges, and acyclic
+     (an execution graph is a DAG); invalid graphs are rejected with a clear
+     error and no output.
+
+Stdlib + `jsonschema` only. See docs/contracts/execution-graph.schema.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+_CONTRACTS = Path(__file__).resolve().parents[1] / "docs" / "contracts"
+_GRAPH_SCHEMA_PATH = _CONTRACTS / "execution-graph.schema.json"
+_INPUT_SCHEMA_PATH = _CONTRACTS / "epic-input.schema.json"
+
+GRAPH_VERSION = "1.0.0"
+# Fixed order so edge inference is deterministic.
+_EDGE_KINDS = ("blocks", "depends_on", "reviews", "should_merge_after")
+
+
+class CompileError(ValueError):
+    """Raised when an epic input or the compiled graph is invalid."""
+
+
+def _load(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def extract_nodes(epic):
+    """Extract work packages into WorkNodes (input order preserved)."""
+    nodes = []
+    for wp in epic.get("work_packages", []):
+        node = {
+            "node_id": wp["id"],
+            "type": wp["type"],
+            "description": wp["description"],
+            "repo": wp["repo"],
+            "status": wp.get("status", "pending"),
+        }
+        if "evidence" in wp:
+            node["evidence"] = wp["evidence"]
+        if "metadata" in wp:
+            node["metadata"] = wp["metadata"]
+        nodes.append(node)
+    return nodes
+
+
+def infer_edges(epic):
+    """Infer DependencyEdges from each package's per-kind edge fields."""
+    edges = []
+    for wp in epic.get("work_packages", []):
+        src = wp["id"]
+        for kind in _EDGE_KINDS:
+            for target in wp.get(kind, []):
+                edges.append({"from": src, "to": target, "type": kind})
+    return edges
+
+
+def _find_cycle(node_ids, edges):
+    """Return a cycle path (list of node ids) if the graph has one, else None."""
+    adjacency = {nid: [] for nid in node_ids}
+    for edge in edges:
+        adjacency[edge["from"]].append(edge["to"])
+
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {nid: WHITE for nid in node_ids}
+    path = []
+
+    def visit(u):
+        color[u] = GRAY
+        path.append(u)
+        for v in adjacency[u]:
+            if color[v] == GRAY:
+                return path[path.index(v):] + [v]
+            if color[v] == WHITE:
+                found = visit(v)
+                if found:
+                    return found
+        color[u] = BLACK
+        path.pop()
+        return None
+
+    for nid in node_ids:
+        if color[nid] == WHITE:
+            found = visit(nid)
+            if found:
+                return found
+    return None
+
+
+def validate_graph(graph):
+    """Validate a compiled graph. Raises CompileError with a clear message."""
+    schema = _load(_GRAPH_SCHEMA_PATH)
+    try:
+        jsonschema.validate(graph, schema)
+    except jsonschema.exceptions.ValidationError as exc:
+        raise CompileError(f"schema validation failed: {exc.message}")
+
+    node_ids = [n["node_id"] for n in graph["nodes"]]
+    id_set = set(node_ids)
+    if len(id_set) != len(node_ids):
+        dupes = sorted({x for x in node_ids if node_ids.count(x) > 1})
+        raise CompileError(f"duplicate node_id(s): {', '.join(dupes)}")
+
+    for edge in graph["edges"]:
+        for end in ("from", "to"):
+            if edge[end] not in id_set:
+                raise CompileError(
+                    f"dangling edge {edge['from']} -{edge['type']}-> {edge['to']}: "
+                    f"references unknown node {edge[end]!r}"
+                )
+
+    cycle = _find_cycle(node_ids, graph["edges"])
+    if cycle:
+        raise CompileError("dependency cycle detected: " + " -> ".join(cycle))
+
+    return True
+
+
+def compile_epic(epic, validate=True):
+    """Compile an epic input dict into an execution-graph dict."""
+    input_schema = _load(_INPUT_SCHEMA_PATH)
+    try:
+        jsonschema.validate(epic, input_schema)
+    except jsonschema.exceptions.ValidationError as exc:
+        raise CompileError(f"epic input invalid: {exc.message}")
+
+    graph = {
+        "version": GRAPH_VERSION,
+        "graph_id": epic["graph_id"],
+        "nodes": extract_nodes(epic),
+        "edges": infer_edges(epic),
+    }
+    for passthrough in ("review_stages", "merge_stages", "metadata"):
+        if passthrough in epic:
+            graph[passthrough] = epic[passthrough]
+
+    if validate:
+        validate_graph(graph)
+    return graph
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Epic-to-DAG compiler (dry-run, #533)")
+    parser.add_argument("--epic", required=True, help="path to an epic input JSON file")
+    parser.add_argument("--out", help="write the graph JSON here (default: stdout — dry-run)")
+    args = parser.parse_args(argv)
+
+    try:
+        epic = _load(args.epic)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 2
+
+    try:
+        graph = compile_epic(epic)
+    except CompileError as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 1
+
+    text = json.dumps(graph, indent=2)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(text + "\n")
+        print(f"wrote {args.out} ({len(graph['nodes'])} nodes, {len(graph['edges'])} edges)")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_epic_to_dag_compiler.py
+++ b/scripts/test_epic_to_dag_compiler.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Regression guard for the Epic-to-DAG compiler (#533).
+
+Runs under `python -m unittest discover -s scripts` (no pytest). Covers the
+acceptance criteria: dry-run compile, machine-readable output, invalid graphs
+rejected with clear errors, and tests over simple / parallel / blocked graphs.
+The Sprint-0 input is asserted to reproduce the hand-authored reference graph
+from #531 (same nodes + edge set + stages).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+from epic_to_dag_compiler import CompileError, compile_epic, validate_graph
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SPRINT0_INPUT = REPO_ROOT / "examples" / "execution-graph-sprint-0-input.json"
+SPRINT0_REFERENCE = REPO_ROOT / "examples" / "execution-graph-sprint-0.json"
+
+
+def _wp(id_, type_="code", repo="demerzel", desc="work", **kinds):
+    node = {"id": id_, "type": type_, "repo": repo, "description": desc}
+    node.update(kinds)
+    return node
+
+
+def _epic(work_packages, graph_id="test-graph", **extra):
+    epic = {"graph_id": graph_id, "work_packages": work_packages}
+    epic.update(extra)
+    return epic
+
+
+def _edge_set(graph):
+    return {(e["from"], e["to"], e["type"]) for e in graph["edges"]}
+
+
+class SimpleGraphTests(unittest.TestCase):
+    def test_simple_linear_chain(self):
+        epic = _epic([
+            _wp("#1", depends_on=["#2"]),
+            _wp("#2", depends_on=["#3"]),
+            _wp("#3"),
+        ])
+        graph = compile_epic(epic)
+        self.assertEqual(graph["version"], "1.0.0")
+        self.assertEqual(len(graph["nodes"]), 3)
+        self.assertEqual(_edge_set(graph), {("#1", "#2", "depends_on"), ("#2", "#3", "depends_on")})
+
+    def test_output_is_machine_readable_json(self):
+        graph = compile_epic(_epic([_wp("#1")]))
+        # round-trips as JSON without loss
+        self.assertEqual(json.loads(json.dumps(graph))["graph_id"], "test-graph")
+
+
+class ParallelGraphTests(unittest.TestCase):
+    def test_fanout_parallel_branches(self):
+        # one root blocks two independent children
+        epic = _epic([
+            _wp("#root", blocks=["#a", "#b"]),
+            _wp("#a"),
+            _wp("#b"),
+        ])
+        graph = compile_epic(epic)
+        self.assertEqual(_edge_set(graph),
+                         {("#root", "#a", "blocks"), ("#root", "#b", "blocks")})
+        # both branches are valid (acyclic, no dangling)
+        self.assertTrue(validate_graph(graph))
+
+
+class BlockedGraphTests(unittest.TestCase):
+    def test_blocks_edge_and_blocked_status(self):
+        epic = _epic([
+            _wp("#up", blocks=["#down"]),
+            _wp("#down", status="blocked"),
+        ])
+        graph = compile_epic(epic)
+        self.assertIn(("#up", "#down", "blocks"), _edge_set(graph))
+        down = next(n for n in graph["nodes"] if n["node_id"] == "#down")
+        self.assertEqual(down["status"], "blocked")
+
+
+class RejectionTests(unittest.TestCase):
+    def test_cycle_is_rejected(self):
+        epic = _epic([
+            _wp("#1", depends_on=["#2"]),
+            _wp("#2", depends_on=["#1"]),
+        ])
+        with self.assertRaises(CompileError) as ctx:
+            compile_epic(epic)
+        self.assertIn("cycle", str(ctx.exception).lower())
+
+    def test_dangling_edge_is_rejected(self):
+        epic = _epic([_wp("#1", blocks=["#999"])])
+        with self.assertRaises(CompileError) as ctx:
+            compile_epic(epic)
+        self.assertIn("dangling", str(ctx.exception).lower())
+
+    def test_duplicate_node_id_is_rejected(self):
+        epic = _epic([_wp("#1"), _wp("#1", desc="dup")])
+        with self.assertRaises(CompileError) as ctx:
+            compile_epic(epic)
+        self.assertIn("duplicate", str(ctx.exception).lower())
+
+    def test_invalid_type_is_rejected(self):
+        epic = _epic([_wp("#1", type_="banana")])
+        with self.assertRaises(CompileError) as ctx:
+            compile_epic(epic)
+        self.assertIn("invalid", str(ctx.exception).lower())
+
+    def test_missing_graph_id_is_rejected(self):
+        with self.assertRaises(CompileError):
+            compile_epic({"work_packages": [_wp("#1")]})
+
+
+class Sprint0Tests(unittest.TestCase):
+    def test_sprint0_reproduces_reference(self):
+        with open(SPRINT0_INPUT, "r", encoding="utf-8") as f:
+            epic = json.load(f)
+        with open(SPRINT0_REFERENCE, "r", encoding="utf-8") as f:
+            reference = json.load(f)
+
+        graph = compile_epic(epic)
+
+        self.assertEqual(graph["version"], reference["version"])
+        self.assertEqual(graph["graph_id"], reference["graph_id"])
+        self.assertEqual(graph["nodes"], reference["nodes"])
+        # edges compared as a set — a graph's edge order is not significant
+        self.assertEqual(_edge_set(graph), _edge_set(reference))
+        self.assertEqual(graph["review_stages"], reference["review_stages"])
+        self.assertEqual(graph["merge_stages"], reference["merge_stages"])
+        self.assertEqual(graph["metadata"], reference["metadata"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #533 (parent #529, depends on #531 ✅). A dry-run compiler that turns structured epic/story metadata into a Planner execution graph.

## Pipeline
`epic input` → **extract** work packages into `WorkNode`s → **infer** `DependencyEdge`s from each package's per-kind fields (`blocks` / `depends_on` / `reviews` / `should_merge_after`) → **validate** → emit JSON.

## Validation (invalid graphs rejected with clear errors, exit 1)
1. **schema-valid** against `docs/contracts/execution-graph.schema.json` (#531);
2. **no dangling edges** — every `from`/`to` references a real node;
3. **acyclic** — DFS cycle detection that reports the cycle path (an execution graph is a DAG). Also rejects duplicate node ids.

Dry-run: prints JSON to stdout (or `--out <file>`); never mutates GitHub or repo state.

## Files
- **`scripts/epic_to_dag_compiler.py`** — the compiler (stdlib + `jsonschema`).
- **`docs/contracts/epic-input.schema.json`** — the epic input model (deliverable 1), co-located with the graph contract.
- **`examples/execution-graph-sprint-0-input.json`** — Sprint-0 epic input.
- **`scripts/test_epic_to_dag_compiler.py`** — the guard.

## Acceptance criteria → evidence
| Criterion | Evidence |
|---|---|
| Runs in dry-run mode | stdout by default, no writes without `--out` |
| Output is machine-readable JSON | `execution-graph.schema.json`-valid dict |
| Invalid graphs rejected with clear errors | cycle / dangling / duplicate / invalid-type tests; e.g. `dependency cycle detected: #1 -> #2 -> #1` |
| Tests cover simple, parallel, blocked | dedicated test classes + rejection cases |
| Sample output for Sprint 0 | **Sprint-0 input compiles to the hand-authored reference** (`execution-graph-sprint-0.json`) — same nodes + edge set + stages |

## Verification
- `python -m unittest discover -s scripts -p 'test_*.py'` → **209 passed** (10 new).
- `python scripts/build_manifest.py` → **green** (no drift).
- CLI: Sprint-0 → 6 nodes / 5 edges; cycle input → `exit 1` + clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)