### PR TITLE
feat(mission-control): agent telemetry metrics — S2 (#745)

### DIFF
--- a/docs/status/mission-control.json
+++ b/docs/status/mission-control.json
@@ -103,6 +103,127 @@
       "percent_complete": 0.0
     }
   ],
+  "agent_telemetry": [
+    {
+      "worker": "claude",
+      "prs_opened": 1,
+      "prs_merged": 0,
+      "reviews": 0,
+      "comments": 0,
+      "workflow_runs": 0,
+      "workflow_successes": 0,
+      "ci_success_rate": null,
+      "unmeasured": [
+        "average_latency",
+        "accepted_findings",
+        "false_positives",
+        "human_rescue_rate",
+        "cost"
+      ]
+    },
+    {
+      "worker": "jules",
+      "prs_opened": 0,
+      "prs_merged": 0,
+      "reviews": 0,
+      "comments": 1,
+      "workflow_runs": 0,
+      "workflow_successes": 0,
+      "ci_success_rate": null,
+      "unmeasured": [
+        "average_latency",
+        "accepted_findings",
+        "false_positives",
+        "human_rescue_rate",
+        "cost"
+      ]
+    },
+    {
+      "worker": "gemini",
+      "prs_opened": 0,
+      "prs_merged": 0,
+      "reviews": 1,
+      "comments": 0,
+      "workflow_runs": 0,
+      "workflow_successes": 0,
+      "ci_success_rate": null,
+      "unmeasured": [
+        "average_latency",
+        "accepted_findings",
+        "false_positives",
+        "human_rescue_rate",
+        "cost"
+      ]
+    },
+    {
+      "worker": "codex",
+      "prs_opened": 0,
+      "prs_merged": 0,
+      "reviews": 0,
+      "comments": 0,
+      "workflow_runs": 0,
+      "workflow_successes": 0,
+      "ci_success_rate": null,
+      "unmeasured": [
+        "average_latency",
+        "accepted_findings",
+        "false_positives",
+        "human_rescue_rate",
+        "cost"
+      ]
+    },
+    {
+      "worker": "augment",
+      "prs_opened": 0,
+      "prs_merged": 0,
+      "reviews": 0,
+      "comments": 0,
+      "workflow_runs": 0,
+      "workflow_successes": 0,
+      "ci_success_rate": null,
+      "unmeasured": [
+        "average_latency",
+        "accepted_findings",
+        "false_positives",
+        "human_rescue_rate",
+        "cost"
+      ]
+    },
+    {
+      "worker": "github-actions",
+      "prs_opened": 0,
+      "prs_merged": 0,
+      "reviews": 0,
+      "comments": 0,
+      "workflow_runs": 1,
+      "workflow_successes": 1,
+      "ci_success_rate": 1.0,
+      "unmeasured": [
+        "average_latency",
+        "accepted_findings",
+        "false_positives",
+        "human_rescue_rate",
+        "cost"
+      ]
+    },
+    {
+      "worker": "human",
+      "prs_opened": 0,
+      "prs_merged": 0,
+      "reviews": 0,
+      "comments": 0,
+      "workflow_runs": 0,
+      "workflow_successes": 0,
+      "ci_success_rate": null,
+      "unmeasured": [
+        "average_latency",
+        "accepted_findings",
+        "false_positives",
+        "human_rescue_rate",
+        "cost"
+      ]
+    }
+  ],
   "critical_path": [],
   "eta": null,
   "eta_confidence": 0.0,

--- a/schemas/progress-snapshot.schema.json
+++ b/schemas/progress-snapshot.schema.json
@@ -57,6 +57,26 @@
         }
       }
     },
