### PR TITLE
feat(aiw): provider-native token accounting + knowledge-type routing doctrine

### DIFF
--- a/docs/architecture/cost-aware-routing.md
+++ b/docs/architecture/cost-aware-routing.md
@@ -22,6 +22,39 @@ To avoid "LLM-by-default" patterns, the following tasks *must* attempt a determi
 - **Syntax Validation**: Use compilers, linters, or tree-sitter.
 - **Dependency Analysis**: Use repo-specific package managers or graph tools.
 
+## Routing by Knowledge Type (parametric vs contextual)
+
+The hierarchy above routes by **risk and stakes**. That is necessary but not
+sufficient: it tends to send *every* hard task to a premium model, because "hard"
+reads as "high-stakes". A second, orthogonal question sharpens it — **which kind of
+knowledge does this task actually draw on?**
+
+- **Parametric knowledge** lives in the model's weights (breadth, prior art,
+  unprompted alternatives, "have you considered X?"). **Planning, grilling,
+  architecture, and design exploration depend on it** — a bigger model is
+  genuinely better here, because you are paying for what it knows that you did not
+  put in the window.
+- **Contextual knowledge** lives in the prompt (the agreed plan, the spec, the
+  files already in context). **Implementation depends mostly on this** — once a
+  task is well-scoped and the plan and seams are decided, a cheaper model performs
+  close to a frontier one, because the hard thinking is already in the window.
+
+**The rule:** *plan with the strongest model available; implement with the cheapest
+model that clears the bar.* A difficult feature does **not** by itself justify a
+premium implementation model — an under-specified one does. If implementation
+quality is poor, the first remedy is a better plan/spec in context, not a bigger
+model.
+
+This composes with, and does not replace, the tier hierarchy: deterministic tools
+still come first, and a high-**risk** change still escalates for review regardless
+of which model produced the diff.
+
+> Wiring note: `state/driver/aiw-worker-lanes.json` already classifies every role by
+> `work_class` (`groom`/`review`/`navigate` are planning-shaped; `net_new_feature`/
+> `fix` are implementation-shaped). That field is the natural hook for making this
+> rule executable in `scripts/aiw_lane_selector.py`; it is documented doctrine
+> today, not yet an enforced selector.
+
 ## Escalation Rules
 
 Escalation to a higher-cost tier is only permitted when:

--- a/docs/workflows/aiw-budget-router.md
+++ b/docs/workflows/aiw-budget-router.md
@@ -169,6 +169,35 @@ python scripts/aiw_budget_gate.py --release-job aiw-0001 `
   --receipt .octo/aiw-receipt.json
 ```
 
+### Provider-native token accounting
+
+Token caps (`max_total_tokens`) are expressed in **canonical** tokens, but each
+provider ships its own tokenizer, so the same prompt bills a different number of
+tokens on each — a 2-3x spread between providers is ordinary. A single normalized
+cap therefore over-admits work on a coarse tokenizer and under-admits it on a fine
+one.
+
+A provider entry in `state/driver/aiw-budget-policy.json` may declare an optional
+`token_multiplier` that converts a canonical estimate into that provider's own
+tokens before the cap is applied:
+
+```json
+{ "id": "some-provider", "tier": "metered-cloud", "token_multiplier": 1.8 }
+```
+
+- **Absent means `1.0`** — a provider that has not been measured keeps exactly the
+  previous behaviour, so adding the field is non-breaking.
+- The value must be a **positive, finite number**; `0`, negatives, NaN, booleans,
+  and strings are rejected as invalid policy.
+- The gate reports both counts in its budget block: `estimated_total_tokens` (the
+  raw canonical estimate) alongside `token_multiplier` and
+  `effective_total_tokens` (what the provider actually bills). `token_cap_exceeded`
+  is raised against the **effective** count.
+
+**Every shipped provider currently omits the field** (i.e. 1.0). Populating real
+multipliers requires *measured* tokenizer ratios per provider — they are
+deliberately not guessed here; contribute them with the measurement as evidence.
+
 ### Live consumer
 
 `.github/workflows/jules-auto-delegate.yml` is the first live consumer of the gate.

