### PR TITLE
feat(aiw): enforce budget gate in the AFK/AIW episode loop (#471 tracer)

### DIFF
--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -47,6 +47,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import aiw_budget_gate as budget  # noqa: E402  (fail-closed AIW budget preflight)
 import council_emit  # noqa: E402  (sibling module in scripts/; self-merge gate)
 import demerzel_kit as kit  # noqa: E402  (shared gh / write-artifact seam)
 
@@ -65,6 +66,78 @@ LOW_KEYWORDS = ("doc", "documentation", "typo", "comment", "test", "config")
 CONSCIENCE_SIGNALS_DIR = ROOT / "state" / "conscience" / "signals"
 CONSCIENCE_BLOCK_WEIGHT = 0.8         # an active signal at/above this blocks self-merge
 SELF_MERGE_MIN_CONFIDENCE = 0.7       # minimum post_council_confidence
+
+# ── AIW budget enforcement (#471) ──────────────────────────────────────────
+# Every worker invocation goes through the fail-closed budget gate first: no
+# granted reservation, no invocation. Each backend maps to an allowlisted
+# provider so the gate applies its per-job / per-cycle caps and local-first rule.
+BACKEND_PROVIDER = {
+    "local": "codex-cli",             # ../afk-harness sandcastle runs Codex CLI
+    "claude-code": "claude-code-cli",  # headless `claude -p` on the subscription
+}
+# Recognized budget numbers an issue may carry to tighten the policy defaults.
+_BUDGET_KEYS = (
+    "estimated_cost_usd", "estimated_total_tokens", "estimated_model_calls",
+    "estimated_retries", "estimated_runner_minutes",
+    "max_cost_usd", "max_total_tokens", "max_model_calls", "max_retries",
+    "max_runner_minutes", "approval_required_above_usd",
+)
+
+
+def _parse_budget_block(body: str) -> dict:
+    """Harvest recognized budget numbers from an issue body (string-based, no
+    regex). Any ``key: number`` line whose key is a known budget field is picked
+    up; unknown keys and non-numeric values are ignored. Missing fields fall back
+    to the gate's policy defaults."""
+    out: dict[str, float] = {}
+    for raw in (body or "").splitlines():
+        line = raw.strip().lstrip("-").strip()
+        key, sep, val = line.partition(":")
+        if not sep or key.strip() not in _BUDGET_KEYS:
+            continue
+        try:
+            num = float(val.strip().rstrip(","))
+        except ValueError:
+            continue
+        if num >= 0:
+            out[key.strip()] = num
+    return out
+
+
+def _budget_request(issue: dict, backend: str) -> dict:
+    """Build an AIW budget request for one issue+backend. Raises for a backend
+    with no budgeted provider mapping (fail closed — an unmapped worker is never
+    reserved)."""
+    provider = BACKEND_PROVIDER.get(backend)
+    if provider is None:
+        raise ValueError(f"backend {backend!r} has no budgeted provider mapping")
+    req = {"job_id": f"aiw-{issue.get('number')}", "provider": provider}
+    req.update(_parse_budget_block(issue.get("body") or ""))
+    return req
+
+
+def _budget_reserve(issue: dict, backend: str) -> tuple[bool, dict]:
+    """Fail-closed budget preflight before any worker invocation. Returns
+    ``(allowed, result)``; ANY error is a block, never an invocation."""
+    try:
+        policy = budget._load(budget.POLICY_PATH)
+        result = budget.reserve(policy, _budget_request(issue, backend),
+                                budget.CYCLE_LEDGER_PATH)
+    except Exception as exc:  # a broken/absent policy must fail closed
+        return False, {"decision": "block", "reasons": ["budget_preflight_error"],
+                       "error": str(exc)[:200]}
+    return result.get("decision") == "allow", result
+
+
+def _budget_release(issue: dict, actual_cost_usd: float = 0.0) -> None:
+    """Best-effort reservation release after an episode; a reconciliation hiccup
+    must never break the loop. Local-seat backends carry no marginal spend."""
+    try:
+        budget.release(budget.CYCLE_LEDGER_PATH, f"aiw-{issue.get('number')}",
+                       actual_cost_usd, policy=budget._load(budget.POLICY_PATH))
+    except Exception as exc:
+        print(f"budget release skipped for #{issue.get('number')}: {exc}",
+              file=sys.stderr)
 
 
 def halt_active() -> tuple[bool, str]:
@@ -533,6 +606,17 @@ def _process_issue(issue: dict, seq: int, today: str, backend: str) -> tuple[dic
         _write_loop_state(state)
         return decision, state
 
+    # Budget preflight (#471): a worker is NEVER invoked without a granted
+    # reservation. A blocked/errored preflight fails closed — no clone, no spend.
+    allowed, budget_result = _budget_reserve(issue, backend)
+    if not allowed:
+        reasons = budget_result.get("reasons") or ["denied"]
+        decision["action"] = f"blocked:budget:{','.join(reasons)}"
+        state["status"] = "halted"
+        state["halt_reason"] = f"budget: {', '.join(reasons)}"
+        _write_loop_state(state)
+        return decision, state
+
     clone = None
     try:
         if backend == "remote":
@@ -579,6 +663,8 @@ def _process_issue(issue: dict, seq: int, today: str, backend: str) -> tuple[dic
     finally:
         if clone:
             shutil.rmtree(clone, ignore_errors=True)
+        # Reconcile the reservation: local-seat backends carry no marginal spend.
+        _budget_release(issue, actual_cost_usd=0.0)
 
     _write_loop_state(state)
     return decision, state

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -356,5 +356,70 @@ class TestClaudeCodeBackend(unittest.TestCase):
         self.assertIn("Bash(python *)", cmd)
 
 
+class TestBudgetGate(unittest.TestCase):
+    """#471: the AIW/AFK loop must run every worker invocation through the
+    fail-closed budget gate (aiw_budget_gate) — no reservation, no invocation."""
+
+    def _issue(self, **over):
+        i = {"number": 77, "title": "fix docs typo", "body": "x", "labels": []}
+        i.update(over)
+        return i
+
+    def test_blocked_budget_prevents_worker_invocation(self):
+        with mock.patch.object(g, "_budget_reserve",
+                               return_value=(False, {"decision": "block",
+                                                     "reasons": ["cycle_cost_cap_exceeded"]})), \
+             mock.patch.object(g, "_prepare_clone") as clone, \
+             mock.patch.object(g, "_invoke_harness") as inv_local, \
+             mock.patch.object(g, "_invoke_harness_claude_code") as inv_cc, \
+             mock.patch.object(g, "_write_loop_state"):
+            decision, state = g._process_issue(self._issue(), seq=1,
+                                               today="2026-07-19", backend="local")
+        clone.assert_not_called()
+        inv_local.assert_not_called()
+        inv_cc.assert_not_called()
+        self.assertIn("budget", decision["action"])
+        self.assertEqual(state["status"], "halted")
+
+    def test_allowed_budget_reserves_then_releases(self):
+        with mock.patch.object(g, "_budget_reserve",
+                               return_value=(True, {"decision": "allow"})) as res, \
+             mock.patch.object(g, "_budget_release") as rel, \
+             mock.patch.object(g, "_prepare_clone", return_value="/tmp/clone"), \
+             mock.patch.object(g, "_invoke_harness",
+                               return_value={"branch": "agent/issue-77",
+                                             "commits": ["x"], "blocked": None}), \
+             mock.patch.object(g, "_open_pr",
+                               return_value="https://github.com/x/y/pull/1"), \
+             mock.patch.object(g.shutil, "rmtree"), \
+             mock.patch.object(g, "_write_loop_state"):
+            decision, state = g._process_issue(self._issue(), seq=1,
+                                               today="2026-07-19", backend="local")
+        res.assert_called_once()
+        rel.assert_called_once()            # reservation reconciled after the episode
+        self.assertEqual(state["status"], "completed")
+
+    def test_parse_budget_block_picks_known_numeric_keys(self):
+        body = ("intro\nmax_cost_usd: 1.5\n- estimated_total_tokens: 50000\n"
+                "ignored_key: nope\nestimated_model_calls: 3\nmax_cost_usd: abc")
+        b = g._parse_budget_block(body)
+        self.assertEqual(b["max_cost_usd"], 1.5)     # numeric wins; "abc" ignored
+        self.assertEqual(b["estimated_total_tokens"], 50000)
+        self.assertEqual(b["estimated_model_calls"], 3)
+        self.assertNotIn("ignored_key", b)
+
+    def test_budget_request_maps_backend_provider(self):
+        self.assertEqual(
+            g._budget_request({"number": 5, "body": ""}, "local")["provider"], "codex-cli")
+        self.assertEqual(
+            g._budget_request({"number": 5, "body": ""}, "claude-code")["provider"],
+            "claude-code-cli")
+
+    def test_unmapped_backend_fails_closed(self):
+        allowed, result = g._budget_reserve({"number": 5, "body": ""}, "remote")
+        self.assertFalse(allowed)
+        self.assertEqual(result["decision"], "block")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Tracer-bullet slice for **#471** (Cherny agent loop + budget router integration), building directly on the merged budget gate **#715**.

## Gap
`run_afk_cycle._process_issue` went `is_eligible → invoke worker → PR` with **zero budget preflight and no cost reconciliation** — the exact "*enforce, not merely document*" gap named in #471 and the operator note of 2026-07-18. #715 shipped the gate; nothing called it.

## Change (budget-control = responsibility #2 of #471's router)
- **Before any clone/invoke**, `_budget_reserve()` runs the fail-closed gate. Blocked or errored preflight → **fail closed** (state `halted`, reason `budget:<reasons>`, no clone, no spend).
- **Backend → provider mapping**: `local → codex-cli`, `claude-code → claude-code-cli`. An unmapped backend (e.g. the unimplemented `remote` seam) **fails closed**.
- **Estimate extraction**: an issue may carry a budget block (`estimated_*` / `max_*` numbers, parsed string-based — no regex) to tighten policy defaults.
- **After the episode**, `_budget_release()` reconciles the reservation (local-seat = no marginal spend), best-effort so a hiccup never breaks the loop.

## Tests (fail-closed for every path)
- blocked reservation prevents *every* worker invocation (`_prepare_clone`/`_invoke_harness*` never called)
- allowed path reserves **then** releases
- estimate extraction picks known numeric keys, ignores the rest
- provider mapping (local/claude-code)
- unmapped backend fails closed

Full suite green: `run_afk_cycle` **42**, discovery **239**; `validate_governance` 13 valid; `build_manifest` PASSED (no drift). 2 files, +151.

## Scope / next
Deliberately just the budget-control leg. The remaining #471 loop-model responsibilities (workspace matrix, autonomy modes, evidence bundle, retry policy) are follow-up slices. **Do not merge without adversarial review** (#471 is `needs-adversarial-review`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)