### PR TITLE
feat(mission-control): read-only progress snapshot generator — S0 (#742)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Demerzel/
 | Personas | 17 | `personas/*.persona.yaml` |
 | Policies | 46 | `policies/*.yaml` |
 | Grammars | 20 | `grammars/*.ebnf` |
-| Schemas | 46 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
+| Schemas | 47 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
 | Behavioral tests | 115 | `tests/behavioral/*.md` |
 | Skills | 69 | `.claude/skills/*/` |
 | Streeling departments | 23 | `state/streeling/departments/*.department.json` |

--- a/docs/status/mission-control.json
+++ b/docs/status/mission-control.json
@@ -1,39 +1,29 @@
 {
-  "generated_at": "2026-06-30T02:45:00Z",
-  "mode": "DRAINING",
-  "summary": {
-    "open_prs": 19,
-    "draft_prs": 12,
-    "mergeable_true": 7,
-    "mergeable_false": 0
-  },
-  "queue": [
-    {
-      "number": 567,
-      "title": "Define Execution Graph Schema v1",
-      "draft": false,
-      "mergeable": true,
-      "next_action": "Review with explicit human approval."
-    },
-    {
-      "number": 572,
-      "title": "Add fan-out/fan-in controller for AFK agent work",
-      "draft": true,
-      "mergeable": true,
-      "next_action": "Drain after PR 567."
-    },
-    {
-      "number": 583,
-      "title": "Add adaptive fan-out backpressure policy",
-      "draft": true,
-      "mergeable": true,
-      "next_action": "Drain after PR 572."
+  "snapshot_id": "sprint-0-snapshot",
+  "observed_at": "2026-07-18T00:00:00Z",
+  "roadmap": "Autonomous Software Organization",
+  "milestone": "M1 Foundations",
+  "sprint": "Sprint 0",
+  "total_nodes": 10,
+  "completed_nodes": 5,
+  "blocked_nodes": 1,
+  "executable_nodes": 3,
+  "percent_complete": 50.0,
+  "dashboard": {
+    "open_prs": 2,
+    "merged_prs": 2,
+    "draft_prs": 1,
+    "review_queue": 1,
+    "issues_by_status": {
+      "done": 5,
+      "executable": 3,
+      "blocked": 1,
+      "planned": 1
     }
-  ],
-  "next_safe_actions": [
-    "Review PR 567.",
-    "Then drain PR 572.",
-    "Then drain PR 583.",
-    "Keep new fan-out on hold."
-  ]
+  },
+  "critical_path": [],
+  "eta": null,
+  "eta_confidence": 0.0,
+  "risks": [],
+  "recommendations": []
 }

--- a/fixtures/mission-control/sprint-0.json
+++ b/fixtures/mission-control/sprint-0.json
@@ -1,0 +1,25 @@
+{
+  "snapshot_id": "sprint-0-snapshot",
+  "observed_at": "2026-07-18T00:00:00Z",
+  "roadmap": "Autonomous Software Organization",
+  "milestone": "M1 Foundations",
+  "sprint": "Sprint 0",
+  "issues": [
+    { "number": 515, "title": "Bootstrap Sprint: contracts, IDs, schemas, registries", "state": "closed", "labels": ["component:demerzel", "priority:P0"] },
+    { "number": 531, "title": "Define Execution Graph Schema v1", "state": "closed", "labels": ["area:planner", "priority:P0"] },
+    { "number": 533, "title": "Build Epic-to-DAG Compiler prototype", "state": "closed", "labels": ["area:planner", "worker:claude"] },
+    { "number": 545, "title": "Bootstrap EngineeringEvent JSONL store", "state": "closed", "labels": ["component:streeling", "critical-path"] },
+    { "number": 584, "title": "Unblock non-Jules AI worker lanes", "state": "closed", "labels": ["component:demerzel", "area:planner"] },
+    { "number": 517, "title": "Core IDs and engineering ontology v1", "state": "open", "labels": ["component:streeling", "ready-for-agent"] },
+    { "number": 519, "title": "Streeling event foundations", "state": "open", "labels": ["component:streeling", "ready-for-agent"] },
+    { "number": 543, "title": "Read-only GitHub App permission model and webhook receiver", "state": "open", "labels": ["component:streeling", "blocked"] },
+    { "number": 547, "title": "Mission Control / Progress Engine", "state": "open", "labels": ["area:mission-control", "ready-for-human"] },
+    { "number": 588, "title": "Add Demerzel policy engine and lifecycle state machines", "state": "open", "labels": ["component:demerzel", "area:planner"] }
+  ],
+  "pull_requests": [
+    { "number": 740, "title": "Streeling append-only EngineeringEvent store", "state": "merged", "draft": false },
+    { "number": 741, "title": "Epic-to-DAG compiler prototype", "state": "merged", "draft": false },
+    { "number": 742, "title": "Mission Control progress snapshot generator", "state": "open", "draft": false },
+    { "number": 733, "title": "WIP: capability routing draft", "state": "open", "draft": true }
+  ]
+}

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -10,7 +10,7 @@
     "persona": 17,
     "pipeline": 23,
     "policy": 46,
-    "schema": 46,
+    "schema": 47,
     "seldon_schema": 7,
     "skill": 69,
     "streeling_schema": 1,
@@ -490,6 +490,10 @@
       {
         "name": "pre-mortem.schema",
         "path": "schemas/pre-mortem.schema.json"
+      },
+      {
+        "name": "progress-snapshot.schema",
+        "path": "schemas/progress-snapshot.schema.json"
       },
       {
         "name": "reconnaissance-profile.schema",

--- a/schemas/progress-snapshot.schema.json
+++ b/schemas/progress-snapshot.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GuitarAlchemist/Demerzel/schemas/progress-snapshot",
+  "title": "Progress Snapshot",
+  "description": "A read-only Mission Control progress snapshot (Epic #547, slice S0 #742). Computed from GitHub issues/labels/PRs by scripts/mission_control_snapshot.py. Fields for later slices (critical_path/eta — S3; risks/recommendations — S4) are present but empty in S0 so those slices extend without a schema change.",
+  "type": "object",
+  "required": [
+    "snapshot_id",
+    "observed_at",
+    "total_nodes",
+    "completed_nodes",
+    "blocked_nodes",
+    "executable_nodes",
+    "percent_complete"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "snapshot_id": { "type": "string" },
+    "observed_at": { "type": "string", "format": "date-time" },
+    "roadmap": { "type": "string" },
+    "milestone": { "type": ["string", "null"] },
+    "sprint": { "type": ["string", "null"] },
+    "total_nodes": { "type": "integer", "minimum": 0 },
+    "completed_nodes": { "type": "integer", "minimum": 0 },
+    "blocked_nodes": { "type": "integer", "minimum": 0 },
+    "executable_nodes": { "type": "integer", "minimum": 0 },
+    "percent_complete": { "type": "number", "minimum": 0, "maximum": 100 },
+    "dashboard": {
+      "type": "object",
+      "description": "Level 1 execution dashboard (#547).",
+      "additionalProperties": true,
+      "properties": {
+        "open_prs": { "type": "integer", "minimum": 0 },
+        "merged_prs": { "type": "integer", "minimum": 0 },
+        "draft_prs": { "type": "integer", "minimum": 0 },
+        "review_queue": { "type": "integer", "minimum": 0 },
+        "issues_by_status": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "critical_path": { "type": "array", "items": { "type": "string" }, "description": "Populated by S3 (#746)." },
+    "eta": { "type": ["string", "null"], "description": "Populated by S3 (#746)." },
+    "eta_confidence": { "type": "number", "minimum": 0, "maximum": 1, "description": "Populated by S3 (#746)." },
+    "risks": { "type": "array", "description": "Populated by S4 (#749)." },
+    "recommendations": { "type": "array", "description": "Populated by S4 (#749)." },
+    "metadata": { "type": "object", "additionalProperties": true }
+  }
+}

--- a/scripts/mission_control_snapshot.py
+++ b/scripts/mission_control_snapshot.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Mission Control progress snapshot generator (Epic #547, slice S0 #742).
+
+Read-only tracer-bullet: reads a GitHub issues/PRs snapshot (an offline fixture,
+so CI is deterministic and never calls live GitHub) and computes a
+`progress_snapshot` conforming to schemas/progress-snapshot.schema.json — the
+counts (#547 Progress Engine) plus a Level 1 execution dashboard. Emits
+machine-readable JSON and an optional Markdown summary.
+
+MVP is read-only / dry-run: it never mutates issues or PRs. Fields owned by later
+slices (critical_path/eta — S3 #746; risks/recommendations — S4 #749) are emitted
+empty so those slices extend the snapshot without a schema change.
+
+Stdlib + `jsonschema` only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schemas" / "progress-snapshot.schema.json"
+
+_READY_LABELS = ("ready-for-agent", "ready-for-human")
+
+
+def classify_issue(issue):
+    """Map a GitHub issue to an execution-node status.
+
+    done (closed) / blocked (a 'blocked' label) / executable (ready + open) /
+    planned (open, not yet ready). Blocked takes precedence over ready.
+    """
+    state = str(issue.get("state", "open")).lower()
+    labels = [str(label).lower() for label in issue.get("labels", [])]
+    if state == "closed":
+        return "done"
+    if any("blocked" in label for label in labels):
+        return "blocked"
+    if any(label in _READY_LABELS for label in labels):
+        return "executable"
+    return "planned"
+
+
+def _dashboard(issues_by_status, pull_requests):
+    open_prs = [p for p in pull_requests if str(p.get("state", "open")).lower() == "open"]
+    return {
+        "open_prs": len(open_prs),
+        "merged_prs": sum(1 for p in pull_requests if str(p.get("state", "")).lower() == "merged"),
+        "draft_prs": sum(1 for p in open_prs if p.get("draft")),
+        "review_queue": sum(1 for p in open_prs if not p.get("draft")),
+        "issues_by_status": issues_by_status,
+    }
+
+
+def build_snapshot(data):
+    """Compute a progress snapshot dict from an issues/PRs fixture."""
+    issues = data.get("issues", [])
+    statuses = [classify_issue(issue) for issue in issues]
+
+    by_status = {}
+    for status in statuses:
+        by_status[status] = by_status.get(status, 0) + 1
+
+    total = len(issues)
+    completed = by_status.get("done", 0)
+    blocked = by_status.get("blocked", 0)
+    executable = by_status.get("executable", 0)
+    percent = round(100.0 * completed / total, 1) if total else 0.0
+
+    snapshot = {
+        "snapshot_id": data.get("snapshot_id", "progress-snapshot"),
+        "observed_at": data["observed_at"],
+        "roadmap": data.get("roadmap", ""),
+        "milestone": data.get("milestone"),
+        "sprint": data.get("sprint"),
+        "total_nodes": total,
+        "completed_nodes": completed,
+        "blocked_nodes": blocked,
+        "executable_nodes": executable,
+        "percent_complete": percent,
+        "dashboard": _dashboard(by_status, data.get("pull_requests", [])),
+        # Owned by later slices — emitted empty in S0.
+        "critical_path": [],
+        "eta": None,
+        "eta_confidence": 0.0,
+        "risks": [],
+        "recommendations": [],
+    }
+    validate_snapshot(snapshot)
+    return snapshot
+
+
+def validate_snapshot(snapshot):
+    with open(_SCHEMA_PATH, "r", encoding="utf-8") as f:
+        schema = json.load(f)
+    jsonschema.validate(snapshot, schema)
+    return True
+
+
+def render_markdown(snapshot):
+    """Render a human-readable Markdown summary of a snapshot."""
+    d = snapshot.get("dashboard", {})
+    by_status = d.get("issues_by_status", {})
+    lines = [
+        f"# Mission Control — {snapshot.get('sprint') or snapshot.get('roadmap', 'Progress')}",
+        "",
+        f"_Snapshot `{snapshot['snapshot_id']}` observed at {snapshot['observed_at']} (read-only)_",
+        "",
+        f"**{snapshot['percent_complete']}% complete** "
+        f"— {snapshot['completed_nodes']}/{snapshot['total_nodes']} done, "
+        f"{snapshot['blocked_nodes']} blocked, {snapshot['executable_nodes']} executable",
+        "",
+        "| Metric | Value |",
+        "|---|---|",
+        f"| Milestone | {snapshot.get('milestone') or '—'} |",
+        f"| Total nodes | {snapshot['total_nodes']} |",
+        f"| Done | {by_status.get('done', 0)} |",
+        f"| Blocked | {by_status.get('blocked', 0)} |",
+        f"| Executable | {by_status.get('executable', 0)} |",
+        f"| Planned | {by_status.get('planned', 0)} |",
+        f"| Open PRs | {d.get('open_prs', 0)} (review queue {d.get('review_queue', 0)}, draft {d.get('draft_prs', 0)}) |",
+        f"| Merged PRs | {d.get('merged_prs', 0)} |",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Mission Control progress snapshot (read-only, #742)")
+    parser.add_argument("--input", required=True, help="path to an issues/PRs snapshot fixture JSON")
+    parser.add_argument("--out", help="write the snapshot JSON here (default: stdout)")
+    parser.add_argument("--markdown", help="also write a Markdown summary here")
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.input, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        snapshot = build_snapshot(data)
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 2
+
+    text = json.dumps(snapshot, indent=2)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(text + "\n")
+        print(f"wrote {args.out} ({snapshot['percent_complete']}% complete)")
+    else:
+        print(text)
+
+    if args.markdown:
+        with open(args.markdown, "w", encoding="utf-8") as f:
+            f.write(render_markdown(snapshot))
+        print(f"wrote {args.markdown}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_mission_control_snapshot.py
+++ b/scripts/test_mission_control_snapshot.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Regression guard for the Mission Control snapshot generator (S0 #742).
+
+Runs under `python -m unittest discover -s scripts` (no pytest). Covers status
+classification, deterministic counts, schema conformance, Markdown rendering, and
+that the committed docs/status/mission-control.json is the generator's output for
+the committed fixture (so it cannot silently drift back to a hand-authored file).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+from mission_control_snapshot import build_snapshot, classify_issue, render_markdown, validate_snapshot
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = REPO_ROOT / "fixtures" / "mission-control" / "sprint-0.json"
+GENERATED = REPO_ROOT / "docs" / "status" / "mission-control.json"
+
+
+def _load(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_closed_is_done(self):
+        self.assertEqual(classify_issue({"state": "closed"}), "done")
+
+    def test_blocked_label_beats_ready(self):
+        self.assertEqual(
+            classify_issue({"state": "open", "labels": ["ready-for-agent", "blocked"]}),
+            "blocked",
+        )
+
+    def test_ready_is_executable(self):
+        self.assertEqual(classify_issue({"state": "open", "labels": ["ready-for-human"]}), "executable")
+
+    def test_open_default_is_planned(self):
+        self.assertEqual(classify_issue({"state": "open", "labels": ["component:demerzel"]}), "planned")
+
+
+class SnapshotTests(unittest.TestCase):
+    def setUp(self):
+        self.data = _load(FIXTURE)
+        self.snapshot = build_snapshot(self.data)
+
+    def test_counts_are_deterministic(self):
+        s = self.snapshot
+        self.assertEqual(s["total_nodes"], 10)
+        self.assertEqual(s["completed_nodes"], 5)
+        self.assertEqual(s["blocked_nodes"], 1)
+        self.assertEqual(s["executable_nodes"], 3)
+        self.assertEqual(s["percent_complete"], 50.0)
+
+    def test_counts_partition_total(self):
+        by_status = self.snapshot["dashboard"]["issues_by_status"]
+        self.assertEqual(sum(by_status.values()), self.snapshot["total_nodes"])
+
+    def test_dashboard_pr_metrics(self):
+        d = self.snapshot["dashboard"]
+        self.assertEqual(d["open_prs"], 2)
+        self.assertEqual(d["merged_prs"], 2)
+        self.assertEqual(d["draft_prs"], 1)
+        self.assertEqual(d["review_queue"], 1)
+
+    def test_snapshot_validates_against_schema(self):
+        self.assertTrue(validate_snapshot(self.snapshot))
+
+    def test_later_slice_fields_empty_in_s0(self):
+        self.assertEqual(self.snapshot["critical_path"], [])
+        self.assertIsNone(self.snapshot["eta"])
+        self.assertEqual(self.snapshot["risks"], [])
+        self.assertEqual(self.snapshot["recommendations"], [])
+
+    def test_empty_input_gives_zero_percent(self):
+        snap = build_snapshot({"observed_at": "2026-07-18T00:00:00Z", "issues": [], "pull_requests": []})
+        self.assertEqual(snap["total_nodes"], 0)
+        self.assertEqual(snap["percent_complete"], 0.0)
+
+    def test_markdown_renders_key_numbers(self):
+        md = render_markdown(self.snapshot)
+        self.assertIn("50.0% complete", md)
+        self.assertIn("| Merged PRs | 2 |", md)
+
+
+class GeneratedFileTests(unittest.TestCase):
+    def test_committed_mission_control_matches_generator(self):
+        # The committed status file must BE the generator's output for the fixture,
+        # not a hand-authored artifact (the LOLLI failure mode S0 exists to kill).
+        self.assertTrue(GENERATED.exists(), "docs/status/mission-control.json missing")
+        expected = build_snapshot(_load(FIXTURE))
+        self.assertEqual(_load(GENERATED), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #742 (S0 of the #547 Mission Control decomposition). The tracer-bullet slice: the smallest end-to-end thing that replaces the **stale, producer-less** `docs/status/mission-control.json` with a generated snapshot.

## What it does (cuts through every layer)
GitHub issues/PRs (offline fixture) → **classify** issues (`done`/`blocked`/`executable`/`planned`) → **compute** a `progress_snapshot` (counts, `percent_complete`) + a Level 1 execution dashboard (open/merged/draft PRs, review queue) → **emit** JSON **+ optional Markdown**.

## Files
- **`schemas/progress-snapshot.schema.json`** — the `progress_snapshot` shape from #547. Later-slice fields (`critical_path`/`eta` → S3 #746; `risks`/`recommendations` → S4 #749) are present but empty, so those slices extend without a schema change.
- **`scripts/mission_control_snapshot.py`** — read-only generator (stdlib + `jsonschema`). Fixture-driven — **never calls live GitHub, never mutates state**.
- **`fixtures/mission-control/sprint-0.json`** — offline Sprint-0 issues/PRs.
- **`docs/status/mission-control.json`** — now **generated** from the fixture (was stale/hand-authored → now has a producer).
- **`scripts/test_mission_control_snapshot.py`** — the guard.

## The stale-file fix
The old status file was `generated_at` 2026-06-30 and referenced PRs 567/572/583 (long gone) with no producer — a classic LOLLI/silent-loop artifact. A test now asserts the committed file **equals the generator's output** for the fixture, so it can't drift back to hand-authored.

## Reconciliation
Reuses #531's execution-graph concept — `execution_node` overlaps `WorkNode`, so no second graph schema is defined.

## Sample output
`50.0% complete — 5/10 done, 1 blocked, 3 executable`; 2 open PRs (review queue 1), 2 merged.

## Verification
- `python -m unittest discover -s scripts -p 'test_*.py'` → **221 passed** (12 new).
- `python scripts/build_manifest.py` → **green** (README schema count bumped 46→47).
- MVP read-only / dry-run per #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)