### PR TITLE
fix(ci): guard capability-expansion scan against missing .tools in registry

### DIFF
--- a/.github/workflows/demerzel-capability-expansion.yml
+++ b/.github/workflows/demerzel-capability-expansion.yml
@@ -60,7 +60,7 @@ jobs:
           # ── MCP tools available ──
           MCP_REGISTRY=""
           if [ -f schemas/capability-registry.json ]; then
-            MCP_REGISTRY=$(jq -r '.tools[].name' schemas/capability-registry.json 2>/dev/null | tr '\n' ', ')
+            MCP_REGISTRY=$(jq -r '(.tools // [])[].name' schemas/capability-registry.json 2>/dev/null | tr '\n' ', ')
           fi
 
           # Save capability map


### PR DESCRIPTION
## Problem
The weekly **Demerzel Capability Expansion** scan has failed every run since at least 2026-06-21 (e.g. run #29270858003).

Root cause (from the failed-run logs): the **Inventory ecosystem capabilities** step dies with **exit code 5** — a `jq` error. `schemas/capability-registry.json` on `master` has **no `.tools` key**, so:

```
jq -r '.tools[].name' schemas/capability-registry.json   # jq: Cannot iterate over null (null) -> exit 5
```

Under the step's default `bash -e -o pipefail`, that aborts the whole step, and the analysis / issue / discussion steps skip.

## Fix
Make the lookup null-safe:

```diff
- MCP_REGISTRY=$(jq -r '.tools[].name' schemas/capability-registry.json 2>/dev/null | tr '\n' ', ')
+ MCP_REGISTRY=$(jq -r '(.tools // [])[].name' schemas/capability-registry.json 2>/dev/null | tr '\n' ', ')
```

`(.tools // [])` yields an empty array when the key is absent, so the registry string is simply empty (acceptable — it is informational context for the LLM prompt) instead of erroring.

## Verification
Reproduced against `master`'s `capability-registry.json`:
- **before:** `jq '.tools[].name'` → exit **5**
- **after:** `jq '(.tools // [])[].name'` → exit **0**, and the guarded step block completes cleanly under `bash -e -o pipefail`.

No provider/LLM call was made (the workflow was intentionally **not** dispatched, to avoid the metered Anthropic call). Definitive green proof is the next scheduled run (Mondays 15:37 UTC) or a manual `workflow_dispatch`.

## Scope
One line; does not touch PR #715 or any other loop. The `self-improvement` scanner is unrelated (it self-recovered on 2026-07-18 with no code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)