### PR TITLE
fix(ixql): assertion checks are juxtaposed, not arrow-joined (Test Case 1 now parses)

### DIFF
--- a/tree-sitter-ixql/grammar.js
+++ b/tree-sitter-ixql/grammar.js
@@ -655,10 +655,19 @@ module.exports = grammar({
         $.assertion_pipeline,
       ),
 
+    // Spec (sci-ml-pipelines.ebnf:453): `assertion_pipeline ::= assertion_subject
+    // assertion_check+` — the checks are JUXTAPOSED, not arrow-joined. The earlier
+    // `repeat(seq($.arrow, $.assertion_check))` required an arrow before each
+    // check, which (a) could not parse the canonical arrow-less form used by every
+    // example in the EBNF and in tests/behavioral/ixql-assertions-cases.md, and
+    // (b) when an arrow was present, absorbed the "check" into the subject's own
+    // pipeline_expr as a pipeline_stage, leaving this rule's check list dead. An
+    // assertion subject that is itself an arrow pipeline still works: those arrows
+    // belong to pipeline_expr, not to the check separator.
     assertion_pipeline: ($) =>
       seq(
         $.assertion_subject,
-        repeat(seq($.arrow, $.assertion_check)),
+        repeat1($.assertion_check),
       ),
 
     // Spec lists data_source | pipeline_expr | ... | identifier as alternatives,

--- a/tree-sitter-ixql/test/corpus/ixql.txt
+++ b/tree-sitter-ixql/test/corpus/ixql.txt
@@ -99,10 +99,34 @@ csv("data.csv") -> random_forest
           (model_stage))))))
 
 ========================================
-assertion over a data source
+assertion with an arrow-less check (spec Test Case 1)
 ========================================
 
-assert input_quality: csv("train.csv") -> assert_check(not_null)
+assert input_quality: csv("train.csv")
+  assert_check(not_null)
+
+---
+
+(source_file
+  (assertion_statement
+    (identifier)
+    (assertion_pipeline
+      (assertion_subject
+        (pipeline_expr
+          (simple_pipeline
+            (data_source
+              (file_source
+                (string_literal))))))
+      (assertion_check
+        (assertion_condition)))))
+
+========================================
+assertion with a pipeline subject and multiple checks
+========================================
+
+assert q: csv("f.csv") -> zscore
+  assert_check(not_null)
+  assert_check(schema: "s.json")
 
 ---
 
@@ -118,14 +142,20 @@ assert input_quality: csv("train.csv") -> assert_check(not_null)
                 (string_literal)))
             (arrow)
             (pipeline_stage
-              (assertion_check
-                (assertion_condition)))))))))
+              (preprocessing_stage
+                (cleaning_expr))))))
+      (assertion_check
+        (assertion_condition))
+      (assertion_check
+        (assertion_condition
+          (string_literal))))))
 
 ========================================
 assertion over a model-stage chain
 ========================================
 
 assert model_quality: random_forest -> f1_score
+  assert_check(not_null)
 
 ---
 
@@ -140,7 +170,9 @@ assert model_quality: random_forest -> f1_score
               (identifier))
             (arrow)
             (pipeline_stage
-              (evaluation_stage))))))))
+              (evaluation_stage)))))
+      (assertion_check
+        (assertion_condition)))))
 
 ========================================
 parallel tool fanout


### PR DESCRIPTION
Follow-up to #805, from an independent adversarial review of the assertion seam.

## The bug

`assertion_pipeline` required an arrow before every check:

```js
seq($.assertion_subject, repeat(seq($.arrow, $.assertion_check)))
```

But the spec (`sci-ml-pipelines.ebnf:453`) is `assertion_subject assertion_check+` — **juxtaposed, no arrow** — and every example in the EBNF and in `tests/behavioral/ixql-assertions-cases.md` writes checks arrow-less on the next line.

So the canonical **behavioral Test Case 1**:

```
assert input_quality: csv("train.csv")
  assert_check(not_null, message: "...")
```

**did not parse** on the merged grammar — the arrow-less `assert_check` was misparsed as a separate statement, producing 2 ERROR nodes. And when an arrow *was* present, the check was absorbed into the subject's `pipeline_expr` as a `pipeline_stage`, leaving `assertion_pipeline`'s check list as dead code.

**#805's corpus case #6 used the arrow form**, so it locked in the buggy contract and gave false confidence. Corrected here.

## The fix

```js
seq($.assertion_subject, repeat1($.assertion_check))
```

Juxtaposed, matching the spec's `+`. A subject that is itself an arrow pipeline still works — those arrows belong to `pipeline_expr`, not the check separator. The Test Case 1 tree now matches the spec's stated expected result (`assertion_check` a **sibling** of `assertion_subject`, not nested).

## Corpus

Case #6 rewritten to the canonical arrow-less form; added a pipeline-subject-with-multiple-checks case and a check on the model-stage case.

## Verification

Clean checkout → `verify.ps1` exits 0, **10/10** corpus tests pass.

## Credit + a correction to #805's reasoning

The defect was surfaced by an adversarial review that also **measured zero external consumers** of these grammar node names across the `ix` clone (~80 crates, no `ix-lsp`; the sole reference is a vendored mirror of this grammar that will need re-syncing — noted as a cross-repo follow-up). That measured-zero-consumers finding is the *sound* justification for #805's `assertion_subject` collapse — better than "no CST existed", since `src/` does exist as an untracked generated dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)