--- a/scripts/aiw_budget_gate.py
+++ b/scripts/aiw_budget_gate.py
@@ -101,6 +101,24 @@ def _is_metered(provider: dict[str, Any]) -> bool:
     return provider.get("tier") == "metered-cloud"
 
 
+def _token_multiplier(provider: dict[str, Any]) -> float:
+    """Convert a canonical token estimate into this provider's own tokens.
+
+    Providers ship different tokenizers, so the same prompt bills a different
+    number of tokens on each (a 2-3x spread is ordinary). A single normalized
+    cap therefore over-admits work on coarse tokenizers and under-admits it on
+    fine ones. An absent multiplier means 1.0, so a provider that has not been
+    measured keeps exactly today's behaviour.
+    """
+    if "token_multiplier" not in provider:
+        return 1.0
+    value = provider["token_multiplier"]
+    if (isinstance(value, bool) or not isinstance(value, (int, float))
+            or not math.isfinite(value) or value <= 0):
+        raise ValueError("token_multiplier must be a positive number")
+    return float(value)
+
+
 def _validate_approval(approval: dict[str, Any] | None, request: dict[str, Any],
                        request_sha256: str) -> bool:
     if approval is None:
@@ -296,6 +314,7 @@ def evaluate(policy: dict[str, Any], request: dict[str, Any],
              approval: dict[str, Any] | None = None) -> dict[str, Any]:
     provider_id = request.get("provider")
     provider = _provider(policy, provider_id)
+    token_multiplier = _token_multiplier(provider)
 
     defaults = policy.get("defaults")
     cycle = policy.get("cycle")
