### PR TITLE
fix(ixql): resolve the stdin/format_spec parser conflict (1 of 2)

### DIFF
--- a/tree-sitter-ixql/grammar.js
+++ b/tree-sitter-ixql/grammar.js
@@ -120,11 +120,18 @@ module.exports = grammar({
         seq("cron", "(", $.string_literal, ")"),
         // prec.right: on `stdin csv` the generator cannot decide with one token
         // of lookahead whether to reduce `stdin` and treat `csv` as the start of
-        // a new source, or shift `csv` into format_spec. Only the second reading
-        // is reachable -- data_source appears in exactly three places
-        // (simple_pipeline, fan_in, assertion_subject) and every one separates
-        // sources with an arrow or a comma, so two sources are never adjacent.
-        // Preferring the shift picks the sole legal parse.
+        // a new source, or shift `csv` into format_spec.
+        //
+        // Shifting is the only legal reading. This choice can only affect a
+        // program if some token that may FOLLOW `stdin` is also a format_spec
+        // token (json/csv/text/binary). The complete follow set, over every
+        // context reaching streaming_source_expr:
+        //   simple_pipeline      -> arrow, or end
+        //   fan_in_expr          -> ',' or ')'
+        //   assertion_subject    -> arrow, or end
+        //   reactive_source_expr -> '=>'          (does NOT go via data_source)
+        // None is a format_spec token, so preferring the shift can never steal a
+        // token belonging to a following construct. No valid program reparses.
         prec.right(seq("stdin", optional($.format_spec))),
         seq("subscribe", "(", $.string_literal, ",", $.string_literal, ")"),
         seq("cdc", "(", $.string_literal, ",", $.string_literal, ")"),

--- a/tree-sitter-ixql/grammar.js
+++ b/tree-sitter-ixql/grammar.js
@@ -118,7 +118,14 @@ module.exports = grammar({
         seq("sse", "(", $.string_literal, ")"),
         seq("webhook", "(", $.provider, ",", $.string_literal, ")"),
         seq("cron", "(", $.string_literal, ")"),
-        seq("stdin", optional($.format_spec)),
+        // prec.right: on `stdin csv` the generator cannot decide with one token
+        // of lookahead whether to reduce `stdin` and treat `csv` as the start of
+        // a new source, or shift `csv` into format_spec. Only the second reading
+        // is reachable -- data_source appears in exactly three places
+        // (simple_pipeline, fan_in, assertion_subject) and every one separates
+        // sources with an arrow or a comma, so two sources are never adjacent.
+        // Preferring the shift picks the sole legal parse.
+        prec.right(seq("stdin", optional($.format_spec))),
         seq("subscribe", "(", $.string_literal, ",", $.string_literal, ")"),
         seq("cdc", "(", $.string_literal, ",", $.string_literal, ")"),
         seq("grpc", "(", $.string_literal, ",", $.string_literal, ")"),


### PR DESCRIPTION
## What this fixes

One of two conflicts that prevent `tree-sitter generate` from running at all. **This PR does not make the grammar generate** â€” see the blocker below.

## The conflict

```
Unresolved conflict for symbol sequence:

  'stdin'  â€¢  'csv'  â€¦

  1:  (streaming_source_expr  'stdin'  â€¢  format_spec)
  2:  (streaming_source_expr  'stdin')  â€¢  'csv'  â€¦
```

With one token of lookahead the generator cannot tell whether `csv` starts a `format_spec` for `stdin`, or is the beginning of a new source (`file_source` also starts with `csv`).

## Why `prec.right` is the correct resolution, not just a silencer

Interpretation 2 is **unreachable**. `data_source` is referenced in exactly three places:

| Rule | How sources are separated |
|---|---|
| `simple_pipeline` | `data_source` then `repeat(seq(arrow, pipeline_stage))` â€” an arrow follows |
| `fan_in` | `data_source, repeat1(seq(",", data_source))` â€” commas |
| `assertion_subject` | single `data_source` |

Two data sources are never adjacent in any legal program, so `stdin csv` has exactly one valid reading â€” stdin carrying a csv format, which is what `seq("stdin", optional($.format_spec))` was written to express. Preferring the shift selects the only parse the language permits.

## Measured

Before â€” `generate` exits 1 on `'stdin' â€¢ 'csv'`.
After â€” that conflict is gone; `generate` still exits 1, now on `identifier â€¢ '.'`.

## Blocker â€” this is where I stopped

The remaining conflict is between `namespace_path` (`identifier ("." identifier)*`) and `tool_invocation` (`namespace_path "." identifier "(" â€¦`). For `a.b.c()` the namespace is greedy and consumes the tool name.

Unlike the `stdin` case, **both resolutions are legal and produce different parse trees** â€” declaring a GLR conflict keeps the `namespace_path` node, restructuring `tool_invocation` removes it from tool-call trees. Two facts make that an owner decision rather than an annotation:

- The file header names **ix-lsp and a VS Code extension** as consumers, so CST shape is a published interface.
- The grammar is **derived from `grammars/sci-ml-pipelines.ebnf`**, which is the upstream spec â€” changing the tree-sitter shape without reconciling there puts the two out of sync.

I also probed the GLR route, and **my first description of that probe was wrong** — corrected here rather than left standing, since it would otherwise become the rationale of record in #780.

I declared `[[$.namespace_path, $.tool_invocation]]` and reported that the conflict "reappeared one level down." Review re-ran it: the output is **byte-identical to declaring nothing at all**. That pair does not address the conflict, because the conflict is `namespace_path` against its own generated `namespace_path_repeat1` — a self-conflict, which is why tree-sitter suggests `[[$.namespace_path]]`, not a pair.

The conclusion survives and is better supported than I had it. Declaring what the tool actually suggests **does** cascade — review measured a third, distinct conflict appearing at `binding_statement • 'csv'`. So #780 is a genuine owner decision rather than a one-line annotation, but on evidence I had not gathered.

Filed as #780.

## Context

Surfaced by #778, which stopped `verify.ps1` discarding native command exit codes. `npm test` had been exiting 1 while the oracle exited 0, so this grammar has likely never generated and nothing noticed.

