### PR TITLE
feat(planner): critical-path analysis over the execution graph (#535)

### DIFF
--- a/scripts/planner_critical_path.py
+++ b/scripts/planner_critical_path.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Critical-path analysis over a compiled execution graph (Planner #535).
+
+Consumes an execution graph as emitted by ``epic_to_dag_compiler.compile_epic``
+(``{nodes, edges}``) and computes the longest precedence chain — the sequence of
+work packages that sets the minimum completion time for the epic.
+
+Precedence semantics (only execution-gating edges count):
+  - ``depends_on`` A->B : B must finish before A  (precedence B -> A)
+  - ``blocks``      A->B : A must finish before B  (precedence A -> B)
+  - ``reviews`` / ``should_merge_after`` : review/merge ordering, NOT execution
+    gates, so they are ignored here.
+
+Pure and deterministic (ties broken lexicographically); it never mutates its
+input. The graph is assumed acyclic (the compiler's ``validate_graph`` guarantees
+it); a defensive cycle check still fails closed rather than recursing forever.
+
+The Planner only *recommends* — this emits analysis, never commands (#529
+guardrail). Run as a CLI for a dry-run report.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+
+# Map an edge to its (predecessor, successor) execution-precedence pair, or None
+# when the edge does not gate execution.
+_PRECEDENCE = {
+    "depends_on": lambda e: (e["to"], e["from"]),
+    "blocks": lambda e: (e["from"], e["to"]),
+}
+
+
+def _precedence(graph: dict[str, Any]):
+    """Return (node_ids, successors, in_degree) for the execution-precedence DAG."""
+    node_ids = [n["node_id"] for n in graph.get("nodes", [])]
+    known = set(node_ids)
+    succ: dict[str, list[str]] = {nid: [] for nid in node_ids}
+    indeg: dict[str, int] = {nid: 0 for nid in node_ids}
+    for edge in graph.get("edges", []):
+        convert = _PRECEDENCE.get(edge.get("type"))
+        if convert is None:
+            continue
+        pred, node = convert(edge)
+        if pred in known and node in known:
+            succ[pred].append(node)
+            indeg[node] += 1
+    return node_ids, succ, indeg
+
+
+def critical_path(graph: dict[str, Any]) -> dict[str, Any]:
+    """Longest execution-precedence chain through the graph.
+
+    Returns ``{"path": [node_id, ...], "length": int, "bottlenecks": [...]}``.
+    ``bottlenecks`` are critical-path nodes that fan out to (or in from) more than
+    one package — the points where the schedule is most sensitive.
+    """
+    node_ids, succ, indeg = _precedence(graph)
+    memo: dict[str, list[str]] = {}
+    on_stack: set[str] = set()
+
+    def longest_from(node: str) -> list[str]:
+        if node in memo:
+            return memo[node]
+        if node in on_stack:  # defensive: a cycle slipped past validation
+            raise ValueError(f"cycle through node {node!r}")
+        on_stack.add(node)
+        best: list[str] = [node]
+        for nxt in succ[node]:
+            candidate = [node] + longest_from(nxt)
+            if len(candidate) > len(best) or (
+                    len(candidate) == len(best) and candidate < best):
+                best = candidate
+        on_stack.discard(node)
+        memo[node] = best
+        return best
+
+    best_path: list[str] = []
+    for nid in node_ids:
+        chain = longest_from(nid)
+        if len(chain) > len(best_path) or (
+                len(chain) == len(best_path) and chain < best_path):
+            best_path = chain
+
+    bottlenecks = [n for n in best_path if len(succ[n]) > 1 or indeg[n] > 1]
+    return {"path": best_path, "length": len(best_path), "bottlenecks": bottlenecks}
+
+
+def annotate(graph: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``graph`` with each node stamped ``critical_path: bool``."""
+    on_path = set(critical_path(graph)["path"])
+    nodes = [{**n, "critical_path": n["node_id"] in on_path}
+             for n in graph.get("nodes", [])]
+    return {**graph, "nodes": nodes}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Critical-path analysis over an execution graph (dry-run, #535)")
+    parser.add_argument("--graph", required=True, help="path to a compiled graph JSON")
+    parser.add_argument("--out", help="write annotated graph here (default: report to stdout)")
+    args = parser.parse_args(argv)
+    try:
+        with open(args.graph, encoding="utf-8") as stream:
+            graph = json.load(stream)
+        result = critical_path(graph)
+        if args.out:
+            with open(args.out, "w", encoding="utf-8") as stream:
+                json.dump(annotate(graph), stream, indent=2)
+                stream.write("\n")
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"critical-path: {error}", file=sys.stderr)
+        return 2
+    print(f"critical path ({result['length']}): {' -> '.join(result['path'])}")
+    if result["bottlenecks"]:
+        print(f"bottlenecks: {', '.join(result['bottlenecks'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_planner_critical_path.py
+++ b/scripts/test_planner_critical_path.py
@@ -1,0 +1,87 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import planner_critical_path as pcp
+
+
+def _graph(nodes, edges):
+    """A minimal execution graph valid against the compiler's node/edge shape."""
+    return {
+        "version": "1.0",
+        "graph_id": "g-test",
+        "nodes": [{"node_id": n, "type": "task", "description": n,
+                   "repo": "demerzel", "status": "pending"} for n in nodes],
+        "edges": edges,
+    }
+
+
+class TestCriticalPath(unittest.TestCase):
+    def test_simple_chain(self):
+        # C depends_on B, B depends_on A  =>  execution order A -> B -> C
+        g = _graph(["A", "B", "C"], [
+            {"from": "C", "to": "B", "type": "depends_on"},
+            {"from": "B", "to": "A", "type": "depends_on"},
+        ])
+        cp = pcp.critical_path(g)
+        self.assertEqual(cp["path"], ["A", "B", "C"])
+        self.assertEqual(cp["length"], 3)
+
+    def test_parallel_branches_pick_the_longest(self):
+        # ROOT blocks A and X; A blocks B blocks C (len 4);  X blocks Y (len 3).
+        g = _graph(["ROOT", "A", "B", "C", "X", "Y"], [
+            {"from": "ROOT", "to": "A", "type": "blocks"},
+            {"from": "ROOT", "to": "X", "type": "blocks"},
+            {"from": "A", "to": "B", "type": "blocks"},
+            {"from": "B", "to": "C", "type": "blocks"},
+            {"from": "X", "to": "Y", "type": "blocks"},
+        ])
+        cp = pcp.critical_path(g)
+        self.assertEqual(cp["path"], ["ROOT", "A", "B", "C"])
+        self.assertEqual(cp["length"], 4)
+        self.assertIn("ROOT", cp["bottlenecks"])   # ROOT fans out to two branches
+
+    def test_blocks_and_depends_on_agree_on_direction(self):
+        # depends_on and blocks expressing the same B-before-A precedence.
+        g_dep = _graph(["A", "B"], [{"from": "A", "to": "B", "type": "depends_on"}])
+        g_blk = _graph(["A", "B"], [{"from": "B", "to": "A", "type": "blocks"}])
+        self.assertEqual(pcp.critical_path(g_dep)["path"], ["B", "A"])
+        self.assertEqual(pcp.critical_path(g_blk)["path"], ["B", "A"])
+
+    def test_review_and_merge_edges_do_not_gate_execution(self):
+        # Only a review/merge edge -> no execution precedence -> path length 1.
+        g = _graph(["A", "B"], [
+            {"from": "A", "to": "B", "type": "reviews"},
+            {"from": "A", "to": "B", "type": "should_merge_after"},
+        ])
+        cp = pcp.critical_path(g)
+        self.assertEqual(cp["length"], 1)
+
+    def test_annotate_marks_only_critical_nodes(self):
+        g = _graph(["ROOT", "A", "B", "C", "X", "Y"], [
+            {"from": "ROOT", "to": "A", "type": "blocks"},
+            {"from": "ROOT", "to": "X", "type": "blocks"},
+            {"from": "A", "to": "B", "type": "blocks"},
+            {"from": "B", "to": "C", "type": "blocks"},
+            {"from": "X", "to": "Y", "type": "blocks"},
+        ])
+        marked = {n["node_id"]: n["critical_path"] for n in pcp.annotate(g)["nodes"]}
+        self.assertTrue(all(marked[n] for n in ("ROOT", "A", "B", "C")))
+        self.assertFalse(marked["Y"])
+        # annotate must not mutate the caller's graph
+        self.assertNotIn("critical_path", g["nodes"][0])
+
+    def test_deterministic_tie_break(self):
+        # Two equal-length chains -> lexicographically smallest path, stably.
+        g = _graph(["A", "B", "M", "N"], [
+            {"from": "B", "to": "A", "type": "depends_on"},   # A -> B
+            {"from": "N", "to": "M", "type": "depends_on"},   # M -> N
+        ])
+        self.assertEqual(pcp.critical_path(g)["path"],
+                         pcp.critical_path(g)["path"])        # stable
+        self.assertEqual(pcp.critical_path(g)["path"], ["A", "B"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Next slice of the Planner MVP (**#529**), building on the landed Epic→DAG compiler (#533 / #741).

## What
`scripts/planner_critical_path.py` — the longest execution-precedence chain through a compiled graph (the sequence that sets an epic's minimum completion time).

**Precedence semantics** (only execution-gating edges count):
- `depends_on A→B`: B before A · `blocks A→B`: A before B
- `reviews` / `should_merge_after` are review/merge ordering, **not** execution gates → ignored.

**API** (pure, deterministic, non-mutating; ties broken lexicographically):
- `critical_path(graph) → {path, length, bottlenecks}` (bottlenecks = critical-path nodes that fan out/in to >1 package)
- `annotate(graph) → graph copy` with each node stamped `critical_path: bool`
- CLI dry-run report — aligns with #529's *recommend, never execute* guardrail.

## Verification
End-to-end on the **real** Sprint-0 epic (`examples/execution-graph-sprint-0-input.json`): compiles to 6 nodes / 5 edges; critical path = **#517 → #519** (Core IDs/ontology → Streeling event foundations), matching the roadmap's foundational dependency.

Tests: simple chain, parallel branches (only the longest is critical), blocks/depends_on direction agreement, non-execution edges ignored, deterministic tie-break, annotation without mutation. Suite green (discovery **240**); `validate_governance` 13 valid; `build_manifest` PASSED (no drift). 2 new files, +211.

## Next
Unblocks **#536** (collision detector), **#539** (scheduler), **#540** (merge planner) — all need "which nodes are on the critical path."

🤖 Generated with [Claude Code](https://claude.com/claude-code)