### PR TITLE
fix(ixql): make the grammar generate — GLR conflicts, corpus, oracle repair (closes #780)

### DIFF
--- a/tree-sitter-ixql/.gitignore
+++ b/tree-sitter-ixql/.gitignore
@@ -1,0 +1,46 @@
+# Rust artifacts
+target/
+
+# Node artifacts
+build/
+prebuilds/
+node_modules/
+*.tgz
+
+# Swift artifacts
+.build/
+Package.resolved
+
+# Go artifacts
+_obj/
+
+# Python artifacts
+.venv/
+dist/
+*.egg-info
+*.whl
+
+# C artifacts
+*.a
+*.so
+*.so.*
+*.dylib
+*.dll
+*.pc
+
+# Example dirs
+/examples/*/
+
+# Grammar volatiles
+*.wasm
+*.obj
+*.o
+
+# Generated parser -- reproduced by `npm test` (which runs `tree-sitter generate`).
+# Not committed: Demerzel holds governance artifacts, not runtime code.
+src/
+
+# node-gyp build artifacts
+parser.exp
+parser.lib
+*.obj

--- a/tree-sitter-ixql/grammar.js
+++ b/tree-sitter-ixql/grammar.js
@@ -27,6 +27,34 @@ module.exports = grammar({
 
   word: ($) => $.identifier,
 
+  // GLR conflicts. Every entry here is a place where one token of lookahead is
+  // not enough to decide a reduction; tree-sitter forks, parses both ways, and
+  // keeps the branch that yields a valid tree. We prefer this over prec.right,
+  // which hard-codes one interpretation and silently misparses the other. Each
+  // conflict below is either a rule against its own optional/repeat boundary (a
+  // self-conflict, written as a single-rule entry) or two rules that share a
+  // prefix. They were surfaced one at a time by `tree-sitter generate`; the set
+  // is minimal in the sense that removing any one reintroduces a generate error.
+  //
+  //   namespace_path        `a.b.c` — extend the path vs. stop for tool_invocation's trailing `.method`
+  //   streaming_source_expr `stdin` with an optional trailing format_spec, before the next statement
+  //   output_sink_expr      `stdout` with an optional trailing format_spec (the `stdin` case's twin)
+  //   preprocessing_stage   a stage's optional trailing clauses vs. the next `->` stage
+  //   guard_conjunction     `a && b && c` associativity
+  //   simple_pipeline       a bare data_source vs. a data_source that begins an arrow chain
+  //   conditional_step_expr dangling-else: bind `else` to the nearest `if`
+  //   pipeline_expr/ensemble_pipeline  a simple_pipeline alone vs. the first arm of an ensemble
+  conflicts: ($) => [
+    [$.namespace_path],
+    [$.streaming_source_expr],
+    [$.output_sink_expr],
+    [$.preprocessing_stage],
+    [$.guard_conjunction],
+    [$.simple_pipeline],
+    [$.conditional_step_expr],
+    [$.pipeline_expr, $.ensemble_pipeline],
+  ],
+
   rules: {
     // =========================================================
     // Top-level: a document is a sequence of statements
@@ -39,7 +67,12 @@ module.exports = grammar({
           $.reactive_pipeline_statement,
           $.mcp_pipeline_statement,
           $.assertion_statement,
-          $.binding_statement,
+          // binding_statement is intentionally NOT a top-level statement. The
+          // spec (sci-ml-pipelines.ebnf) defines `binding_step` only as an
+          // mcp_step, and mcp_step_expr already includes it. Listing it here as
+          // well made `identifier <- ...` reducible two ways and blocked
+          // generate. Removed to match the spec; bindings still parse inside
+          // MCP pipelines.
           $.comment,
         ),
       ),
@@ -118,21 +151,14 @@ module.exports = grammar({
         seq("sse", "(", $.string_literal, ")"),
         seq("webhook", "(", $.provider, ",", $.string_literal, ")"),
         seq("cron", "(", $.string_literal, ")"),
-        // prec.right: on `stdin csv` the generator cannot decide with one token
-        // of lookahead whether to reduce `stdin` and treat `csv` as the start of
-        // a new source, or shift `csv` into format_spec.
-        //
-        // Shifting is the only legal reading. This choice can only affect a
-        // program if some token that may FOLLOW `stdin` is also a format_spec
-        // token (json/csv/text/binary). The complete follow set, over every
-        // context reaching streaming_source_expr:
-        //   simple_pipeline      -> arrow, or end
-        //   fan_in_expr          -> ',' or ')'
-        //   assertion_subject    -> arrow, or end
-        //   reactive_source_expr -> '=>'          (does NOT go via data_source)
-        // None is a format_spec token, so preferring the shift can never steal a
-        // token belonging to a following construct. No valid program reparses.
-        prec.right(seq("stdin", optional($.format_spec))),
+        // `stdin` may carry an optional format_spec. Because source_file is a
+        // bare repeat with no statement terminator, a format_spec keyword (csv,
+        // json, ...) can also begin the *next* statement (file_source starts
+        // with `csv`/`json`/`parquet`). One token of lookahead cannot tell
+        // `stdin csv(...)` (one source) from `stdin` / `csv(...)` (two
+        // statements). The [$.streaming_source_expr] conflict lets the parser
+        // decide by which reading actually yields a valid tree.
+        seq("stdin", optional($.format_spec)),
         seq("subscribe", "(", $.string_literal, ",", $.string_literal, ")"),
         seq("cdc", "(", $.string_literal, ",", $.string_literal, ")"),
         seq("grpc", "(", $.string_literal, ",", $.string_literal, ")"),
@@ -561,8 +587,12 @@ module.exports = grammar({
     gated_tool_expr: ($) =>
       seq("when", $.mog_guard, ":", $.mcp_step_expr),
 
+    // Spec: `binding_step ::= identifier "<-" mcp_step`. The earlier
+    // `choice($.mcp_step_expr, $.pipeline_expr)` widened the RHS beyond the
+    // spec and made a binding indistinguishable from a pipeline_statement's
+    // optional `identifier <-` prefix. Narrowed to the spec form.
     binding_statement: ($) =>
-      seq($.identifier, "<-", choice($.mcp_step_expr, $.pipeline_expr)),
+      seq($.identifier, "<-", $.mcp_step_expr),
 
     conditional_step_expr: ($) =>
       seq(
@@ -631,8 +661,17 @@ module.exports = grammar({
         repeat(seq($.arrow, $.assertion_check)),
       ),
 
+    // Spec lists data_source | pipeline_expr | ... | identifier as alternatives,
+    // but they are mutually reducible: pipeline_expr -> simple_pipeline is a
+    // data_source followed by an (optionally empty) arrow chain, and data_source
+    // already covers a bare identifier. Keeping all three as direct choices made
+    // every assertion subject ambiguous. pipeline_expr subsumes the others, so a
+    // subject like `csv("train.csv")` or `random_forest -> f1_score` still parses;
+    // it simply nests one level deeper. Since this grammar had never generated,
+    // there was no prior CST for consumers to depend on -- this is the first
+    // shape, not a breaking change to an existing one.
     assertion_subject: ($) =>
-      choice($.data_source, $.identifier, $.pipeline_expr),
+      $.pipeline_expr,
 
     assertion_check: ($) =>
       seq(

--- a/tree-sitter-ixql/package.json
+++ b/tree-sitter-ixql/package.json
@@ -28,9 +28,9 @@
     "tree-sitter-cli": "^0.23.0"
   },
   "scripts": {
-    "build": "tree-sitter generate && node-gyp build",
-    "generate": "tree-sitter generate",
-    "test": "tree-sitter test",
+    "build": "tree-sitter generate --no-bindings && node-gyp build",
+    "generate": "tree-sitter generate --no-bindings",
+    "test": "tree-sitter generate --no-bindings && tree-sitter test",
     "lint": "tree-sitter generate --report-states-for-rule source_file"
   },
   "tree-sitter": [

--- a/tree-sitter-ixql/queries/highlights.scm
+++ b/tree-sitter-ixql/queries/highlights.scm
@@ -81,8 +81,8 @@
   "subscribe"
   "cdc"
   "grpc"
-  "governance_state"
-  "git_history"
+  (governance_state_source)
+  (git_history_source)
   "mcp_tool_output"
 ] @function.builtin
 
@@ -284,8 +284,6 @@
   "alert"
   "github"
   "notify"
-  "mcp_register"
-  "mcp_invoke"
 ] @function.builtin
 
 ; Sink target providers

--- a/tree-sitter-ixql/test/corpus/ixql.txt
+++ b/tree-sitter-ixql/test/corpus/ixql.txt
@@ -1,0 +1,192 @@
+========================================
+stdin followed by a csv statement parses as two statements
+========================================
+
+stdin
+csv("f.csv")
+
+---
+
+(source_file
+  (pipeline_statement
+    (pipeline_expr
+      (simple_pipeline
+        (data_source
+          (streaming_source_expr)))))
+  (pipeline_statement
+    (pipeline_expr
+      (simple_pipeline
+        (data_source
+          (file_source
+            (string_literal)))))))
+
+========================================
+stdin with an explicit format spec
+========================================
+
+stdin csv
+
+---
+
+(source_file
+  (pipeline_statement
+    (pipeline_expr
+      (simple_pipeline
+        (data_source
+          (streaming_source_expr
+            (format_spec)))))))
+
+========================================
+dotted tool invocation
+========================================
+
+ix.ml.deep.classify(x)
+
+---
+
+(source_file
+  (mcp_pipeline_statement
+    (mcp_step_expr
+      (tool_invocation
+        (namespace_path
+          (identifier)
+          (identifier)
+          (identifier))
+        (identifier)
+        (arg_list
+          (expression
+            (identifier)))))))
+
+========================================
+mcp binding to a tool invocation
+========================================
+
+result <- context7.resolve("react")
+
+---
+
+(source_file
+  (mcp_pipeline_statement
+    (mcp_step_expr
+      (binding_statement
+        (identifier)
+        (mcp_step_expr
+          (tool_invocation
+            (namespace_path
+              (identifier))
+            (identifier)
+            (arg_list
+              (expression
+                (string_literal)))))))))
+
+========================================
+simple file pipeline
+========================================
+
+csv("data.csv") -> random_forest
+
+---
+
+(source_file
+  (pipeline_statement
+    (pipeline_expr
+      (simple_pipeline
+        (data_source
+          (file_source
+            (string_literal)))
+        (arrow)
+        (pipeline_stage
+          (model_stage))))))
+
+========================================
+assertion over a data source
+========================================
+
+assert input_quality: csv("train.csv") -> assert_check(not_null)
+
+---
+
+(source_file
+  (assertion_statement
+    (identifier)
+    (assertion_pipeline
+      (assertion_subject
+        (pipeline_expr
+          (simple_pipeline
+            (data_source
+              (file_source
+                (string_literal)))
+            (arrow)
+            (pipeline_stage
+              (assertion_check
+                (assertion_condition)))))))))
+
+========================================
+assertion over a model-stage chain
+========================================
+
+assert model_quality: random_forest -> f1_score
+
+---
+
+(source_file
+  (assertion_statement
+    (identifier)
+    (assertion_pipeline
+      (assertion_subject
+        (pipeline_expr
+          (simple_pipeline
+            (data_source
+              (identifier))
+            (arrow)
+            (pipeline_stage
+              (evaluation_stage))))))))
+
+========================================
+parallel tool fanout
+========================================
+
+parallel(a.b(x), c.d(y))
+
+---
+
+(source_file
+  (mcp_pipeline_statement
+    (mcp_step_expr
+      (parallel_tools_expr
+        (tool_invocation
+          (namespace_path
+            (identifier))
+          (identifier)
+          (arg_list
+            (expression
+              (identifier))))
+        (tool_invocation
+          (namespace_path
+            (identifier))
+          (identifier)
+          (arg_list
+            (expression
+              (identifier))))))))
+
+========================================
+reactive webhook to sink
+========================================
+
+webhook(github, "push") => csv("f.csv") => stdout json
+
+---
+
+(source_file
+  (reactive_pipeline_statement
+    (reactive_source_expr
+      (streaming_source_expr
+        (provider)
+        (string_literal)))
+    (pipeline_expr
+      (simple_pipeline
+        (data_source
+          (file_source
+            (string_literal)))))
+    (output_sink_expr
+      (format_spec))))


### PR DESCRIPTION
## What this fixes

The `tree-sitter-ixql` grammar **had never generated**. `src/` never existed, `tree-sitter test` ran against an empty corpus, and `scripts/verify.ps1` swallowed the failure (fixed in #778). Once #778 made the exit code honest, the oracle went red and stayed red — the grammar could not be built at all. This makes it build, and locks that in.

`#788` fixed the first of two reported conflicts with `prec.right`. That approach is **superseded here** — see below.

## The core correction: `prec.right` → GLR conflict

`#788` merged `prec.right(seq("stdin", optional($.format_spec)))`. Its in-code comment argued the shift is always safe by enumerating what can follow `stdin` *within an expression*. It omitted that `source_file` is a bare `repeat` with **no statement terminator**, and `format_spec` keywords (`csv`, `json`, …) also begin the *next* statement (`file_source` starts with `csv(`). So:

```
stdin
csv("f.csv")
```

is a valid **two-statement** program that `prec.right` turns into a parse error — it greedily shifts `csv` into `stdin`'s format_spec. `prec.right` hard-codes one reading; the right tool is a GLR conflict that lets the parser keep whichever reading actually yields a valid tree. Corpus test #1 is exactly this input, now passing.

> Honesty note: I could not build a *generating* `prec.right` variant of the full grammar to measure the ERROR directly (the grammar didn't generate until the other conflicts were also resolved). The claim that `prec.right` breaks the two-statement case is reasoned from the follow-set + verified structurally; the GLR version demonstrably parses it (exit 0, two sibling `pipeline_statement` nodes).

## The rest of the conflict chain

Removing the first conflict revealed a chain, each surfaced one at a time by `tree-sitter generate`. The final `conflicts` set is **minimal** — removing any entry reintroduces a generate error — and every entry is documented inline. Three of them were not just LR boundaries but **spec divergences** the port introduced over `grammars/sci-ml-pipelines.ebnf`:

| Divergence | Spec says | Port had | Fix |
|---|---|---|---|
| `binding_statement` at top level | `binding_step` is an `mcp_step` only | also a `source_file` statement | removed from `source_file` |
| `binding_statement` RHS | `identifier "<-" mcp_step` | `choice(mcp_step_expr, pipeline_expr)` | narrowed to `mcp_step_expr` |
| `assertion_subject` | `data_source \| pipeline_expr \| … \| identifier` | all three as direct choices | collapsed to `pipeline_expr` (subsumes the mutually-reducible others) |

**On the CST-consumer concern #780 raised:** it's moot. `src/` never existed, so the parser has never emitted a CST. There is no published tree shape for `ix-lsp` to depend on — this is the *first* shape, not a breaking change to an existing one.

## Corpus tests — NEW

`test/corpus/ixql.txt`: 9 cases derived from the spec's own worked examples, including the two-statement `stdin` regression guard and a model-stage assertion subject. Before this, `tree-sitter test` asserted nothing.

## Two more silent failures found and fixed along the way

- **`queries/highlights.scm`** referenced nodes that don't exist (`governance_state`/`git_history` as strings vs. the `(…_source)` named nodes; `mcp_register`/`mcp_invoke`, which the port never implemented). Only checkable once `generate` worked.
- **`scripts/verify.ps1`** JSON leg crashed on the committed `package-lock.json`: npm lockfileVersion ≥ 2 keys the root package on `""`, which `ConvertFrom-Json` rejects without `-AsHashtable`. The oracle died on a *valid* JSON file before reaching the npm leg. Same silent-failure family as #778/#782. `-AsHashtable` tolerates the empty key and still rejects malformed JSON.
- **`package.json`**: `test` now runs `tree-sitter generate --no-bindings && tree-sitter test` so a non-generating grammar fails loudly. `--no-bindings` stops `generate` from **overwriting `package.json`'s scripts** (it rewrote `test` to a non-existent `bindings/node/*_test.js` path — which would have re-hidden the failure). Generated `src/` is gitignored: reproduced by `npm test`, and Demerzel holds governance artifacts, not runtime code.

## Verification

From a **clean checkout** (no `node_modules`, no `src/`):

```
pwsh -NoProfile -File scripts/verify.ps1   →  exit 0
  9/9 corpus tests ✓
```

The first green oracle in this repo's history — green because real tests pass, not because nothing ran.

Closes #780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)