@@ -331,7 +350,9 @@ def evaluate(policy: dict[str, Any], request: dict[str, Any],
         reasons.append("job_cost_cap_exceeded")
     if cycle_spend + estimated_cost > cycle_max_cost:
         reasons.append("cycle_cost_cap_exceeded")
-    if tokens > max_tokens:
+    # Caps are expressed in canonical tokens; compare in the provider's own.
+    effective_tokens = tokens * token_multiplier
+    if effective_tokens > max_tokens:
         reasons.append("token_cap_exceeded")
     if calls > max_calls:
         reasons.append("model_call_cap_exceeded")
@@ -358,6 +379,8 @@ def evaluate(policy: dict[str, Any], request: dict[str, Any],
             "estimated_cost_usd": estimated_cost,
             "cycle_spend_usd": cycle_spend,
             "estimated_total_tokens": int(tokens),
+            "token_multiplier": token_multiplier,
+            "effective_total_tokens": int(effective_tokens),
             "estimated_model_calls": int(calls),
             "estimated_retries": int(retries),
             "estimated_runner_minutes": runner_minutes,

--- a/scripts/test_aiw_budget_gate.py
+++ b/scripts/test_aiw_budget_gate.py
@@ -281,6 +281,52 @@ class BudgetGateTests(unittest.TestCase):
             self.assertEqual("block", result["decision"], provider)
             self.assertIn("provider_requires_manual_approval", result["reasons"])
 
+    def _policy_with_multiplier(self, value, provider="claude-code-cli"):
+        """A policy copy whose named provider declares a token multiplier."""
+        policy = json.loads(json.dumps(POLICY))
+        for item in policy["providers"]:
+            if item["id"] == provider:
+                item["token_multiplier"] = value
+        return policy
+
+    def test_absent_token_multiplier_leaves_tokens_unchanged(self):
+        # Regression guard: every shipped provider omits the field, so the
+        # effective count must equal the raw estimate and existing caps hold.
+        result = evaluate(POLICY, request(estimated_total_tokens=150000))
+        self.assertEqual("allow", result["decision"])
+        self.assertEqual(1.0, result["budget"]["token_multiplier"])
+        self.assertEqual(150000, result["budget"]["effective_total_tokens"])
+
+    def test_provider_token_multiplier_scales_tokens_against_the_cap(self):
+        # 120k raw tokens fits the 200k cap on a 1.0 provider, but a provider
+        # that tokenizes ~2x coarser really consumes 240k and must be blocked.
+        raw = 120000
+        self.assertEqual("allow", evaluate(POLICY, request(
+            estimated_total_tokens=raw))["decision"])
+        result = evaluate(self._policy_with_multiplier(2.0),
+                          request(estimated_total_tokens=raw))
+        self.assertEqual("block", result["decision"])
+        self.assertIn("token_cap_exceeded", result["reasons"])
+        self.assertEqual(240000, result["budget"]["effective_total_tokens"])
+        self.assertEqual(raw, result["budget"]["estimated_total_tokens"])
+
+    def test_token_multiplier_below_one_widens_effective_headroom(self):
+        # A finer-grained tokenizer legitimately fits more raw text per cap.
+        result = evaluate(self._policy_with_multiplier(0.5),
+                          request(estimated_total_tokens=300000))
+        self.assertEqual("allow", result["decision"])
+        self.assertEqual(150000, result["budget"]["effective_total_tokens"])
+
+    def test_non_positive_token_multiplier_is_rejected(self):
+        for bad in (0, -1, float("nan")):
+            with self.assertRaisesRegex(ValueError, "token_multiplier"):
+                evaluate(self._policy_with_multiplier(bad), request())
+
+    def test_non_numeric_token_multiplier_is_rejected(self):
+        for bad in ("2", True, None):
+            with self.assertRaisesRegex(ValueError, "token_multiplier"):
+                evaluate(self._policy_with_multiplier(bad), request())
+
     def test_cli_ledger_shape_is_json_serializable(self):
         result = evaluate(POLICY, request())
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
Follow-up to #771 — executes two items from that PR's adoption table (P5, P6), grounded in Pocock's token + cost videos.

## P5 — provider-native token accounting (code)

Budget caps (`max_total_tokens`) are expressed in **canonical** tokens, but every provider ships its own tokenizer, so the same prompt bills a different count on each (**a 2–3× spread is ordinary**). A single normalized cap silently **over-admits** work on coarse tokenizers and **under-admits** it on fine ones — a latent correctness gap, most consequential for the metered providers.

Adds an optional per-provider `token_multiplier` to `state/driver/aiw-budget-policy.json` that converts a canonical estimate into the provider's own tokens before the cap check.

- **Absent means `1.0`** → every currently shipped provider keeps *exactly* its previous behaviour. Non-breaking by construction.
- Must be **positive and finite**; `0`, negatives, NaN, booleans and strings are rejected as invalid policy.
- Gate now reports `estimated_total_tokens` (raw) alongside `token_multiplier` and `effective_total_tokens`; `token_cap_exceeded` is raised against the **effective** count.

**Real multipliers are deliberately not guessed.** Populating them needs *measured* tokenizer ratios per provider; the doc asks for the measurement as evidence. Shipping the mechanism without inventing the data.

## P6 — knowledge-type routing (doctrine)

`cost-aware-routing.md` routes by **risk/stakes**, which tends to send every *hard* task to a premium model. Adds an orthogonal axis:

- **Parametric** knowledge (in the weights) → planning, grilling, architecture. A bigger model is genuinely better; you're paying for what it knows that you didn't put in the window.
- **Contextual** knowledge (in the prompt) → implementation. Once the plan and seams are decided, a cheaper model performs close to a frontier one.

**Rule:** plan with the strongest model, implement with the cheapest that clears the bar. A hard feature doesn't justify a premium *implementation* model — an under-specified one does; the first remedy for poor output is a better plan in context, not a bigger model.

Documented doctrine only. `aiw-worker-lanes.json`'s existing `work_class` field is noted as the natural hook to make it executable later — **the hardened lane selector is untouched**.

## Deliberately NOT built

The **monthly-reset AFK ledger** (also in the adoption table). Anthropic's AFK credit is monthly/non-rolling, but **no consumer tracks a monthly boundary today** — building it now would be speculative. Deferred as a proposal rather than shipped blind.

## Verification

- Budget gate **32 → 37** tests (5 new, written red-first — including a regression guard that the absent-field path is unchanged).
- **62** tests green across the full AIW suite (gate, consumer, lane selector, prompt pack) — no regressions.
- `validate_governance` 13 valid / 0 invalid; `build_manifest` green, no drift (regenerated `governance-health.json` reverted to keep the diff surgical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)