### PR TITLE
docs: correct skill count five→four in agentic-engineering (closes #799)

### DIFF
--- a/docs/methodology/agentic-engineering-2026-07.md
+++ b/docs/methodology/agentic-engineering-2026-07.md
@@ -83,7 +83,8 @@ are all installed and live**, alongside `git-guardrails-claude-code` and `ubiqui
 
 The accurate finding is a one-liner: the **project-scoped** copy under `.claude/skills/` is stale
 while the newer generation sits at **user scope**. The fix is to sync, not to rebuild. Acting on the
-original table would have duplicated five working skills — in a document arguing for a leaner surface.
+original table would have duplicated four working skills (`implement`, `triage`, `handoff`, `review`) —
+in a document arguing for a leaner surface.
 **Only `wayfinder` is genuinely absent.**
 
 **The current flow:**


### PR DESCRIPTION
`docs/methodology/agentic-engineering-2026-07.md:86` said acting on the original adoption table "would have duplicated **five** working skills". It was **four**.

The table had exactly four items proposing to rebuild already-installed skills — A1 `implement`, P2 `triage`, P4 `handoff`, W2 `review`. `prototype` appears only as a §1 `[NEW]` prose bullet, never as a table row (verified against the pre-correction table `0d765e6`), so it was never something the table proposed rebuilding. The error is a skills-*discussed* vs adoption-*items* conflation: five were discussed as installed in §1, but only four were adoption items.

**Fix:** `five` → `four`, and name the four inline so the count and the list can't drift apart again — which is exactly how the error arose. This is the sentence a reader would cite to justify the anti-sprawl rule, so its number should be right.

Found in round-3 adversarial review of #771 during #775 work. #775 corrects the same claim in `harness-driven-development.md`; fixing it here keeps the two files from disagreeing once #775 merges.

Closes #799.

🤖 Generated with [Claude Code](https://claude.com/claude-code)