### PR TITLE
fix(ideation): stop SIGPIPE killing the loop as the backlog grows (#704)

### DIFF
--- a/.github/workflows/demerzel-ideation.yml
+++ b/.github/workflows/demerzel-ideation.yml
@@ -88,21 +88,24 @@ jobs:
           RECENT=$(git log --oneline -10)
 
           # Recent changes (what files changed)
-          CHANGED=$(git diff --name-only HEAD~5..HEAD 2>/dev/null | head -30)
+          # `shell: bash` runs with `set -eo pipefail`, so a `| head -N` that closes
+          # the pipe early kills the writer with SIGPIPE and fails the step with 141.
+          # Use each tool's own limit where it has one; tolerate the pipe where it does not.
+          CHANGED=$( { git diff --name-only HEAD~5..HEAD 2>/dev/null || true; } | head -30)
 
           # Open issues across all repos
-          DEMERZEL_ISSUES=$(gh issue list --repo GuitarAlchemist/Demerzel --state open --json number,title --jq '.[].title' | head -15)
-          IX_ISSUES=$(gh issue list --repo GuitarAlchemist/ix --state open --json number,title --jq '.[].title' 2>/dev/null | head -5)
-          TARS_ISSUES=$(gh issue list --repo GuitarAlchemist/tars --state open --json number,title --jq '.[].title' 2>/dev/null | head -5)
-          GA_ISSUES=$(gh issue list --repo GuitarAlchemist/ga --state open --json number,title --jq '.[].title' 2>/dev/null | head -5)
+          DEMERZEL_ISSUES=$(gh issue list --repo GuitarAlchemist/Demerzel --state open --limit 15 --json number,title --jq '.[].title')
+          IX_ISSUES=$(gh issue list --repo GuitarAlchemist/ix --state open --limit 5 --json number,title --jq '.[].title' 2>/dev/null)
+          TARS_ISSUES=$(gh issue list --repo GuitarAlchemist/tars --state open --limit 5 --json number,title --jq '.[].title' 2>/dev/null)
+          GA_ISSUES=$(gh issue list --repo GuitarAlchemist/ga --state open --limit 5 --json number,title --jq '.[].title' 2>/dev/null)
 
           # Open PRs
-          GA_PRS=$(gh pr list --repo GuitarAlchemist/ga --state open --json number,title --jq '.[].title' 2>/dev/null | head -5)
+          GA_PRS=$(gh pr list --repo GuitarAlchemist/ga --state open --limit 5 --json number,title --jq '.[].title' 2>/dev/null)
 
           # Conscience state
           CONSCIENCE=""
           if [ -f "state/conscience/weekly/2026-03-17-weekly.report.json" ]; then
-            CONSCIENCE=$(jq -r '.self_reflection' state/conscience/weekly/*.report.json 2>/dev/null | head -5)
+            CONSCIENCE=$( { jq -r '.self_reflection' state/conscience/weekly/*.report.json 2>/dev/null || true; } | head -5)
           fi
 
           # Build context
@@ -230,7 +233,8 @@ jobs:
           fi
 
           # Extract JSON from response
-          REVIEW_JSON=$(echo "$REVIEW_TEXT" | sed -n '/\[/,/\]/p' | head -50)
+          # Same pipefail/SIGPIPE hazard as the context step above.
+          REVIEW_JSON=$( { echo "$REVIEW_TEXT" | sed -n '/\[/,/\]/p' || true; } | head -50)
           echo "$REVIEW_JSON" > /tmp/review.json
 
           APPROVED=$(echo "$REVIEW_JSON" | jq '[.[] | select(.verdict == "APPROVE")] | length' 2>/dev/null || echo "0")


### PR DESCRIPTION
Fixes #704.

## Diagnosis

`demerzel-ideation.yml` has failed **6 consecutive runs** with **exit 141** = `128 + 13` = **SIGPIPE**.

```
$ gh run list --workflow demerzel-ideation.yml --limit 6
2026-07-19T03:21  push  failure
2026-07-19T03:13  push  failure
2026-07-19T03:05  push  failure
2026-07-19T02:33  push  failure
2026-07-19T02:19  push  failure
2026-07-18T22:12  push  failure

##[error]Process completed with exit code 141
```

`defaults.run.shell: bash` runs every step with `set -eo pipefail`. The "Gather ecosystem context" step piped several commands into `head -N`. When the writer produces more lines than `head` will read, `head` exits, the writer takes SIGPIPE, and `pipefail` turns that into a failed step.

## Why it started failing now — the interesting part

**The loop broke because the backlog grew.**

`gh issue list ... | head -15` *cannot* SIGPIPE while fewer than 15 issues exist. There are now 65. So this ran green for months and then failed six times in a row with no change to the workflow, the runner, or the code.

That makes it a member of this repo's recurring family — a mechanism that works until a threshold is crossed silently, then fails in a way nobody is watching. Same shape as the oracle exiting 0 with a failing test (#778) and the overseer reporting green from a stale artifact (#782).

## Fix

Remove the pipe where the tool has its own limit, rather than suppressing the signal:

| Before | After |
|---|---|
| `gh issue list ... \| head -15` | `gh issue list --limit 15 ...` |
| `gh pr list ... \| head -5` | `gh pr list --limit 5 ...` |

Where there is no native limit (`git diff`, `jq`), the writer is wrapped so a closed pipe cannot fail the step:

```bash
CHANGED=$( { git diff --name-only HEAD~5..HEAD 2>/dev/null || true; } | head -30)
```

Also guarded the identical construct in the review step (~line 236) — same latent bug, same file, would have surfaced the same way.

## Verification

- YAML parses; the single job `generate-ideas` is intact.
- No remaining unguarded `| head` in the file.
- The diagnosis is grounded in the exit code, the documented `shell: bash` behaviour, and the issue count crossing the limit — but **I cannot execute a GitHub runner**, so the green run is the real proof. Worth watching the next push-triggered run rather than assuming.

## Not fixed here

`demerzel-capability-expansion.yml` has failed **every scheduled run since 2026-06-22** and needs its own diagnosis — tracked in #703. Its failure mode may differ; I have not assumed it is the same bug.
