### PR TITLE
feat(planner): merge planner + dry-run simulator (#540) — Planner MVP finale

### DIFF
--- a/scripts/planner_merge_simulator.py
+++ b/scripts/planner_merge_simulator.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Merge planner and dry-run execution simulator over an execution graph (#540).
+
+The Planner MVP finale: given a compiled execution graph, produce a deterministic
+merge order and a dry-run simulation of where every work package sits in its
+lifecycle, then assemble a PlannerReport.
+
+Composes the earlier slices:
+  - execution precedence + critical path (planner_critical_path, #535);
+  - collision-driven review stages (planner_scheduler, #539, which itself uses
+    the collision detector, #536).
+
+Merge precedence = execution dependencies (``depends_on`` / ``blocks``) PLUS
+explicit ``should_merge_after`` edges. States are computed from each node's
+``status`` (default ``pending``) plus dependency completion and review needs:
+
+  - ``blocked``    : an execution predecessor is not yet done;
+  - ``ready``      : dependencies done, the package itself not yet done;
+  - ``in-review``  : done, but flagged for a review stage that is unresolved;
+  - ``mergeable``  : done and reviewed (or no review needed).
+
+Deterministic, non-mutating, recommend-only (#529 guardrail). CLI dry-run report.
+"""
+from __future__ import annotations
+
+import argparse
+import heapq
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import planner_critical_path as pcp  # noqa: E402
+import planner_scheduler as ps  # noqa: E402
+
+_DONE = {"done", "complete", "completed", "merged"}
+
+# Merge precedence: 'value' must land before 'key-source'.
+_MERGE_PRECEDENCE = {
+    "depends_on": lambda e: (e["to"], e["from"]),
+    "blocks": lambda e: (e["from"], e["to"]),
+    "should_merge_after": lambda e: (e["to"], e["from"]),
+}
+
+
+def merge_order(graph: dict[str, Any]) -> list[str]:
+    """Deterministic merge order over execution + should_merge_after precedence."""
+    node_ids = [n["node_id"] for n in graph.get("nodes", [])]
+    known = set(node_ids)
+    succ: dict[str, set[str]] = {nid: set() for nid in node_ids}
+    indeg: dict[str, int] = {nid: 0 for nid in node_ids}
+    for edge in graph.get("edges", []):
+        convert = _MERGE_PRECEDENCE.get(edge.get("type"))
+        if convert is None:
+            continue
+        pred, node = convert(edge)
+        if pred in known and node in known and node not in succ[pred]:
+            succ[pred].add(node)
+            indeg[node] += 1
+
+    heap = [nid for nid in node_ids if indeg[nid] == 0]
+    heapq.heapify(heap)
+    order: list[str] = []
+    while heap:
+        node = heapq.heappop(heap)
+        order.append(node)
+        for nxt in sorted(succ[node]):
+            indeg[nxt] -= 1
+            if indeg[nxt] == 0:
+                heapq.heappush(heap, nxt)
+    if len(order) != len(node_ids):
+        raise ValueError("merge graph is not acyclic")
+    return order
+
+
+def simulate(graph: dict[str, Any]) -> dict[str, str]:
+    """Return {node_id: state} for the current snapshot."""
+    node_ids, succ, _ = pcp._precedence(graph)
+    preds: dict[str, set[str]] = {nid: set() for nid in node_ids}
+    for pred, nexts in succ.items():
+        for node in nexts:
+            preds[node].add(pred)
+    by_id = {n["node_id"]: n for n in graph.get("nodes", [])}
+    review = set(ps.schedule(graph)["review_required"])
+
+    def done(nid: str) -> bool:
+        return by_id[nid].get("status", "pending") in _DONE
+
+    states: dict[str, str] = {}
+    for nid in node_ids:
+        if not all(done(p) for p in preds[nid]):
+            states[nid] = "blocked"
+        elif not done(nid):
+            states[nid] = "ready"
+        elif nid in review:
+            states[nid] = "in-review"
+        else:
+            states[nid] = "mergeable"
+    return states
+
+
+def plan(graph: dict[str, Any]) -> dict[str, Any]:
+    """Assemble the PlannerReport: merge order, per-node states, summary,
+    assumptions, risks, evidence references, and recommended next actions."""
+    order = merge_order(graph)
+    states = simulate(graph)
+    review = ps.schedule(graph)["review_required"]
+    summary = {state: sum(1 for v in states.values() if v == state)
+               for state in ("ready", "blocked", "in-review", "mergeable")}
+    evidence = {n["node_id"]: n["evidence"]
+                for n in graph.get("nodes", []) if n.get("evidence")}
+
+    def in_state(state: str) -> list[str]:
+        return [nid for nid in order if states[nid] == state]
+
+    next_actions: list[str] = []
+    if in_state("mergeable"):
+        next_actions.append("merge (in order): " + ", ".join(in_state("mergeable")))
+    if in_state("in-review"):
+        next_actions.append("resolve review stages: " + ", ".join(in_state("in-review")))
+    if in_state("blocked"):
+        next_actions.append("unblock by completing dependencies: "
+                            + ", ".join(in_state("blocked")))
+
+    return {
+        "merge_order": order,
+        "states": states,
+        "summary": summary,
+        "assumptions": [
+            "node status is read from the graph (default 'pending'); a review stage "
+            "is treated as unresolved until approved",
+            "merge precedence = execution dependencies + should_merge_after edges",
+        ],
+        "risks": review,
+        "evidence": evidence,
+        "next_actions": next_actions,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Merge planner + dry-run simulator over an execution graph (#540)")
+    parser.add_argument("--graph", required=True, help="path to a compiled graph JSON")
+    parser.add_argument("--out", help="write the PlannerReport JSON here (default: stdout summary)")
+    args = parser.parse_args(argv)
+    try:
+        with open(args.graph, encoding="utf-8") as stream:
+            graph = json.load(stream)
+        report = plan(graph)
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"merge-simulator: {error}", file=sys.stderr)
+        return 2
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as stream:
+            json.dump(report, stream, indent=2)
+            stream.write("\n")
+    print("merge order: " + " -> ".join(report["merge_order"]))
+    print("states: " + ", ".join(f"{k}={v}" for k, v in report["summary"].items()))
+    for action in report["next_actions"]:
+        print("next: " + action)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_planner_merge_simulator.py
+++ b/scripts/test_planner_merge_simulator.py
@@ -1,0 +1,80 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import planner_merge_simulator as pms
+
+
+def _node(nid, status="pending", repo="demerzel", paths=None, evidence=None):
+    n = {"node_id": nid, "type": "task", "description": nid,
+         "repo": repo, "status": status}
+    if paths is not None:
+        n["paths"] = paths
+    if evidence is not None:
+        n["evidence"] = evidence
+    return n
+
+
+def _graph(nodes, edges=None):
+    return {"version": "1.0", "graph_id": "g", "nodes": nodes, "edges": edges or []}
+
+
+class TestMergeOrder(unittest.TestCase):
+    def test_merge_order_respects_should_merge_after(self):
+        # B should_merge_after A  =>  A merges before B.
+        g = _graph([_node("A"), _node("B")],
+                   [{"from": "B", "to": "A", "type": "should_merge_after"}])
+        order = pms.merge_order(g)
+        self.assertLess(order.index("A"), order.index("B"))
+
+    def test_merge_order_deterministic(self):
+        g = _graph([_node("A"), _node("B"), _node("C")],
+                   [{"from": "C", "to": "A", "type": "should_merge_after"}])
+        self.assertEqual(pms.merge_order(g), pms.merge_order(g))
+
+
+class TestSimulate(unittest.TestCase):
+    def test_blocked_when_dependency_not_done(self):
+        g = _graph([_node("A", status="pending"), _node("B", status="pending")],
+                   [{"from": "B", "to": "A", "type": "depends_on"}])
+        st = pms.simulate(g)
+        self.assertEqual(st["A"], "ready")     # no deps, not done
+        self.assertEqual(st["B"], "blocked")   # dep A not done
+
+    def test_ready_when_dependency_done(self):
+        g = _graph([_node("A", status="done"), _node("B", status="pending")],
+                   [{"from": "B", "to": "A", "type": "depends_on"}])
+        self.assertEqual(pms.simulate(g)["B"], "ready")
+
+    def test_mergeable_when_done_and_no_review(self):
+        g = _graph([_node("A", status="done", paths=["a/x"])])
+        self.assertEqual(pms.simulate(g)["A"], "mergeable")
+
+    def test_in_review_when_done_and_colliding(self):
+        g = _graph([_node("A", status="done", paths=["scripts/x.py"]),
+                    _node("B", status="done", paths=["scripts/x.py"])])
+        st = pms.simulate(g)
+        self.assertEqual(st["A"], "in-review")
+        self.assertEqual(st["B"], "in-review")
+
+
+class TestPlannerReport(unittest.TestCase):
+    def test_report_has_all_sections_and_is_deterministic(self):
+        g = _graph([_node("A", status="done", evidence=["pr#1"], paths=["docs/a.md"]),
+                    _node("B", status="done", paths=["scripts/x.py"]),
+                    _node("C", status="done", paths=["scripts/x.py"])])
+        r = pms.plan(g)
+        for key in ("merge_order", "states", "summary", "assumptions",
+                    "risks", "evidence", "next_actions"):
+            self.assertIn(key, r)
+        self.assertEqual(r["evidence"]["A"], ["pr#1"])         # evidence refs surfaced
+        self.assertEqual(r["summary"]["mergeable"], 1)          # A
+        self.assertEqual(r["summary"]["in-review"], 2)          # B, C collide
+        self.assertEqual(sorted(r["risks"]), ["B", "C"])
+        self.assertTrue(any("resolve review" in a for a in r["next_actions"]))
+        self.assertEqual(pms.plan(g), pms.plan(g))             # deterministic
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The **Planner MVP finale** (#529) — composes every prior slice into a merge plan + dry-run report. Depends on #535/#536/#539 (all merged).

## What
- **`merge_order(graph)`** — deterministic order over execution dependencies **+** `should_merge_after` edges (Kahn, id tie-break).
- **`simulate(graph)`** — per-node lifecycle state:
  - `blocked` (a dependency isn't done) · `ready` (deps done, not done yet) · `in-review` (done, but flagged for an unresolved review stage) · `mergeable` (done, no review pending).
- **`plan(graph)`** — the **PlannerReport**: merge_order, states, summary, **assumptions**, **risks** (collision-involved packages), **evidence references**, **recommended next actions**. Deterministic, non-mutating, recommend-only (#529 guardrail); CLI dry-run.

## Acceptance criteria (all tested)
- merge order deterministic ✓ · blockers + unresolved reviews represented ✓ · ready/blocked/in-review/mergeable states ✓ · report includes assumptions/risks/evidence/next-actions ✓

## Verification (real Sprint-0 epic)
```
merge order: #517 -> #523 -> #520 -> #525 -> #527 -> #519
states: ready=3, blocked=3, in-review=0, mergeable=0
next: unblock by completing dependencies: #520, #525, #519
```
Suite green (discovery **267**); `validate_governance` 13 valid; `build_manifest` PASSED. 2 new files, +246.

## Planner MVP complete 🎯
`compile (#533) → critical-path (#535) → collisions (#536) → schedule (#539) → merge/simulate (#540)` — the full analysis chain, every slice deterministic and explainable, verified end-to-end on real Sprint-0 data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)