### PR TITLE
feat(planner): parallel scheduler + review planner (#539)

### DIFF
--- a/scripts/planner_scheduler.py
+++ b/scripts/planner_scheduler.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Parallel work scheduler and review planner over an execution graph (#539).
+
+Turns a compiled execution graph (``epic_to_dag_compiler.compile_epic``) into a
+safe, deterministic execution plan by composing the two prior Planner slices:
+
+  - dependency **levels** (Kahn layering over precedence edges): each level is the
+    set of packages whose predecessors have all completed, i.e. dependency-ready
+    together (reuses planner_critical_path's precedence — #535);
+  - within a level, packages are dependency-independent but may still collide, so
+    the **collision graph** (planner_collision_detector — #536) is greedily
+    coloured into parallel **batches**: two packages that collide never share a
+    batch, non-colliding packages run in parallel.
+
+Review planning: any package involved in a collision receives a review stage (a
+human decides the sequencing/merge), reported in recommended-review order.
+
+Deterministic (sorted + greedy) and explainable; never mutates input; recommends
+only (#529 guardrail). Run as a CLI for a dry-run plan.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import planner_collision_detector as pcd  # noqa: E402
+import planner_critical_path as pcp  # noqa: E402
+
+
+def _levels(graph: dict[str, Any]) -> list[list[str]]:
+    """Kahn layering over execution precedence: level i = nodes at dependency
+    depth i. Reuses the single precedence definition from planner_critical_path."""
+    node_ids, succ, indeg = pcp._precedence(graph)
+    remaining = dict(indeg)
+    ready = sorted(n for n in node_ids if remaining[n] == 0)
+    levels: list[list[str]] = []
+    placed = 0
+    while ready:
+        levels.append(list(ready))
+        placed += len(ready)
+        nxt: list[str] = []
+        for node in ready:
+            for succ_node in succ[node]:
+                remaining[succ_node] -= 1
+                if remaining[succ_node] == 0:
+                    nxt.append(succ_node)
+        ready = sorted(nxt)
+    if placed != len(node_ids):  # defensive: a cycle would strand nodes
+        raise ValueError("graph is not acyclic; cannot schedule")
+    return levels
+
+
+def _collision_pairs(graph: dict[str, Any]) -> set[frozenset[str]]:
+    return {frozenset((c["a"], c["b"]))
+            for c in pcd.detect_collisions(graph)["collisions"]}
+
+
+def _batches(level: list[str], collisions: set[frozenset[str]]) -> list[list[str]]:
+    """Greedy graph colouring: colliding nodes get different colours (batches)."""
+    colour: dict[str, int] = {}
+    for node in sorted(level):
+        blocked = {colour[other] for other in level
+                   if other in colour and frozenset((node, other)) in collisions}
+        chosen = 0
+        while chosen in blocked:
+            chosen += 1
+        colour[node] = chosen
+    grouped: dict[int, list[str]] = {}
+    for node in level:
+        grouped.setdefault(colour[node], []).append(node)
+    return [sorted(grouped[c]) for c in sorted(grouped)]
+
+
+def schedule(graph: dict[str, Any]) -> dict[str, Any]:
+    """Return a deterministic parallel execution + review plan.
+
+    ``waves``: dependency levels, each ``{level, batches}`` where every batch is a
+    set of packages safe to run in parallel. ``execution_order``: a flattened
+    deterministic order. ``review_required`` / ``review_order``: collision-involved
+    packages needing a review stage. ``critical_path``: the schedule-critical chain.
+    """
+    levels = _levels(graph)
+    collisions = _collision_pairs(graph)
+    waves: list[dict[str, Any]] = []
+    execution_order: list[str] = []
+    for depth, level in enumerate(levels):
+        batches = _batches(level, collisions)
+        waves.append({"level": depth, "batches": batches})
+        for batch in batches:
+            execution_order.extend(batch)
+
+    involved = sorted({n for pair in collisions for n in pair})
+    order_index = {n: i for i, n in enumerate(execution_order)}
+    review_order = sorted(involved, key=lambda n: order_index.get(n, len(order_index)))
+    return {
+        "waves": waves,
+        "execution_order": execution_order,
+        "review_required": involved,
+        "review_order": review_order,
+        "critical_path": pcp.critical_path(graph)["path"],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Parallel scheduler + review planner over an execution graph (dry-run, #539)")
+    parser.add_argument("--graph", required=True, help="path to a compiled graph JSON")
+    args = parser.parse_args(argv)
+    try:
+        with open(args.graph, encoding="utf-8") as stream:
+            graph = json.load(stream)
+        plan = schedule(graph)
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"scheduler: {error}", file=sys.stderr)
+        return 2
+    for wave in plan["waves"]:
+        lanes = " | ".join("[" + ", ".join(b) + "]" for b in wave["batches"])
+        print(f"wave {wave['level']}: {lanes}")
+    if plan["review_required"]:
+        print("review stages: " + ", ".join(plan["review_order"]))
+    print("critical path: " + " -> ".join(plan["critical_path"]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_planner_scheduler.py
+++ b/scripts/test_planner_scheduler.py
@@ -1,0 +1,84 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import planner_scheduler as ps
+
+
+def _node(nid, repo="demerzel", paths=None):
+    n = {"node_id": nid, "type": "task", "description": nid,
+         "repo": repo, "status": "pending"}
+    if paths is not None:
+        n["paths"] = paths
+    return n
+
+
+def _graph(nodes, edges=None):
+    return {"version": "1.0", "graph_id": "g", "nodes": nodes, "edges": edges or []}
+
+
+def _batch_of(waves, level, nid):
+    for i, b in enumerate(waves[level]["batches"]):
+        if nid in b:
+            return i
+    return None
+
+
+class TestScheduler(unittest.TestCase):
+    def test_colliding_nodes_are_not_in_the_same_batch(self):
+        # A,B,C independent, same repo. A & B touch the same file (collide); C disjoint.
+        g = _graph([_node("A", paths=["scripts/x.py"]),
+                    _node("B", paths=["scripts/x.py"]),
+                    _node("C", paths=["personas/c.yaml"])])
+        sched = ps.schedule(g)
+        self.assertEqual(len(sched["waves"]), 1)                 # all dependency-ready
+        wave0 = sched["waves"][0]["batches"]
+        self.assertNotEqual(_batch_of(sched["waves"], 0, "A"),
+                            _batch_of(sched["waves"], 0, "B"))   # collision splits them
+        self.assertEqual(_batch_of(sched["waves"], 0, "A"),
+                         _batch_of(sched["waves"], 0, "C"))      # disjoint -> parallel
+
+    def test_dependency_chain_forms_waves(self):
+        # C depends_on B, B depends_on A  =>  three dependency levels.
+        g = _graph([_node("A"), _node("B"), _node("C")], [
+            {"from": "C", "to": "B", "type": "depends_on"},
+            {"from": "B", "to": "A", "type": "depends_on"},
+        ])
+        sched = ps.schedule(g)
+        self.assertEqual([w["batches"] for w in sched["waves"]],
+                         [[["A"]], [["B"]], [["C"]]])
+        self.assertEqual(sched["execution_order"], ["A", "B", "C"])
+
+    def test_independent_disjoint_nodes_run_in_one_batch(self):
+        g = _graph([_node("A", paths=["a/x"]), _node("B", paths=["b/y"]),
+                    _node("C", paths=["c/z"])])
+        sched = ps.schedule(g)
+        self.assertEqual(sched["waves"], [{"level": 0, "batches": [["A", "B", "C"]]}])
+
+    def test_collision_nodes_get_review_stages(self):
+        g = _graph([_node("A", paths=["scripts/x.py"]),
+                    _node("B", paths=["scripts/x.py"])])
+        sched = ps.schedule(g)
+        self.assertEqual(sched["review_required"], ["A", "B"])
+        self.assertEqual(sched["review_order"], ["A", "B"])
+
+    def test_no_collisions_means_no_review(self):
+        g = _graph([_node("A", repo="ga", paths=["s/x"]),
+                    _node("B", repo="ix", paths=["s/x"])])   # different repos
+        self.assertEqual(ps.schedule(g)["review_required"], [])
+
+    def test_precedence_respected_and_deterministic(self):
+        g = _graph([_node("A"), _node("B"), _node("C")], [
+            {"from": "A", "to": "B", "type": "blocks"},   # A before B
+            {"from": "A", "to": "C", "type": "blocks"},   # A before C
+        ])
+        first, second = ps.schedule(g), ps.schedule(g)
+        self.assertEqual(first, second)                            # deterministic
+        order = first["execution_order"]
+        self.assertLess(order.index("A"), order.index("B"))        # precedence held
+        self.assertLess(order.index("A"), order.index("C"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Composes the two prior Planner slices (#535 critical-path, #536 collisions — both merged) into a safe, deterministic execution plan. Parent **#529**.

## What
- **Dependency levels** (Kahn layering over precedence, reusing `planner_critical_path`): each level = the dependency-ready set.
- Within a level, the **collision graph** (`planner_collision_detector`) is greedily coloured into parallel **batches** — colliding packages never share a batch.
- **Review stages** for every collision-involved package, in recommended-review order.

`schedule(graph) → {waves:[{level,batches}], execution_order, review_required, review_order, critical_path}`. Deterministic, non-mutating, recommend-only (#529 guardrail); CLI dry-run.

## Acceptance criteria (all tested)
- ready nodes grouped into parallel batches ✓
- collision risks constrain parallelism (colouring) ✓
- collision nodes receive review stages ✓
- deterministic + precedence-respecting output ✓

## Verification
End-to-end on the **real** Sprint-0 epic:
```
wave 0: [#517, #523, #527]
wave 1: [#519, #520, #525]
review stages: #527, #525
critical path: #517 -> #519
```
Suite green (discovery **260**); `validate_governance` 13 valid; `build_manifest` PASSED. 2 new files, +214.

## Planner MVP status
`compile → critical-path (#535) → collisions (#536) → schedule (#539, this PR)` — the analysis chain is complete. Remaining epic slice: **#540** (merge planner + dry-run simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)