### PR TITLE
feat(ci): scheduled-run health guard (green != dead for scanners)

### DIFF
--- a/.github/workflows/demerzel-scheduled-run-health.yml
+++ b/.github/workflows/demerzel-scheduled-run-health.yml
@@ -1,0 +1,117 @@
+name: Demerzel Scheduled-Run Health
+
+# Green != dead guard for SCHEDULED workflows.
+#
+# A scanner that fails silently is indistinguishable from a healthy one until you
+# look — that is exactly how `demerzel-capability-expansion` stayed RED for ~a
+# month in 2026 unnoticed (every scheduled run failed at exit 5, nobody saw it).
+# The existing `demerzel-quality-trend-freshness` guard catches dead DATA feeders
+# by file staleness, but scanners that only emit issues/discussions produce no file
+# that goes stale, so nothing watched their run health.
+#
+# This runs INDEPENDENTLY of every loop: it inspects the latest SCHEDULED run
+# conclusion of every cron workflow and turns RED — opening/updating one tracking
+# issue (+ an optional Discord alert) — when any of them last failed. Silent on
+# green; never remediates.
+
+on:
+  schedule:
+    # Weekly, Monday 14:00 UTC — after the other Monday scanners have run.
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      SELF: demerzel-scheduled-run-health.yml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Inspect latest scheduled run of every cron workflow
+        id: scan
+        run: |
+          set -euo pipefail
+          : > /tmp/failed.txt
+          count=0
+          for wf in .github/workflows/*.yml; do
+            base=$(basename "$wf")
+            # Do not police ourselves — avoids a self-referential red loop.
+            [ "$base" = "$SELF" ] && continue
+            # A workflow is "scheduled" iff it declares a cron trigger.
+            grep -qE '^[[:space:]]*-?[[:space:]]*cron:' "$wf" || continue
+            count=$((count + 1))
+            run=$(gh run list --repo "$REPO" --workflow "$base" --event schedule \
+                    --limit 1 --json conclusion,url \
+                    --jq '.[0] | "\(.conclusion // "none")\t\(.url // "")"' 2>/dev/null \
+                  || printf 'error\t')
+            concl=${run%%$'\t'*}
+            url=${run#*$'\t'}
+            case "$concl" in
+              failure|timed_out|startup_failure)
+                printf -- '- `%s` — last scheduled run: **%s** (%s)\n' "$base" "$concl" "$url" >> /tmp/failed.txt
+                ;;
+            esac
+          done
+          echo "Checked $count scheduled workflow(s)."
+          if [ -s /tmp/failed.txt ]; then
+            echo "Red loops:"; cat /tmp/failed.txt
+            echo "HAS_FAILURES=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "All scheduled loops green."
+            echo "HAS_FAILURES=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update tracking issue
+        if: steps.scan.outputs.HAS_FAILURES == 'true'
+        run: |
+          set -euo pipefail
+          DATE=$(date -u +%Y-%m-%d)
+          FAILED=$(cat /tmp/failed.txt)
+          BODY=$(printf '## Scheduled-run health — %s\n\nThese scheduled workflows last **failed** on their schedule (green != dead):\n\n%s\n---\n*Demerzel Scheduled-Run Health guard. Silent on green; this issue exists because a loop is RED. It never remediates — a human decides the fix.*\n' "$DATE" "$FAILED")
+          # Ensure the label exists (idempotent), then upsert a single tracking issue.
+          gh label create loop-health --repo "$REPO" --color B60205 \
+            --description "A scheduled workflow's latest run failed" 2>/dev/null || true
+          NUM=$(gh issue list --repo "$REPO" --state open --label loop-health \
+                  --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --repo "$REPO" --body "$BODY"
+          else
+            gh issue create --repo "$REPO" \
+              --title "Scheduled loop(s) failing — $DATE" \
+              --body "$BODY" --label loop-health
+          fi
+
+      - name: Discord alert (dormant until DISCORD_WEBHOOK_URL secret is set)
+        if: steps.scan.outputs.HAS_FAILURES == 'true'
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+            echo "::notice::DISCORD_WEBHOOK_URL secret not set — skipping Discord alert."
+            exit 0
+          fi
+          FAILED=$(cat /tmp/failed.txt)
+          CONTENT=$(printf '🔴 **Demerzel: scheduled loop(s) failing**\n%s' "$FAILED")
+          jq -n --arg c "$CONTENT" '{content: $c}' \
+            | curl -sS -X POST -H 'content-type: application/json' -d @- "$DISCORD_WEBHOOK_URL" >/dev/null
+          echo "Posted Discord alert."
+
+      - name: Fail the guard if any scheduled loop is red
+        if: steps.scan.outputs.HAS_FAILURES == 'true'
+        run: |
+          echo "::error::One or more scheduled workflows last failed on their schedule. See the loop-health issue."
+          exit 1


### PR DESCRIPTION
## Why
`demerzel-capability-expansion` was RED for ~a month (every scheduled run failed at exit 5) before anyone noticed — the "silent loop death" failure mode. The existing `demerzel-quality-trend-freshness` guard catches dead **data** feeders by file staleness, but **scanners** that only emit issues/discussions produce no file that goes stale, so their run failures were invisible.

This is the metafix for that: watch scheduled-run **health**, not just data freshness.

## What
A weekly, independent guard (`demerzel-scheduled-run-health.yml`) that:
- reads the latest **scheduled** run `conclusion` of every cron workflow;
- **silent on green**; turns **RED** and opens/updates one `loop-health` tracking issue when any last failed (`failure` / `timed_out` / `startup_failure`);
- posts a **Discord** alert too — **dormant until a `DISCORD_WEBHOOK_URL` repo secret is added** (logs a notice + no-ops until then);
- skips itself (no self-referential flapping); **never remediates** — a human decides the fix.
- Uses the default `GITHUB_TOKEN` (`actions:read` + `issues:write`), no PAT.

## Verification (against live run data, read-only)
Checked **12** scheduled workflows; stayed silent on the 10 green; correctly flagged:
- `demerzel-capability-expansion` — last scheduled run failed 07-13 (its fixed run lands next Monday)
- `ecosystem-freshness` — **a second silently-failing loop this guard surfaced on first run**

YAML validated. The `ecosystem-freshness` red is a pre-existing, separate issue worth its own triage — surfaced here as proof the guard works.

## Notes
- Aligns with the existing `demerzel-quality-trend-freshness` "green != dead" doctrine, generalised from data-staleness to run-health.
- To enable Discord: add repo secret `DISCORD_WEBHOOK_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)