+    "agent_telemetry": {
+      "type": "array",
+      "description": "Per-worker visible activity (#547 Level 3 / S2 #745), derived from the Streeling event store (#545). Metrics not derivable from visible activity are null / listed in `unmeasured` — never guessed.",
+      "items": {
+        "type": "object",
+        "required": ["worker", "prs_opened", "prs_merged", "reviews", "comments", "workflow_runs", "workflow_successes", "ci_success_rate", "unmeasured"],
+        "additionalProperties": false,
+        "properties": {
+          "worker": { "type": "string" },
+          "prs_opened": { "type": "integer", "minimum": 0 },
+          "prs_merged": { "type": "integer", "minimum": 0 },
+          "reviews": { "type": "integer", "minimum": 0 },
+          "comments": { "type": "integer", "minimum": 0 },
+          "workflow_runs": { "type": "integer", "minimum": 0 },
+          "workflow_successes": { "type": "integer", "minimum": 0 },
+          "ci_success_rate": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+          "unmeasured": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
     "critical_path": { "type": "array", "items": { "type": "string" }, "description": "Populated by S3 (#746)." },
     "eta": { "type": ["string", "null"], "description": "Populated by S3 (#746)." },
     "eta_confidence": { "type": "number", "minimum": 0, "maximum": 1, "description": "Populated by S3 (#746)." },

--- a/scripts/mission_control_snapshot.py
+++ b/scripts/mission_control_snapshot.py
@@ -23,11 +23,22 @@ from pathlib import Path
 
 import jsonschema
 
+from streeling_event_store import EventStore
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SCHEMA_PATH = _REPO_ROOT / "schemas" / "progress-snapshot.schema.json"
 _CAPABILITY_MAP_PATH = _REPO_ROOT / "state" / "driver" / "mission-control-capability-map.json"
+# The Streeling event store (#545) is the telemetry source. In MVP this is the
+# committed sample; in production it is the live append-only log.
+_EVENTS_PATH = _REPO_ROOT / "fixtures" / "streeling" / "engineering-events-sample.jsonl"
 
 _READY_LABELS = ("ready-for-agent", "ready-for-human")
+
+# Workers reported in telemetry (schema worker enum minus "unknown"), fixed order.
+_TELEMETRY_WORKERS = ("claude", "jules", "gemini", "codex", "augment", "github-actions", "human")
+# Level 3 metrics that are NOT derivable from visible GitHub/Streeling activity
+# today — reported as unmeasured rather than guessed (#745 non-goal).
+_UNMEASURED = ("average_latency", "accepted_findings", "false_positives", "human_rescue_rate", "cost")
 
 
 def classify_issue(issue):
@@ -87,6 +98,47 @@ def capability_progress(issues, capability_map):
     return rows
 
 
+def load_events(path=None):
+    """Read engineering events through the #545 Streeling store reader. Empty if
+    the log does not exist."""
+    return list(EventStore(Path(path) if path else _EVENTS_PATH).read_all())
+
+
+def agent_telemetry(events):
+    """Per-worker visible activity from the Streeling event stream. Reports every
+    known worker (0s if idle); unmeasurable Level 3 metrics are null/unmeasured,
+    never guessed."""
+    rows = []
+    for worker in _TELEMETRY_WORKERS:
+        mine = [e for e in events if e.get("worker") == worker]
+
+        def _action(evt):
+            return (evt.get("metadata") or {}).get("action")
+
+        prs_opened = sum(1 for e in mine if e.get("event_type") == "pr" and _action(e) == "opened")
+        prs_merged = sum(1 for e in mine if e.get("event_type") == "pr" and _action(e) == "merged")
+        reviews = sum(1 for e in mine if e.get("event_type") == "review")
+        comments = sum(1 for e in mine if e.get("event_type") == "comment")
+        workflow_runs = sum(1 for e in mine if e.get("event_type") == "workflow")
+        workflow_successes = sum(
+            1 for e in mine if e.get("event_type") == "workflow" and e.get("severity") == "success"
+        )
+        ci_rate = round(workflow_successes / workflow_runs, 2) if workflow_runs else None
+
+        rows.append({
+            "worker": worker,
+            "prs_opened": prs_opened,
+            "prs_merged": prs_merged,
+            "reviews": reviews,
+            "comments": comments,
+            "workflow_runs": workflow_runs,
+            "workflow_successes": workflow_successes,
+            "ci_success_rate": ci_rate,
+            "unmeasured": list(_UNMEASURED),
+        })
+    return rows
+
+
 def _dashboard(issues_by_status, pull_requests):
     open_prs = [p for p in pull_requests if str(p.get("state", "open")).lower() == "open"]
     return {
@@ -98,7 +150,7 @@ def _dashboard(issues_by_status, pull_requests):
     }
 
 
-def build_snapshot(data, capability_map=None):
+def build_snapshot(data, capability_map=None, events=None):
     """Compute a progress snapshot dict from an issues/PRs fixture."""
     issues = data.get("issues", [])
     statuses = [classify_issue(issue) for issue in issues]
@@ -111,6 +163,8 @@ def build_snapshot(data, capability_map=None):
 
     if capability_map is None:
         capability_map = load_capability_map()
+    if events is None:
+        events = load_events()
 
     snapshot = {
         "snapshot_id": data.get("snapshot_id", "progress-snapshot"),
@@ -125,6 +179,7 @@ def build_snapshot(data, capability_map=None):
         "percent_complete": percent,
         "dashboard": _dashboard(by_status, data.get("pull_requests", [])),
         "capabilities": capability_progress(issues, capability_map),
+        "agent_telemetry": agent_telemetry(events),
         # Owned by later slices — emitted empty in S0.
         "critical_path": [],
         "eta": None,
@@ -176,6 +231,20 @@ def render_markdown(snapshot):
                 f"| {cap['capability']} | {cap['percent_complete']}% | "
                 f"{cap['completed_nodes']}/{cap['total_nodes']} |"
             )
+
+    def _active_worker(t):
+        return t["prs_opened"] or t["prs_merged"] or t["reviews"] or t["comments"] or t["workflow_runs"]
+
+    telemetry = [t for t in snapshot.get("agent_telemetry", []) if _active_worker(t)]
+    if telemetry:
+        lines += ["", "## Agent telemetry", "",
+                  "| Worker | PRs opened | PRs merged | Reviews | CI success |", "|---|---|---|---|---|"]
+        for t in telemetry:
+            ci = "—" if t["ci_success_rate"] is None else f"{int(t['ci_success_rate'] * 100)}%"
+            lines.append(
+                f"| {t['worker']} | {t['prs_opened']} | {t['prs_merged']} | {t['reviews']} | {ci} |"
+            )
+        lines += ["", f"_Not yet measurable: {', '.join(_UNMEASURED)}._"]
 
     return "\n".join(lines) + "\n"
 

--- a/scripts/test_mission_control_snapshot.py
+++ b/scripts/test_mission_control_snapshot.py
@@ -14,10 +14,12 @@ from pathlib import Path
 import unittest
 
 from mission_control_snapshot import (
+    agent_telemetry,
     build_snapshot,
     capability_progress,
     classify_issue,
     load_capability_map,
+    load_events,
     render_markdown,
     validate_snapshot,
 )
@@ -135,6 +137,51 @@ class SprintZeroCapabilityTests(unittest.TestCase):
         self.assertEqual(rows["observability"]["total_nodes"], 5)
         self.assertEqual(rows["observability"]["completed_nodes"], 1)  # #545
         self.assertEqual(rows["governance"]["completed_nodes"], 1)     # #515 done, #588 planned
+
+
+class TelemetryTests(unittest.TestCase):
+    EVENTS = [
+        {"worker": "claude", "event_type": "pr", "metadata": {"action": "opened"}},
+        {"worker": "claude", "event_type": "pr", "metadata": {"action": "merged"}},
+        {"worker": "gemini", "event_type": "review"},
+        {"worker": "github-actions", "event_type": "workflow", "severity": "success"},
+        {"worker": "github-actions", "event_type": "workflow", "severity": "info"},
+    ]
+
+    def setUp(self):
+        self.rows = {r["worker"]: r for r in agent_telemetry(self.EVENTS)}
+
+    def test_pr_open_and_merge_counted(self):
+        self.assertEqual(self.rows["claude"]["prs_opened"], 1)
+        self.assertEqual(self.rows["claude"]["prs_merged"], 1)
+
+    def test_review_counted(self):
+        self.assertEqual(self.rows["gemini"]["reviews"], 1)
+
+    def test_ci_success_rate_computed(self):
+        self.assertEqual(self.rows["github-actions"]["workflow_runs"], 2)
+        self.assertEqual(self.rows["github-actions"]["ci_success_rate"], 0.5)
+
+    def test_ci_rate_null_without_runs(self):
+        # gemini has no workflow events -> rate is unknown, not 0.0
+        self.assertIsNone(self.rows["gemini"]["ci_success_rate"])
+
+    def test_unmeasured_metrics_listed_not_guessed(self):
+        self.assertIn("cost", self.rows["claude"]["unmeasured"])
+        self.assertIn("human_rescue_rate", self.rows["claude"]["unmeasured"])
+
+    def test_all_known_workers_reported(self):
+        self.assertEqual(len(self.rows), 7)
+        for worker in ("claude", "jules", "gemini", "codex", "augment", "github-actions", "human"):
+            self.assertIn(worker, self.rows)
+
+    def test_telemetry_reads_streeling_store(self):
+        # the default source is the committed Streeling sample (#545) — the wiring
+        events = load_events()
+        self.assertTrue(events, "telemetry should read the Streeling event store")
+        rows = {r["worker"]: r for r in agent_telemetry(events)}
+        self.assertEqual(rows["claude"]["prs_opened"], 1)
+        self.assertEqual(rows["github-actions"]["ci_success_rate"], 1.0)
 
 
 class GeneratedFileTests(unittest.TestCase):


### PR DESCRIPTION
Closes #745 (S2 of #547). Extends the snapshot with per-worker visible activity (#547 Level 3), derived from the **Streeling event store (#545)** — the wiring that finally gives that store a downstream consumer.

## Added / changed
- **`scripts/mission_control_snapshot.py`** — `agent_telemetry()` reads engineering events **through the #545 `EventStore` reader** and aggregates per worker: PRs opened/merged, reviews, comments, workflow runs, and **CI success rate**. Reports every known worker (0s if idle).
- **Honesty gate (#745 non-goal):** metrics not derivable from visible activity — `average_latency`, `accepted_findings`, `false_positives`, `human_rescue_rate`, `cost` — are reported as `unmeasured` / `null`, **never guessed**. `ci_success_rate` is `null` (not `0.0`) when a worker has no workflow runs.
- **`schemas/progress-snapshot.schema.json`** — adds the `agent_telemetry` array (extends S0/S1 schema).
- **Markdown** — agent-telemetry table + an explicit "not yet measurable" line.
- **`docs/status/mission-control.json`** — regenerated.

## Sprint-0 result
`claude` 1 PR opened · `gemini` 1 review · `github-actions` 100% CI success. Idle workers report zeros.

## Verification
- `python -m unittest discover -s scripts -p 'test_*.py'` → **234 passed** (7 new).
- `python scripts/build_manifest.py` → **green**.
- Read-only / dry-run per #547.

> **Note:** touches `schemas/**` + `docs/status/**`, so `risk-report` flags `policy.blocked_path` and needs the human-review override (admin merge / `agent-blackbox-reviewed`) — same as S0 #752 / S1 #753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)