### PR TITLE
fix(schemas): resolvable http draft-07 metaschema + regression guard (closes #792)

### DIFF
--- a/schemas/conscience-pattern.schema.json
+++ b/schemas/conscience-pattern.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "conscience-pattern.schema.json",
   "title": "Conscience Pattern",
   "description": "Detected pattern across accumulated conscience signals — clusters of related moral concerns",

--- a/schemas/conscience-signal.schema.json
+++ b/schemas/conscience-signal.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "conscience-signal.schema.json",
   "title": "Conscience Signal",
   "description": "A discomfort signal logged by Demerzel's proto-conscience",

--- a/schemas/conscience-weekly-report.schema.json
+++ b/schemas/conscience-weekly-report.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "conscience-weekly-report.schema.json",
   "title": "Conscience Weekly Report",
   "description": "Weekly conscience report for Demerzel governance — posted to GitHub Discussions",

--- a/schemas/council-verdict.schema.json
+++ b/schemas/council-verdict.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "council-verdict.schema.json",
   "title": "LLM Council Verdict",
   "description": "A structured verdict from the LLM council reviewing a high-risk or borderline-confidence change",

--- a/schemas/course-production.schema.json
+++ b/schemas/course-production.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "course-production.schema.json",
   "title": "Course Production Pipeline Run",
   "description": "Log entry for a complete course production pipeline: research → outline → content → translation → review → publish",

--- a/schemas/driver-state.schema.json
+++ b/schemas/driver-state.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "driver-state.schema.json",
   "title": "Driver State",
   "description": "Persistent state for the autonomous driver — lock, schedule, health, and strategy",

--- a/schemas/loop-health.schema.json
+++ b/schemas/loop-health.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "loop-health.schema.json",
   "title": "Loop Health Registry",
   "description": "Universal ecosystem-freshness registry: every scheduled producer must prove liveness or be deliberately disabled for a bounded, mechanically verified window. The monitor turns the board red for dead, failed, stale, activation-mismatched, or unregistered loops.",

--- a/schemas/loop-state.schema.json
+++ b/schemas/loop-state.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "loop-state.schema.json",
   "title": "Loop State",
   "description": "Tracks an autonomous loop's iterations, stall detection, and governance decisions",

--- a/schemas/octopus-review-request.schema.json
+++ b/schemas/octopus-review-request.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "octopus-review-request.schema.json",
   "title": "Repo-scoped Octopus review request",
   "description": "Identity and required-provider contract for one exact Git diff review run.",

--- a/schemas/octopus-review-result.schema.json
+++ b/schemas/octopus-review-result.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "octopus-review-result.schema.json",
   "title": "Repo-scoped Octopus provider result",
   "description": "Current-run provider outcome and evidence consumed by the fail-closed delivery gate.",

--- a/schemas/research-anomaly.schema.json
+++ b/schemas/research-anomaly.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "research-anomaly.schema.json",
   "title": "Research Anomaly",
   "description": "Anomaly entry logged when a research cycle produces F, U, or C outcomes",

--- a/schemas/research-cycle.schema.json
+++ b/schemas/research-cycle.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "research-cycle.schema.json",
   "title": "Research Cycle Log",
   "description": "Log entry for a single research cycle executed by the Streeling autoresearch loop",

--- a/schemas/research-weights.schema.json
+++ b/schemas/research-weights.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "research-weights.schema.json",
   "title": "Research Weight Profile",
   "description": "Per-department probability weights for the scientific method grammar productions",

--- a/schemas/resilience-metric.schema.json
+++ b/schemas/resilience-metric.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/GuitarAlchemist/Demerzel/schemas/resilience-metric.schema.json",
   "title": "Governance Resilience Metric",
   "description": "Schema for resilience metric records — R = injections_caught / injections_total across 7 detection levels",

--- a/schemas/situation-report.schema.json
+++ b/schemas/situation-report.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "situation-report.schema.json",
   "title": "Situation Report",
   "description": "A point-in-time assessment of ecosystem health, open work, and recommended priorities",

--- a/schemas/trigger.schema.json
+++ b/schemas/trigger.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "trigger.schema.json",
   "title": "Driver Trigger",
   "description": "An event or condition that initiates a driver cycle",

--- a/schemas/work-manifest.schema.json
+++ b/schemas/work-manifest.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "work-manifest.schema.json",
   "title": "Driver Work Manifest",
   "description": "A complete record of one autonomous driver cycle — plan, execution, and outcomes",

--- a/scripts/test_schema_metaschema.py
+++ b/scripts/test_schema_metaschema.py
@@ -1,0 +1,59 @@
+"""Guard: every schema in schemas/ must declare a *resolvable* $schema metaschema.
+
+Draft-07's registered identifier is `http://json-schema.org/draft-07/schema#`.
+The `https://` variant does not resolve: jsonschema silently falls back to the
+latest draft (2020-12) and validates the schema under semantics it never
+declared, emitting only a warning. Seventeen schemas shipped with the `https`
+form (issue #792); this test asserts the class cannot regress.
+
+The check is deliberately about *resolvability*, not a hard-coded string: any
+$schema jsonschema cannot map to a concrete validator is a failure, so the
+guard also covers future metaschema typos, not just this one.
+"""
+
+import glob
+import json
+import os
+import unittest
+import warnings
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCHEMA_GLOB = os.path.join(_REPO_ROOT, "schemas", "*.json")
+
+
+class SchemaMetaschemaResolves(unittest.TestCase):
+    def test_every_schema_declares_a_resolvable_metaschema(self):
+        try:
+            from jsonschema.validators import validator_for
+        except ModuleNotFoundError:
+            self.skipTest("jsonschema not installed")
+
+        offenders = []
+        for path in sorted(glob.glob(_SCHEMA_GLOB)):
+            with open(path, encoding="utf-8") as handle:
+                schema = json.load(handle)
+            declared = schema.get("$schema")
+            if not declared:
+                continue
+            # validator_for warns and falls back to the latest draft when it
+            # cannot resolve the declared metaschema. Turn that warning into the
+            # signal: a schema whose $schema does not resolve is the defect.
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                validator_for(schema)
+                if any("metaschema" in str(w.message).lower() for w in caught):
+                    offenders.append(
+                        (os.path.relpath(path, _REPO_ROOT), declared)
+                    )
+
+        self.assertEqual(
+            offenders,
+            [],
+            "these schemas declare an unresolvable $schema (jsonschema falls back "
+            "to the latest draft and validates under undeclared semantics):\n"
+            + "\n".join(f"  {rel}: {uri}" for rel, uri in offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

17 schemas declared `"$schema": "https://json-schema.org/draft-07/schema#"`. Draft-07's registered identifier uses **`http://`**. jsonschema can't resolve the `https` form, so it **silently falls back to 2020-12** and validates each schema under semantics it never declared — emitting only a warning that a future release turns into a hard error.

## The part that needed verifying (not assumed)

The issue explicitly cautioned that the set of schemas whose *validation actually changes* "should not be assumed to be empty." Measured:

- **None** of the 17 use 2020-12-only keywords (`prefixItems`, `$dynamicRef`, `unevaluatedProperties`, `dependentSchemas`, …).
- **None** use array-form `items` (the primary draft-07 ↔ 2020-12 divergence).
- `Draft7Validator.check_schema` and `Draft202012Validator.check_schema` **agree** on all 17.

So `https`→`http` pins each schema to the draft-07 it already declares and changes **zero** validation outcomes. Confirmed at the validator level: `http` → `Draft7Validator`, no warning; `https` → `Draft202012Validator` + fallback warning.

## Regression guard

`scripts/test_schema_metaschema.py`, discovered by the existing `unittest discover -s scripts` job — **no `.github/` edit** (that's a blocked path). It keys on whether jsonschema *falls back*, so it also catches future metaschema typos, not just this one. Verified: passes on the fixed tree; fails and names the offender when any file is reverted.

## Scope notes

- `governance-manifest.json` is unchanged, so the manifest-staleness check passes.
- 17 files, exactly +1/−1 line each; no line-ending churn.

Closes #792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)