### PR TITLE
feat(loop-health): Discord alert when ecosystem-freshness trips

### DIFF
--- a/.github/workflows/ecosystem-freshness.yml
+++ b/.github/workflows/ecosystem-freshness.yml
@@ -90,6 +90,7 @@ jobs:
           path: ${{ runner.temp }}/ecosystem-freshness-result
 
       - name: Persist failure or verified recovery
+        id: persist
         if: always()
         run: |
           result_dir="$RUNNER_TEMP/ecosystem-freshness-result"
@@ -122,3 +123,26 @@ jobs:
           git commit -m "$message"
           git pull --rebase
           git push
+
+          # Signal a newly-committed trip so the next step can alert once
+          # (not every daily run — recovery/no-change paths never reach here).
+          if [[ -f "$target_alert" ]]; then
+            echo "alerted=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Discord alert on trip (dormant until DISCORD_WEBHOOK_URL secret is set)
+        if: steps.persist.outputs.alerted == 'true'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+            echo "::notice::DISCORD_WEBHOOK_URL secret not set — skipping Discord alert."
+            exit 0
+          fi
+          alert="state/loop-health/.freshness-alert.json"
+          summary=$(jq -r '"🔴 **Demerzel loop-health tripped**\n"
+            + ([.problems[] | "- `\(.workflow)` — \(.kind)"] | join("\n"))' "$alert")
+          jq -n --arg c "$summary" '{content: $c}' \
+            | curl -sS -X POST -H 'content-type: application/json' -d @- "$DISCORD_WEBHOOK_URL" >/dev/null
+          echo "Posted Discord alert."


### PR DESCRIPTION
## What
Adds an optional **Discord** notification to the **existing** `ecosystem-freshness` guard — *not* a parallel workflow (that mistake was #758, reverted in #759).

When the `persist` job commits a new/changed trip, it emits an `alerted` output and a follow-up step posts the tripped workflows + kinds to Discord.

## Design
- **Fires only on a committed change** — the recovery/no-change paths `exit 0` before it, so no daily spam; you get pinged when a loop newly trips (or the set of red loops changes).
- **Dormant until `DISCORD_WEBHOOK_URL` secret is set** — logs a `::notice::` and no-ops otherwise, so this is a safe no-op until you add the secret.
- Message built from the **verified** committed alert schema (`state/loop-health/.freshness-alert.json` → `.problems[].workflow` + `.kind`), e.g.:
  ```
  🔴 Demerzel loop-health tripped
  - `demerzel-capability-expansion.yml` — failed_run
  ```

## Verification
YAML parses; the summary jq renders correctly against the real alert artifact. +24 lines, single file.

## To enable
Add repo secret **`DISCORD_WEBHOOK_URL`** (a Discord channel webhook URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)