### PR TITLE
docs(streeling): core identifiers + engineering ontology v1 (#517)

### DIFF
--- a/docs/architecture/core-identifiers.md
+++ b/docs/architecture/core-identifiers.md
@@ -1,0 +1,74 @@
+# Core identifiers (v1)
+
+Streeling observes, Seldon learns, Demerzel decides, IX optimizes, TARS executes.
+They can only agree on *what happened* if they name the same entity the same way.
+This document fixes that vocabulary: the ten identifiers every repo uses to point
+at a worker, a capability, a pipeline, and so on.
+
+It is a **naming contract**, not a schema — it says how an id is *spelled* and what
+it *means to stay stable*, so a `worker_id` emitted by Streeling resolves to the
+same worker in a Demerzel decision and an IX metric. Companion: the
+[engineering ontology](engineering-ontology.md), which defines the *entities* these
+ids point at and how they relate.
+
+## Conventions
+
+These generalize what the schemas and registries already do (`pipeline_id`,
+`artifact_id`, `worker_id`; workers spelled `claude` / `jules` / `github-actions`):
+
+- **Field name** — `snake_case` with an `_id` suffix (`worker_id`, not `workerId`
+  or `worker`). JSON keys and schema properties use this form.
+- **Value** — a lowercase **kebab-case slug**, optionally namespaced with `:` when
+  a bare slug would collide across producers (`worker_id: "jules"`,
+  `capability_id: "review"`, `metric_id: "ix:token-cost"`). No spaces, no camelCase,
+  no opaque UUIDs where a human-stable slug will do.
+- **Stability** — ids are **append-only**: once emitted and referenced, a slug is
+  not renamed in place. A supersede is a *new* slug plus a `supersedes` note (the
+  same non-breaking pattern the cross-repo contracts use), never a silent rename —
+  a renamed id orphans every belief, metric, and decision that referenced the old
+  one.
+- **Ownership** — each id has one *authoritative producer* (below). Others reference
+  it; they do not mint new spellings for the same entity.
+
+## The ten identifiers
+
+| Id | Field | Value format | Authoritative producer | Example (grounded) |
+|---|---|---|---|---|
+| **WorkerId** | `worker_id` | agent/runner slug | Demerzel worker registry | `claude`, `codex`, `jules`, `github-actions` |
+| **CapabilityId** | `capability_id` | domain-verb slug | Demerzel capability registry | `implementation`, `observability`, `review` |
+| **RepositoryId** | `repository_id` | ecosystem repo key | `schemas/capability-registry.json` `.repos` | `demerzel`, `ix`, `tars`, `ga` |
+| **PipelineId** | `pipeline_id` | pipeline slug | pipeline registry | `qa-architect-cycle`, `ml-feedback` |
+| **PolicyId** | `policy_id` | policy file stem | `policies/` | `alignment-policy`, `autonomous-loop-policy` |
+| **DecisionId** | `decision_id` | `<producer>:<verb>:<seq-or-hash>` | Demerzel advisory decisions | `demerzel:escalate:2026-07-19-001` |
+| **MetricId** | `metric_id` | `<repo>:<measure>` | IX / emitters | `ix:token-cost`, `demerzel:artifact-effectiveness` |
+| **EvidenceId** | `evidence_id` | `<kind>:<ref>` | any producer | `pr:GuitarAlchemist/Demerzel#767`, `test:discovery-267` |
+| **KnowledgeId** | `knowledge_id` | knowledge-package slug | Seldon | `seldon:planner-mvp`, `harvest:2026-07-19` |
+| **ArtifactId** | `artifact_id` | governance-artifact path stem | `governance-manifest.json` | `skeptical-auditor`, `execution-graph` |
+
+Notes:
+
+- **WorkerId vs provider** — a `worker_id` is the agent identity (`claude`); a
+  *provider* is a concrete execution channel for that worker (`claude-code-local`,
+  `claude-code-cli`, an `ANTHROPIC_API_KEY` fallback). One worker, many providers;
+  budget/routing lives at the provider level (see
+  [cost-aware routing](cost-aware-routing.md)).
+- **EvidenceId** is the join key between an action and its proof — a Demerzel
+  decision cites `evidence_id`s; Streeling emits them; Seldon distills over them.
+- **ArtifactId** reuses the manifest's `name` (a file stem), so the governance
+  graph and the ontology share one key space rather than two.
+
+## How other sprint packs reference this
+
+- Streeling events (`docs/architecture/streeling-event-store.md`) carry
+  `worker_id` / `repository_id` / `evidence_id` on every envelope.
+- Demerzel advisory decisions (`demerzel-advisory-decisions.md`) key on
+  `decision_id` and cite `evidence_id`s.
+- The registry factory (#525) is the authoritative producer for `worker_id`,
+  `capability_id`, `pipeline_id`, `policy_id`, `metric_id`.
+- IX/Seldon control models (#594, #596) consume `metric_id` / `evidence_id`.
+
+## Status
+
+v1 — the starting vocabulary. Additions are append-only; changes to an existing
+id's semantics require a supersede note and cross-repo coordination per the
+Galactic Protocol.

--- a/docs/architecture/engineering-ontology.md
+++ b/docs/architecture/engineering-ontology.md
@@ -1,0 +1,80 @@
+# Engineering ontology (v1)
+
+The shared model of *what exists* in the GuitarAlchemist software organization:
+twelve entities and the edges between them. Streeling emits instances, Seldon
+learns over them, Demerzel decides against them, IX measures them, TARS executes
+them. Their identifiers are fixed in [core identifiers](core-identifiers.md); this
+document fixes what they *are* and how they *connect*.
+
+It exists so the eventual knowledge graph (Wave 3) has a spine agreed up front,
+rather than each repo inventing an incompatible half of it.
+
+## The twelve entities
+
+| Entity | Id | Is | Owned by |
+|---|---|---|---|
+| **Worker** | `worker_id` | An agent identity that can be assigned work (`claude`, `jules`, `github-actions`). Executes through one or more providers. | Demerzel |
+| **Capability** | `capability_id` | A thing a worker can do (`implementation`, `review`, `observability`). The unit routing matches work against. | Demerzel |
+| **Repository** | `repository_id` | An ecosystem repo (`demerzel`, `ix`, `tars`, `ga`) — the boundary for collisions and ownership. | shared |
+| **Pipeline** | `pipeline_id` | A declarative multi-step process (`qa-architect-cycle`, `ml-feedback`) a worker runs. | Demerzel / IX / TARS |
+| **Policy** | `policy_id` | A governance rule that constrains decisions and workers. Overrides personas. | Demerzel |
+| **Decision** | `decision_id` | A recorded choice (`escalate`, `proceed`, `standardize`) with evidence and a confidence. Advisory by default. | Demerzel |
+| **Evidence** | `evidence_id` | A verifiable fact backing a decision or metric (a PR, a test log, a receipt). The join key between action and proof. | any producer |
+| **Metric** | `metric_id` | A measured quantity over time (`ix:token-cost`, effectiveness deltas). | IX / emitters |
+| **Artifact** | `artifact_id` | A governance object on disk (persona, schema, skill, constitution) — a node in `governance-manifest.json`. | Demerzel |
+| **Review** | — | An assessment stage applied to a change before merge (council, adversarial, human). Produces Evidence. | Demerzel |
+| **Workflow** | — | An automated GitHub Actions process; a Workflow may *run* a Pipeline and *emit* Evidence/Metrics. | shared |
+| **Knowledge** | `knowledge_id` | A distilled, transferable package (a Seldon course, a harvested learning). | Seldon |
+
+(Review and Workflow are addressed by their GitHub-native ids — a run url, a
+workflow file — rather than a minted slug; they still appear in the graph as first
+-class nodes.)
+
+## Core relationships
+
+The edges that make the model a graph rather than a glossary:
+
+```text
+Worker      --has-->        Capability
+Worker      --assigned-->   WorkPackage        (Planner, #529)
+Capability  --matches-->    WorkPackage
+Pipeline    --runs-in-->    Repository
+Workflow    --runs-->       Pipeline
+Workflow    --emits-->      Evidence, Metric
+Review      --produces-->   Evidence
+Decision    --cites-->      Evidence
+Decision    --governed-by-->Policy
+Metric      --measures-->   Worker | Capability | Pipeline | Artifact
+Knowledge   --distills-->   Evidence, Metric
+Artifact    --references--> Artifact            (the governance manifest edges)
+```
+
+### Reading the roles onto the model
+
+- **Streeling (observe)** emits `Evidence` and `Metric` instances tagged with
+  `worker_id` / `repository_id`.
+- **Seldon (learn)** turns streams of Evidence/Metric into `Knowledge`.
+- **Demerzel (decide)** produces `Decision`s that cite Evidence and are governed by
+  `Policy`, and owns the `Worker` / `Capability` registries that routing consumes.
+- **IX (optimize)** produces `Metric`s and control models over them.
+- **TARS (execute)** runs `Pipeline`s declared against `Repository`s.
+
+## Alignment with existing artifacts
+
+This is a naming-and-relationship layer over things that already exist — it does
+not replace them:
+
+- `Worker`/`Capability`/`Pipeline`/`Policy`/`Metric` are materialized by the
+  registry factory (#525);
+- `Evidence` and its envelope are the [Streeling event store](streeling-event-store.md);
+- `Decision` is [Demerzel advisory decisions](demerzel-advisory-decisions.md);
+- `Artifact` + its edges are `governance-manifest.json` (ADR-0002, harvested not
+  declared);
+- `Knowledge` is the Seldon delivery / harvest output.
+
+## Status
+
+v1 — a spine to build the knowledge graph on, deliberately small. Adding an entity
+or edge kind is append-only; changing the meaning of an existing one requires a
+supersede note and cross-repo coordination. No runtime types are mandated here;
+consumers (e.g. the registry factory) may implement types once this stabilizes.


### PR DESCRIPTION
SprintPack **S0-A** — the shared vocabulary Streeling/Seldon/Demerzel/IX/TARS use to name the same entity the same way. This is the **critical-path root** of the Sprint-0 DAG (`#517 → #519`, per the critical-path analysis merged in #762).

## Deliverables
- **`docs/architecture/core-identifiers.md`** — the ten ids (Worker, Capability, Repository, Pipeline, Policy, Decision, Metric, Evidence, Knowledge, Artifact), each with field name, value format, authoritative producer, and grounded examples.
- **`docs/architecture/engineering-ontology.md`** — the twelve entities + the edges between them, mapped onto observe/learn/decide/optimize/execute, aligned to existing artifacts.

## Grounded, not invented
Conventions **generalize existing usage** (verified in the schemas/registries): `snake_case` + `_id` fields, kebab-case slugs, workers spelled `claude`/`jules`/`github-actions`, capabilities `implementation`/`review`/`observability`. IDs are **append-only** (supersede, never rename in place) so beliefs/metrics/decisions don't orphan.

## Acceptance criteria
- IDs have stable names + semantics ✓ · ontology defines the 12 entities ✓ · no runtime mandated ("no runtime unless trivial") ✓ · other sprint packs can reference the vocabulary ✓ (cross-refs to #525 registry, Streeling event store, advisory decisions, governance-manifest).

## Verification
`validate_governance` 13 valid; `build_manifest` PASSED (docs aren't counted artifacts → no drift). All four cross-referenced architecture docs exist. 2 new files, +154.

## Note
v1 **draft for team review** (issue suggested Jules-first on the vocabulary). Additions append-only; semantic changes need a supersede note + Galactic-Protocol coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)