### PR TITLE
fix(oracle): verify.ps1 rejected a valid lockfile, then swallowed the real failure

### DIFF
--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -4,7 +4,12 @@ $root = Split-Path -Parent $PSScriptRoot
 
 Get-ChildItem -LiteralPath $root -Recurse -File -Include *.json |
     Where-Object { $_.FullName -notmatch '\\node_modules\\|\\.git\\' } |
-    ForEach-Object { Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json | Out-Null }
+    # -AsHashtable: npm lockfiles legitimately use "" as the root package key.
+    # That is valid JSON, but ConvertFrom-Json rejects an empty-string property
+    # name unless it deserializes to a hashtable - which made the repo oracle
+    # fail on a well-formed file. Parsing is still the check; only the target
+    # type changes.
+    ForEach-Object { Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json -AsHashtable | Out-Null }
 
 if (Test-Path -LiteralPath (Join-Path $root 'tree-sitter-ixql/package.json')) {
     Push-Location (Join-Path $root 'tree-sitter-ixql')

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -11,15 +11,27 @@ Get-ChildItem -LiteralPath $root -Recurse -File -Include *.json |
     # type changes.
     ForEach-Object { Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json -AsHashtable | Out-Null }
 
+# $ErrorActionPreference = 'Stop' does NOT cover native command exit codes
+# ($PSNativeCommandUseErrorActionPreference is False here), so every native
+# call below must be checked explicitly or its failure is silently discarded.
+function Assert-NativeSuccess([string]$what) {
+    if ($LASTEXITCODE -ne 0) {
+        throw "$what failed with exit code $LASTEXITCODE"
+    }
+}
+
 if (Test-Path -LiteralPath (Join-Path $root 'tree-sitter-ixql/package.json')) {
     Push-Location (Join-Path $root 'tree-sitter-ixql')
     try {
         if (Test-Path -LiteralPath 'package-lock.json') {
             npm ci
+            Assert-NativeSuccess 'npm ci'
         } else {
             npm install
+            Assert-NativeSuccess 'npm install'
         }
         npm test
+        Assert-NativeSuccess 'npm test'
     } finally {
         Pop-Location
     }


### PR DESCRIPTION
## What this is now

The original version of this PR claimed the npm leg "prints `No language found` yet still exits 0, so that half of the oracle may be passing vacuously." **That was backwards, and adversarial review caught it.** Corrected below.

## Two defects, both measured

**1. False failure on a valid lockfile.** `ConvertFrom-Json` rejects an empty-string property name unless it deserializes to a hashtable. npm lockfiles legitimately use `""` as the root package key, so the oracle failed on a well-formed file. Fixed with `-AsHashtable`.

Review confirmed this does not weaken the check: 13 malformed/edge inputs (truncated object, trailing comma, bare `NaN`, control char, duplicate keys, 200-deep nesting) behave identically with and without the flag. The only divergence is the empty-string key — the intended fix. `tree-sitter-ixql/package-lock.json` is the only file repo-wide with that shape; the fix branch parses all 923 non-`node_modules` JSON files.

**2. Swallowed native failures.** `$ErrorActionPreference = 'Stop'` does **not** cover native command exit codes (`PSNativeCommandUseErrorActionPreference` is `False`), and `verify.ps1` never tested `$LASTEXITCODE`.

Measured on this branch before the second commit:

```
npm test    -> exit 1  ("No language found")
verify.ps1  -> exit 0
```

The oracle's only executable assertion was failing and being discarded. Its real coverage was *"923 JSON files parse."* Added `Assert-NativeSuccess` after `npm ci` / `npm install` / `npm test`.

## What this PR does NOT do

**It does not unblock the loop, and the oracle is still red.** Fixing the swallow surfaced a genuine pre-existing defect: the grammar cannot generate at all —

```
Unresolved conflict for symbol sequence:  'stdin'  •  'csv'  …
tree-sitter generate -> exit 1
```

— so `tree-sitter test` finds no language. `tree-sitter-ixql/src/` has never existed, and `package.json`'s `test` script has no `generate` step. This leg has almost certainly never passed. Filed separately rather than papered over; adding a skip condition here is how the vacuous pass would return by another name.

The earlier claim that "no supervised autonomous cycle can complete" was also overstated: preflight refuses at step 1 (`overseer_missing`) before the oracle at step 4 is reached.

## Net effect

The oracle moves from **incorrectly green on a broken test** to **correctly red on a real defect**. That is the intended direction, but it means this PR alone does not make `verify.ps1` pass.

## Scope limit

This ends one form of vacuous passing, not all of it. If `tree-sitter-ixql/` is absent entirely, the whole block is skipped and the oracle still exits 0 on the JSON scan alone. That path is pre-existing and unchanged here, but it means "the oracle is now honest" holds only while the directory exists.
