### PR TITLE
feat(backlog): create the queue supervised-loop consumes, from a real architecture review

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -136,19 +136,33 @@ follows its precondition chain, not its interest level.
   cycle.
 - **Possible dead modules** — `aiw_lane_selector.py`, `aiw_prompt_pack.py`,
   `poincare_roadmap.py`, `seldon_intelligence_dry_run.py`,
-  `streeling_tracer_bullet.py`, `planner_*.py` have no production callers (tests and
-  docs only). This is a `/demerzel evolve` question, not a refactor — and
-  cleanup candidates are usually false positives until verified against docs and
-  consumer counts.
-- **21 scripts recomputing the repo root** two different ways despite `kit.ROOT`.
+  `streeling_tracer_bullet.py` have no production callers. The last three are
+  deader than first stated — zero references anywhere outside this file, not even
+  tests. `aiw_lane_selector.py` and `aiw_prompt_pack.py` do have test coverage.
+  This is a `/demerzel evolve` question, not a refactor — and cleanup candidates
+  are usually false positives until verified against docs and consumer counts.
+  **`planner_*.py` was wrongly listed here and has been removed**: it merged two
+  commits ago (`728bd84` / #767, `08ec2c8` / #766), and only
+  `planner_critical_path.py` lacks a non-test reference. It was exactly the false
+  positive the sentence above warns about.
+- **30 scripts recomputing the repo root** two different ways despite `kit.ROOT`
+  (25 via `parents[1]`, 5 via `parent.parent`).
   Too small to spend a cycle on; fold into whichever entry touches the file.
 
 ## agent-blackbox install-audit follow-ups
 
 `docs/harness-observability.md` (:36, :96) points here for these. They are
-tracked, not queued: the `loop-controls` and `response-quality` evidence credits
-live as **workflow step strings** inside `.github/workflows/agent-blackbox.yml`,
-which is in the protected-paths list. The supervised loop cannot edit it.
+tracked, not queued: the `harness-audit` and `response-quality` evidence credits
+are described by `docs/harness-observability.md` as living in **workflow step
+strings** inside `.github/workflows/agent-blackbox.yml`, which is in the
+protected-paths list.
+
+*Caveat: that premise does not currently check out. Neither `harness-audit` nor
+`response-quality` appears anywhere in `agent-blackbox.yml` (its steps are
+Checkout / Set up Python / Collect PR evidence / Generate risk report / Comment /
+Upload artifacts / Enforce verdict). Either the workflow changed since the doc was
+written, or the credits live somewhere else entirely. Verify before acting on the
+"not loop-eligible" conclusion below, which rests entirely on it.*
 
 - **Not loop-eligible by construction.** Closing these needs either an operator
   workflow edit or a relaxation of the audit rule in `agent-blackbox` itself.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -141,12 +141,25 @@ follows its precondition chain, not its interest level.
   tests. `aiw_lane_selector.py` and `aiw_prompt_pack.py` do have test coverage.
   This is a `/demerzel evolve` question, not a refactor — and cleanup candidates
   are usually false positives until verified against docs and consumer counts.
-  **`planner_*.py` was wrongly listed here and has been removed**: it merged two
-  commits ago (`728bd84` / #767, `08ec2c8` / #766), and only
-  `planner_critical_path.py` lacks a non-test reference. It was exactly the false
-  positive the sentence above warns about.
-- **30 scripts recomputing the repo root** two different ways despite `kit.ROOT`
-  (25 via `parents[1]`, 5 via `parent.parent`).
+  **`planner_*.py` is listed separately below** rather than as a dead-module
+  candidate: it merged two commits ago (`728bd84` / #767, `08ec2c8` / #766), which
+  is far too early to call anything dead. It was the false positive the sentence
+  above warns about.
+
+- **The `planner_*` cluster has no external consumer yet.** All four modules
+  reference only each other: `planner_critical_path` is imported by
+  `planner_merge_simulator.py:34` and `planner_scheduler.py:31` (6 references, the
+  most of the four), while the cluster's apex `planner_merge_simulator` has **zero**
+  references outside its own test. So intra-cluster imports are not evidence of
+  production use — they describe a self-contained island. Not actionable now;
+  revisit after a release, and if nothing external consumes it by then, that is the
+  finding. *(An earlier draft of this entry stated the reference counts exactly
+  backwards.)*
+- **29 scripts recomputing the repo root** two different ways despite `kit.ROOT`
+  (24 via `parents[1]`, 5 via `parent.parent`). The raw grep returns 30; one of
+  those is `demerzel_kit.py:49`, which *is* `kit.ROOT` and cannot duplicate itself.
+  `demerzel_halt.py:71` is the clearest waste — it recomputes inline while already
+  importing `demerzel_kit as kit` at :58.
   Too small to spend a cycle on; fold into whichever entry touches the file.
 
 ## agent-blackbox install-audit follow-ups
@@ -159,9 +172,10 @@ protected-paths list.
 
 *Caveat: that premise does not currently check out. Neither `harness-audit` nor
 `response-quality` appears anywhere in `agent-blackbox.yml` (its steps are
-Checkout / Set up Python / Collect PR evidence / Generate risk report / Comment /
-Upload artifacts / Enforce verdict). Either the workflow changed since the doc was
-written, or the credits live somewhere else entirely. Verify before acting on the
+Checkout target repo / Set up Python / Checkout Agent Blackbox / Collect PR
+evidence / Generate risk report / Comment risk report / Upload risk artifacts /
+Enforce verdict -- eight, including two distinct checkouts). Either the workflow
+changed since the doc was written, or the credits live somewhere else entirely. Verify before acting on the
 "not loop-eligible" conclusion below, which rests entirely on it.*
 
 - **Not loop-eligible by construction.** Closing these needs either an operator

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -50,9 +50,10 @@ follows its precondition chain, not its interest level.
   -p 'test_*.py'` block, guarded on `python` being present, failing on non-zero.
   Converts 21 already-written test modules from decorative into load-bearing.
   *Expect pre-existing red tests on first run — that is the finding, not a blocker.*
-  *Blocked on #778 (the oracle currently swallowed native failures) and #780 (the
-  grammar leg cannot pass). Follow #778's `Assert-NativeSuccess` pattern — a bare
-  native call in `verify.ps1` is discarded, not fatal.*
+  *#778 has merged, so `verify.ps1` now checks `$LASTEXITCODE` — follow its
+  `Assert-NativeSuccess` pattern, because a bare native call is discarded, not
+  fatal. Still blocked on #780: the grammar leg cannot pass, so the oracle stays
+  red regardless of what this entry adds.*
   *Note: consider extending to Pester (`tests/powershell/`), which C3a depends on.*
 
 - [ ] 🔒 **C6 — Finish the `demerzel_kit` migration for `compliance_report.py`.**
@@ -155,11 +156,15 @@ follows its precondition chain, not its interest level.
   revisit after a release, and if nothing external consumes it by then, that is the
   finding. *(An earlier draft of this entry stated the reference counts exactly
   backwards.)*
-- **29 scripts recomputing the repo root** two different ways despite `kit.ROOT`
-  (24 via `parents[1]`, 5 via `parent.parent`). The raw grep returns 30; one of
-  those is `demerzel_kit.py:49`, which *is* `kit.ROOT` and cannot duplicate itself.
-  `demerzel_halt.py:71` is the clearest waste — it recomputes inline while already
-  importing `demerzel_kit as kit` at :58.
+- **Many scripts recompute the repo root** two different ways (`Path(__file__).resolve().parents[1]`
+  and `.parent.parent`) despite `kit.ROOT`. `demerzel_halt.py:71` is the clearest
+  waste — it recomputes inline while already importing `demerzel_kit as kit` at :58.
+  **No count is given here deliberately.** Four successive hand-counts of this were
+  wrong (17 → 21 → 30 → 29), each correction introducing a new error: one included
+  `demerzel_kit.py:49`, which *is* `kit.ROOT` and cannot duplicate itself; another
+  counted a docstring in `test_apply_ml_feedback.py` that says the test *avoids*
+  the pattern. The number is derivable and should be generated, not written — see
+  #789. Until then, run the grep rather than trusting a figure in this file.
   Too small to spend a cycle on; fold into whichever entry touches the file.
 
 ## agent-blackbox install-audit follow-ups

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -20,7 +20,12 @@ architecture is clean" — that has no fixed point.
 - **Do not** delete an entry to skip it. Either do it, or record why not as an ADR so
   future reviews stop re-proposing it (`docs/adr/`).
 - 🔒 marks entries that must **not** run unattended — they change the loop's own
-  safety gate or lack a regression net. A human drives those.
+  gate, or the target has no regression net. A human drives those. Applied
+  honestly this locks 4 of 6 entries, which is itself the finding: most of this
+  queue is not yet safe to automate, and C1 is why.
+- **Nothing parses this file.** No checkbox reader exists in `scripts/` or
+  `.github/`; the consumer is an LLM reading `supervised-loop/SKILL.md`. Slice
+  selection is model judgment, unenforced.
 
 ## Provenance
 
@@ -33,18 +38,26 @@ follows its precondition chain, not its interest level.
 
 ## Queue
 
-- [ ] **C1 — Run the Python test suite in the oracle.**
+- [ ] 🔒 **C1 — Run the Python test suite in the oracle.**
   `scripts/verify.ps1`. ~10 lines, 1 file. **Precondition for everything below.**
-  The oracle runs `ConvertFrom-Json` over `*.json` plus one npm test. The 20
+  **Human-driven — this edits the loop's own pass/fail criterion.** An autonomous
+  cycle rewriting the oracle it will then be judged by is the sharpest
+  self-referential hazard in this queue.
+  The oracle runs `ConvertFrom-Json` over `*.json` plus one npm test. The 21
   `scripts/test_*.py` modules run **only** in `governance-validate.yml` — so an
   autonomous cycle can gut `demerzel_kit`, `aiw_budget_gate`, or `build_manifest`,
   get a green `verify.ps1`, and commit. Add a `python -m unittest discover -s scripts
   -p 'test_*.py'` block, guarded on `python` being present, failing on non-zero.
-  Converts 20 already-written test modules from decorative into load-bearing.
+  Converts 21 already-written test modules from decorative into load-bearing.
   *Expect pre-existing red tests on first run — that is the finding, not a blocker.*
-  *Note: consider extending to Pester (`tests/powershell/`), which C3 depends on.*
+  *Blocked on #778 (the oracle currently swallowed native failures) and #780 (the
+  grammar leg cannot pass). Follow #778's `Assert-NativeSuccess` pattern — a bare
+  native call in `verify.ps1` is discarded, not fatal.*
+  *Note: consider extending to Pester (`tests/powershell/`), which C3a depends on.*
 
-- [ ] **C6 — Finish the `demerzel_kit` migration for `compliance_report.py`.**
+- [ ] 🔒 **C6 — Finish the `demerzel_kit` migration for `compliance_report.py`.**
+  *(🔒 for the same reason as C5a: there is no `scripts/test_compliance_report.py`,
+  so this refactor has no regression net.)*
   `scripts/compliance_report.py`. ~40 lines, 1–2 files. Low risk. Already a declared
   to-do in `CONTEXT.md`. It still carries its own `_now_iso` and `_atomic_write` (a
   hand-rolled duplicate of `kit.atomic_write`), and its docstring cites
@@ -81,17 +94,24 @@ follows its precondition chain, not its interest level.
   *Do not refactor `_lock` in this slice — a crash between acquire and the `finally`
   wedges the ledger, and that path is untested.*
 
-- [ ] 🔒 **C3a — Make `supervised-loop-preflight.ps1` consume `Get-DomainGateState`.**
-  `scripts/supervised-loop-preflight.ps1`, `scripts/DomainGate.psm1`. ~40 lines.
-  **Human-driven — this is the loop's own safety gate.**
-  `Get-DomainGateState` is a genuinely deep module with **zero callers**: both the
-  overseer and preflight `Import-Module` it and then reach past it to leaf helpers.
-  `CONTEXT.md` claims these are "thin deciders that weigh those facts themselves" —
-  they are not. Worse, the two scripts read protected paths from **different sources**
-  (`baseline.json` vs `$script:ProtectedPaths`) and nothing checks they agree.
-  Start with preflight (the safest slice), single-sourcing on `Get-ProtectedPaths`.
+- [ ] 🔒 **C3a — Decide whether `Get-DomainGateState` should exist.**
+  `scripts/DomainGate.psm1`. **Human-driven — this is the loop's own safety gate.**
+  The aggregator is defined (`DomainGate.psm1:68`) and exported (`:85`) but has
+  **zero callers**. Both the overseer and preflight `Import-Module` it and then
+  call leaf helpers directly. It is referenced only in `CONTEXT.md` and ADR-0003.
+  This is a **deletion-test question, not a refactor.** Either adopt it or remove
+  it — an exported deep module with no callers is a claim the codebase does not
+  honor. Note `CONTEXT.md:79` sits under *"Architecture seams (designed…)"*, i.e.
+  declared intent, so the drift is narrow: the aggregator went unadopted, not
+  that the callers are wrong.
+  *An earlier version of this entry also claimed preflight and the overseer read
+  protected paths from different sources. That was false and has been removed:
+  preflight reaches them via `Test-ProtectedDirty` → `$script:ProtectedPaths`
+  (`DomainGate.psm1:61`), the overseer does not read them at all, and
+  `supervised-loop-preflight.ps1:32` already says "single source of protected
+  paths". The remedy proposed was work already done.*
   *Blocked on: C1 extended to run Pester. There is no `DomainGate.Tests.ps1` and no
-  overseer test at all, so today this refactor has no regression net.*
+  overseer test at all, so today this has no regression net.*
 
 - [ ] 🔒 **C5a — Thread a `root` seam through `build_manifest.py` (part 1 of 4).**
   `scripts/build_manifest.py`. ~80 lines. **Human-driven.**
@@ -120,5 +140,17 @@ follows its precondition chain, not its interest level.
   docs only). This is a `/demerzel evolve` question, not a refactor — and
   cleanup candidates are usually false positives until verified against docs and
   consumer counts.
-- **17 scripts recomputing the repo root** two different ways despite `kit.ROOT`.
+- **21 scripts recomputing the repo root** two different ways despite `kit.ROOT`.
   Too small to spend a cycle on; fold into whichever entry touches the file.
+
+## agent-blackbox install-audit follow-ups
+
+`docs/harness-observability.md` (:36, :96) points here for these. They are
+tracked, not queued: the `loop-controls` and `response-quality` evidence credits
+live as **workflow step strings** inside `.github/workflows/agent-blackbox.yml`,
+which is in the protected-paths list. The supervised loop cannot edit it.
+
+- **Not loop-eligible by construction.** Closing these needs either an operator
+  workflow edit or a relaxation of the audit rule in `agent-blackbox` itself.
+  Both are human decisions, so neither becomes a `## Queue` entry — recording
+  them here is the whole obligation.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,124 @@
+# Backlog
+
+The queue `supervised-loop` pulls from. It picks **the smallest unchecked entry**,
+implements it, runs the oracle (`pwsh scripts/verify.ps1`), emits cycle evidence,
+and stops — one slice per cycle, no chaining.
+
+**This file is the ratification gate.** An entry lands here only via a merged PR, so
+a human has accepted it before any agent can pick it up. Adding an entry is the
+decision; checking it off is just bookkeeping.
+
+**Termination:** the loop is done when there are no unchecked entries. Not "until the
+architecture is clean" — that has no fixed point.
+
+## How to use
+
+- Entries are ordered; earlier ones are preconditions for later ones where noted.
+- Each entry must fit one cycle: **≤200 lines / ≤10 files** (600 absolute cap).
+- `supervised-loop` may only edit `documents`, `scripts/`, `state/`, `.claude/`.
+  It cannot touch `policies/`, `constitutions/`, `personas/`, `.github/workflows/`.
+- **Do not** delete an entry to skip it. Either do it, or record why not as an ADR so
+  future reviews stop re-proposing it (`docs/adr/`).
+- 🔒 marks entries that must **not** run unattended — they change the loop's own
+  safety gate or lack a regression net. A human drives those.
+
+## Provenance
+
+Candidates from an architecture review of `scripts/` (2026-07-20) using the
+`improve-codebase-architecture` vocabulary — module / interface / depth / seam /
+locality, with the deletion test applied to each. Ranked by the review; ordering below
+follows its precondition chain, not its interest level.
+
+---
+
+## Queue
+
+- [ ] **C1 — Run the Python test suite in the oracle.**
+  `scripts/verify.ps1`. ~10 lines, 1 file. **Precondition for everything below.**
+  The oracle runs `ConvertFrom-Json` over `*.json` plus one npm test. The 20
+  `scripts/test_*.py` modules run **only** in `governance-validate.yml` — so an
+  autonomous cycle can gut `demerzel_kit`, `aiw_budget_gate`, or `build_manifest`,
+  get a green `verify.ps1`, and commit. Add a `python -m unittest discover -s scripts
+  -p 'test_*.py'` block, guarded on `python` being present, failing on non-zero.
+  Converts 20 already-written test modules from decorative into load-bearing.
+  *Expect pre-existing red tests on first run — that is the finding, not a blocker.*
+  *Note: consider extending to Pester (`tests/powershell/`), which C3 depends on.*
+
+- [ ] **C6 — Finish the `demerzel_kit` migration for `compliance_report.py`.**
+  `scripts/compliance_report.py`. ~40 lines, 1–2 files. Low risk. Already a declared
+  to-do in `CONTEXT.md`. It still carries its own `_now_iso` and `_atomic_write` (a
+  hand-rolled duplicate of `kit.atomic_write`), and its docstring cites
+  `schemas/contracts/compliance-report.schema.json` while writing with **no
+  validation** — the same silent-corruption path `CONTEXT.md` describes for
+  `council_emit._write_verdict`. Replace with `kit.write_artifact(..., schema=...)`.
+  *Hazard: `write_artifact` raises where `_atomic_write` did not, so a currently
+  invalid report will start failing loudly. Run `--dry-run` against ix/tars/ga first
+  and confirm the schema matches what `build_report` emits.*
+
+- [ ] **C2 — Add `halt_state()` to `demerzel_kit`, mirroring PowerShell's `Test-HaltAll`.**
+  `scripts/demerzel_kit.py`, `run_afk_cycle.py`, `run_ml_feedback_cycle.py`,
+  `demerzel_halt.py`. ~60 lines, 4 files + 1 test. Do **after** C1.
+  `run_afk_cycle.halt_active()` and `run_ml_feedback_cycle._halt_active()` are
+  near-identical 16-line functions that say so in their own docstrings, with a third
+  partial copy of the expiry logic in `demerzel_halt.cmd_status`. Neither
+  schema-validates the marker (the PowerShell adapter does), and both hardcode the
+  path with no seam, so neither is testable. HALT-ALL is described in `CONTEXT.md` as
+  "the **only mandatory** cross-repo signal". Return a fact-shape
+  `{present, valid, active, reason, marker}`; callers keep their own decisions.
+  *Consistent with ADR-0003: `now` stays a per-call parameter, so temporal checks
+  remain at point of use.*
+
+- [ ] **C4a — Give `aiw_budget_gate` a public assembly entry point.**
+  `scripts/aiw_budget_gate.py`, `scripts/run_afk_cycle.py`. ~80 lines, 3 files.
+  The gate hides real depth (O_EXCL locking, ledger invariants, request
+  fingerprinting, receipt binding) but leaks it back out: the only in-process caller
+  must invoke the **private** `budget._load(budget.POLICY_PATH)` plus a module
+  constant, twice per issue, re-reading the same file. `main()` is the only code that
+  knows the correct assembly and is reachable only as a subprocess — which is why
+  `run_afk_cycle` catches bare `Exception` and invents a reason code
+  (`budget_preflight_error`) the gate never emits. Add `open_gate(...)` /
+  `reserve_request` / `release_job`; promote `_request_sha256` to public.
+  *Do not refactor `_lock` in this slice — a crash between acquire and the `finally`
+  wedges the ledger, and that path is untested.*
+
+- [ ] 🔒 **C3a — Make `supervised-loop-preflight.ps1` consume `Get-DomainGateState`.**
+  `scripts/supervised-loop-preflight.ps1`, `scripts/DomainGate.psm1`. ~40 lines.
+  **Human-driven — this is the loop's own safety gate.**
+  `Get-DomainGateState` is a genuinely deep module with **zero callers**: both the
+  overseer and preflight `Import-Module` it and then reach past it to leaf helpers.
+  `CONTEXT.md` claims these are "thin deciders that weigh those facts themselves" —
+  they are not. Worse, the two scripts read protected paths from **different sources**
+  (`baseline.json` vs `$script:ProtectedPaths`) and nothing checks they agree.
+  Start with preflight (the safest slice), single-sourcing on `Get-ProtectedPaths`.
+  *Blocked on: C1 extended to run Pester. There is no `DomainGate.Tests.ps1` and no
+  overseer test at all, so today this refactor has no regression net.*
+
+- [ ] 🔒 **C5a — Thread a `root` seam through `build_manifest.py` (part 1 of 4).**
+  `scripts/build_manifest.py`. ~80 lines. **Human-driven.**
+  ADR-0001's keystone — the derived manifest every README count, CI invariant and
+  sibling repo reads — is 545 lines with **no test file**, because `REPO` is a module
+  global all 9 harvesters reach for directly. There is no `root` parameter anywhere,
+  so no seam to test against a fixture. Introduce `root: Path` (defaulting to `REPO`)
+  through `harvest_inventory` + `_first_yaml_doc`.
+  *Stop rule: this slice must produce a **byte-identical** `governance-manifest.json`.
+  A non-empty diff means stop and escalate. Remaining parts (validators, fixture
+  tests, README-parser dedupe) are separate entries once this lands.*
+
+---
+
+## Deliberately not queued
+
+- **`council_emit` vs `.github/scripts/llm_call.sh` provider drift.** Real and
+  confirmed — the two have already diverged on model ids (shell pins
+  `claude-sonnet-4`/`gemini-2.0-flash`, Python pins `claude-opus-4-8`/
+  `gemini-2.5-flash`) and on error contracts. But the shell half lives under
+  `.github/`, at or past the loop's edit boundary. Needs a human and a plan, not a
+  cycle.
+- **Possible dead modules** — `aiw_lane_selector.py`, `aiw_prompt_pack.py`,
+  `poincare_roadmap.py`, `seldon_intelligence_dry_run.py`,
+  `streeling_tracer_bullet.py`, `planner_*.py` have no production callers (tests and
+  docs only). This is a `/demerzel evolve` question, not a refactor — and
+  cleanup candidates are usually false positives until verified against docs and
+  consumer counts.
+- **17 scripts recomputing the repo root** two different ways despite `kit.ROOT`.
+  Too small to spend a cycle on; fold into whichever entry touches the file.


### PR DESCRIPTION
## The missing link

`supervised-loop` picks "the smallest unchecked entry in `BACKLOG.md` (when present)". **`BACKLOG.md` did not exist** — so the bounded executor had nothing to pull from. That, not a missing detector, was the actual gap between candidate generation and execution.

This creates it, populated from a real architecture review of `scripts/` (module / interface / depth / seam / locality, deletion test applied to each). **Six candidates**, ordered by precondition chain rather than interest.

## Why this shape, rather than "make the skill model-invocable and loop it"

You asked whether we could loop `improve-codebase-architecture` until the architecture is clean. I'd argue the literal version is the wrong target, for three reasons:

1. **"Until clean" has no fixed point.** Architecture candidates are tradeoffs, not defects — there is always another refactor. The loop would either never stop or stop when the LLM says so, which is the "agents fake completion" failure. **"Until no unchecked entries" terminates.**
2. **The skill is deliberately human-gated** — it presents candidates and asks which to explore. Pocock is explicit that it is *not* an AFK skill. That gate is **preserved, not removed**: it moves to the PR that adds entries here. **Merging this PR is the ratification.**
3. **Model-invocable would leak its description into every context window**, re-inflating the instruction budget #775 just reduced.

## Ordering is a dependency chain, not a ranking

**C1 is first because it is a precondition, not because it is interesting.** The oracle does not run the Python test suite — the 20 `scripts/test_*.py` modules run only in `governance-validate.yml`. So an autonomous cycle can gut `demerzel_kit`, `aiw_budget_gate`, or `build_manifest`, get a green `verify.ps1`, and commit. Every other entry's safety argument rests on fixing that first.

(Related but distinct from #778, which fixes the oracle *failing on valid JSON*. #778 makes it run; C1 makes it mean something.)

## Two entries must not run unattended 🔒

- **C3a** changes the loop's **own safety gate** (`supervised-loop-preflight.ps1`) and has no regression net — there is no `DomainGate.Tests.ps1` and no overseer test, and `verify.ps1` never invokes Pester.
- **C5a** touches the 545-line ADR-0001 keystone that has **no test file**. Its stop rule is a byte-identical `governance-manifest.json`; any diff means stop.

## Deliberately not queued

The `council_emit` ↔ `llm_call.sh` provider drift (real and confirmed — they've already diverged on model ids and error contracts — but its other half lives under `.github/`, past the loop's edit boundary); a set of **possible** dead modules (an `/demerzel evolve` question, and cleanup candidates are usually false positives until verified); and 17 scripts recomputing the repo root (too small to spend a cycle on).

## Reviewing this

The entries are the decision. If one is wrong, **reject it here** rather than deleting it later — and if it's wrong for a reason a future review would need, the backlog asks for an ADR so the same candidate stops being re-proposed. That's the anti-churn mechanism, and it's already how all 4 existing ADRs came to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)