### PR TITLE
governance(galactic-protocol): v1.3.0 status-honesty amendment + first contract-instance gate

### DIFF
--- a/.github/workflows/governance-validate.yml
+++ b/.github/workflows/governance-validate.yml
@@ -48,6 +48,12 @@ jobs:
         with:
           python-version: '3.12'
 
+      # jsonschema powers the compliance-report contract-instance gate
+      # (galactic-protocol.md v1.3.0); the validator degrades to a printed
+      # skip without it, so install it to keep the gate real.
+      - name: Install deps
+        run: pip install jsonschema
+
       - name: Run governance validator
         run: python scripts/validate_governance.py
 

--- a/contracts/galactic-protocol.md
+++ b/contracts/galactic-protocol.md
@@ -1,12 +1,37 @@
 # Galactic Protocol Specification
 
-Version: 1.2.0
+Version: 1.3.0
 Effective: 2026-03-15
-Updated: 2026-03-23
+Updated: 2026-07-21
+
+## Changelog
+
+- **1.3.0 (2026-07-21)** — status-honesty amendment — spec now distinguishes IMPLEMENTED from DRAFT; no protections are claimed that code does not provide. Adds the §Implementation Status table, the Registered Machine Emitters table (Rule 1 amendment), documents the observer model for compliance reports, fixes the v1.1 version drift in the embedded issue template, and voids the lapsed 2026-04-15 integrity hard-reject deadline until reissued. Append-only: no sections removed; unimplemented sections carry explicit status labels instead.
+- **1.2.0 (2026-03-23)** — prior baseline (Message Integrity layer specified); see git history.
 
 ## Purpose
 
 This document defines the behavioral semantics of the Galactic Protocol — the communication and persistence protocol between Demerzel and consumer repos (ix, tars, ga). Contract schemas in `schemas/contracts/` define message formats; this document defines when and how those messages flow.
+
+## Implementation Status (v1.3.0)
+
+What this spec claims vs. what code actually provides, as of 2026-07-21. Only the compliance-report flow is live end-to-end. This table is normative for honesty: any claim elsewhere in this document counts only as strong as its status row here.
+
+| Message type / layer | Status | Evidence |
+|---|---|---|
+| `compliance-report` | **IMPLEMENTED** | Emitted daily by `scripts/compliance_report.py` (observer model — see below) into `state/oversight/compliance-reports/` (~110 instances; gitignored runtime state). Consumed by the ix `violation_pattern_detector` producer → `state/oversight/ml-recommendations/` → `scripts/apply_ml_feedback.py`. Instances are schema-validated by `scripts/validate_governance.py`. |
+| `directive` (JSON message instance) | **DRAFT — NO EMITTER** | Schema exists; zero instances ever produced. Directives flow today as GitHub Issues (§Directive → GitHub Issue Mapping), not as protocol JSON messages. |
+| `knowledge-package` | **DRAFT — NO EMITTER** | Schema exists; zero instances ever produced. |
+| `belief-snapshot` | **DRAFT — NO EMITTER** | Schema exists; zero instances ever produced. |
+| `learning-outcome` | **DRAFT — NO EMITTER** | Schema exists; zero instances ever produced. |
+| `external-sync-envelope` | **DRAFT — NO EMITTER** | Schema exists; zero instances ever produced; no adapters defined. |
+| Message Integrity layer (§Message Integrity) | **SPECIFIED — NOT IMPLEMENTED** | No receiver verifies origin, hash, timestamp, or replay. `state/security/processed-messages.json` does not exist. The compliance-report emitter *attaches* integrity fields, but nothing checks them on receipt. The 2026-04-15 hard-reject deadline (§Backward Compatibility) passed unenforced and is **void until reissued**. |
+
+New message types or integrity enforcement move to IMPLEMENTED only when an emitter/verifier ships with instances or checks on disk — no artifact without consumer.
+
+### Observer model for compliance reports
+
+Compliance reports are synthesized **centrally by Demerzel**: `scripts/compliance_report.py` runs governance checks against each consumer repo's local `governance/demerzel/` mirror on the same machine. `origin_repo` therefore identifies the **observed** repo (ix, tars, ga), not the author of the message — the author is always Demerzel's `compliance-reporter` emitter. Consumers do not self-report in the current implementation (acknowledged in the emitter's docstring as the pragmatic single-home option; strict self-reporting fidelity would move the checks into each consumer repo).
 
 ## Message Types
 
@@ -18,6 +43,8 @@ This document defines the behavioral semantics of the Galactic Protocol — the 
 | `belief-snapshot.schema.json` | Consumer → Demerzel | Belief state export |
 | `learning-outcome.schema.json` | Consumer → Demerzel | PDCA/5 Whys/knowledge results |
 | `external-sync-envelope.schema.json` | Bidirectional | External system wrapper |
+
+Only `compliance-report` has a live emitter as of v1.3.0 — see §Implementation Status for the authoritative per-type status.
 
 ## Protocol Flows
 
@@ -64,6 +91,8 @@ Both require logged reasoning with specific constitutional citations.
 
 ## Message Integrity
 
+> **Status (v1.3.0): SPECIFIED — NOT IMPLEMENTED.** This entire section describes intended protections that no code currently provides. There is no receiver-side verification of origin, hash, timestamp, sequence, or replay; `state/security/` does not exist; content scanning is not performed. The section is retained per append-only discipline as the design target. Do not rely on any protection described here until this label is lifted in a future version.
+
 All Galactic Protocol messages must include integrity fields to prevent forgery, tampering, and replay attacks. This section was added per `policies/adversarial-resilience-policy.yaml` to close the blind spot identified in the HBR "Agents as Team Members" reflection.
 
 ### Required Integrity Fields
@@ -81,7 +110,13 @@ Every protocol message (directive, compliance report, belief snapshot, learning 
 
 ### Verification Rules
 
-1. **Origin verification:** `origin_repo` must be a registered participant in the Galactic Protocol. `origin_agent` must be a valid persona in that repo. Messages from unregistered origins are rejected.
+1. **Origin verification:** `origin_repo` must be a registered participant in the Galactic Protocol. `origin_agent` must be a valid persona in that repo **or a machine emitter listed in the Registered Machine Emitters table below** *(amended v1.3.0: every live message carries `origin_agent: "compliance-reporter"`, which is an emitter script, not a persona — the rule as originally written was violated by 100% of real traffic)*. Messages from unregistered origins are rejected.
+
+   **Registered Machine Emitters (v1.3.0):** machine emitters are scripts, not personas; they are valid `origin_agent` values under this rule.
+
+   | `origin_agent` | Emitter | Model |
+   |---|---|---|
+   | `compliance-reporter` | `scripts/compliance_report.py` | Observer — Demerzel synthesizes the report from the consumer's local mirror; `origin_repo` = observed repo, not author (see §Implementation Status → Observer model). |
 
 2. **Timestamp validation:** `timestamp` must be within 5 minutes of receiver's clock (clock skew tolerance). Messages older than 24 hours are rejected as stale — potential replay attacks.
 
@@ -129,6 +164,8 @@ Beyond structural integrity, message content is scanned for adversarial patterns
 ### Backward Compatibility
 
 Existing messages without integrity fields are accepted during a **transition period ending 2026-04-15** with a governance warning logged. After 2026-04-15, messages without integrity fields are **hard-rejected** — no grace period, no override. Consumer repos must update their message generation to include integrity fields before this deadline. The transition period is not extendable without a constitutional amendment (requires human approval per Governance Promotion Protocol §Stage 2).
+
+> **v1.3.0 note:** the 2026-04-15 deadline passed with no rejection logic ever implemented — no message was ever warned or hard-rejected. The deadline is **void until reissued** in a future version alongside an actual verifier. Claiming an enforced deadline that code does not enforce would violate the status-honesty principle of this amendment.
 
 ## Error Handling
 
@@ -371,7 +408,7 @@ Governance directives are materialized as GitHub Issues in the target repo.
 Per Galactic Protocol §1, valid rejection requires First Law or Second Law override with logged constitutional citations.
 
 ---
-*Issued via Galactic Protocol v1.1 — [directive schema](https://github.com/GuitarAlchemist/Demerzel/blob/master/schemas/contracts/directive.schema.json)*
+*Issued via Galactic Protocol v1.3.0 — [directive schema](https://github.com/GuitarAlchemist/Demerzel/blob/master/schemas/contracts/directive.schema.json)*
 ```
 
 ### Compliance Report → Issue Comment Mapping

--- a/governance-health.json
+++ b/governance-health.json
@@ -9,6 +9,6 @@
   "quality_trend": {
     "latest_artifact": "afk-graduated-self-merge",
     "source": "state/quality-trend/2026-07.jsonl",
-    "computed_at": "2026-07-18T12:00:00Z"
+    "computed_at": "2026-07-21T13:22:15Z"
   }
 }

--- a/scripts/test_validate_governance.py
+++ b/scripts/test_validate_governance.py
@@ -1,0 +1,101 @@
+"""Tests for the compliance-report contract-instance gate in validate_governance.
+
+The gate (galactic-protocol.md v1.3.0 §Implementation Status) must be TRUE —
+a malformed report fails — without being theater: a report shaped like the
+real emitter output (scripts/compliance_report.py) passes, and an empty
+directory is a note, not a failure.
+"""
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from scripts.validate_governance import check_compliance_reports
+except ModuleNotFoundError:  # `unittest discover -s scripts` imports top-level tests.
+    from validate_governance import check_compliance_reports
+
+try:
+    import jsonschema  # noqa: F401
+    HAS_JSONSCHEMA = True
+except ImportError:  # pragma: no cover
+    HAS_JSONSCHEMA = False
+
+
+def _valid_report() -> dict:
+    """A report shaped exactly like scripts/compliance_report.py output."""
+    return {
+        "id": "cr-ix-20260721",
+        "repo": "ix",
+        "agent": "compliance-reporter",
+        "reporting_period": {
+            "from": "2026-06-21T00:00:00Z",
+            "to": "2026-07-21T00:00:00Z",
+        },
+        "constitutional_compliance": [
+            {"article": "Article 7 - Auditability", "status": "compliant"},
+        ],
+        "policy_compliance": [
+            {"policy": "persona-requirements", "status": "compliant"},
+        ],
+        "violations": [],
+        "overall_status": "compliant",
+        "reported_at": "2026-07-21T00:00:00Z",
+        "channel": "crisp",
+        "message_id": "0239b368-6f61-4960-b1b0-b5ff4bcc24f8",
+        "origin_repo": "ix",
+        "origin_agent": "compliance-reporter",
+        "content_hash": "c105b257520277a06d0e4ec09cefe464f7ab2b4bb96b02346744a508ee41e05e",
+        "hash_algorithm": "sha256",
+        "timestamp": "2026-07-21T00:00:00Z",
+    }
+
+
+def _run(reports_dir: Path) -> tuple[int, int]:
+    with contextlib.redirect_stdout(io.StringIO()):
+        return check_compliance_reports(reports_dir)
+
+
+class ComplianceReportGateTests(unittest.TestCase):
+    def test_missing_or_empty_directory_is_not_a_failure(self):
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual((0, 0), _run(Path(root) / "does-not-exist"))
+            self.assertEqual((0, 0), _run(Path(root)))
+
+    @unittest.skipUnless(HAS_JSONSCHEMA, "jsonschema not installed")
+    def test_valid_report_passes(self):
+        with tempfile.TemporaryDirectory() as root:
+            path = Path(root) / "cr-ix-20260721.json"
+            path.write_text(json.dumps(_valid_report()), encoding="utf-8")
+            self.assertEqual((1, 0), _run(Path(root)))
+
+    @unittest.skipUnless(HAS_JSONSCHEMA, "jsonschema not installed")
+    def test_malformed_report_fails(self):
+        bad = _valid_report()
+        del bad["overall_status"]           # missing required field
+        bad["repo"] = "not-a-real-repo"     # enum violation
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "cr-bad.json").write_text(json.dumps(bad), encoding="utf-8")
+            self.assertEqual((0, 1), _run(Path(root)))
+
+    @unittest.skipUnless(HAS_JSONSCHEMA, "jsonschema not installed")
+    def test_missing_integrity_fields_fail(self):
+        bad = _valid_report()
+        for field in ("message_id", "origin_repo", "origin_agent",
+                      "content_hash", "hash_algorithm", "timestamp"):
+            del bad[field]
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "cr-no-integrity.json").write_text(json.dumps(bad), encoding="utf-8")
+            self.assertEqual((0, 1), _run(Path(root)))
+
+    @unittest.skipUnless(HAS_JSONSCHEMA, "jsonschema not installed")
+    def test_unparseable_json_fails(self):
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "cr-broken.json").write_text("{not json", encoding="utf-8")
+            self.assertEqual((0, 1), _run(Path(root)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_governance.py
+++ b/scripts/validate_governance.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 """
-Governance validator — evolution-log enum check, pure stdlib.
+Governance validator — evolution-log enum check plus the first Galactic
+Protocol contract-instance gate.
 
 Every state/evolution/*.evolution.json validates against the enums in
-logic/governance-evolution.schema.json (artifact_type, event.type).
+logic/governance-evolution.schema.json (artifact_type, event.type) — pure
+stdlib. Every state/oversight/compliance-reports/*.json validates against
+schemas/contracts/compliance-report.schema.json — needs `jsonschema`,
+degrades to a printed skip when it is not installed.
 
 Exits non-zero on any violation. Prints one line per file with OK/FAIL.
 
@@ -25,6 +29,8 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 SCHEMA = REPO / "logic" / "governance-evolution.schema.json"
 EVOLUTION_DIR = REPO / "state" / "evolution"
+CONTRACTS_DIR = REPO / "schemas" / "contracts"
+REPORTS_DIR = REPO / "state" / "oversight" / "compliance-reports"
 
 
 def check_evolution_enums() -> tuple[int, int]:
@@ -53,13 +59,78 @@ def check_evolution_enums() -> tuple[int, int]:
     return ok, bad
 
 
+def check_compliance_reports(reports_dir: Path = REPORTS_DIR) -> tuple[int, int]:
+    """Validate compliance-report instances against their contract schema.
+
+    First Galactic Protocol contract-instance gate (galactic-protocol.md
+    v1.3.0 §Implementation Status): compliance-report is the only message
+    type with a live emitter (scripts/compliance_report.py), so it is the
+    only one gated here — no gate without instances to gate.
+
+    Strategy: the contract schema pulls in integrity-fields.schema.json via a
+    relative `allOf` $ref that jsonschema won't resolve without a registry, so
+    we validate the body schema (allOf stripped) and the integrity-fields
+    schema separately — together equivalent to the full contract. Verified
+    2026-07-21: all 111 live instances pass BOTH parts (the emitter attaches
+    integrity fields even though no receiver verifies them — see the v1.3.0
+    status table), so this gate enforces the full contract, not a weakened one.
+
+    Degrades gracefully: `jsonschema` missing -> printed skip (the CI validate
+    job installs it); directory absent/empty -> printed note, not a failure
+    (instances are gitignored runtime state, present only where the daily
+    driver runs).
+    """
+    try:
+        import jsonschema
+    except ImportError:
+        print("SKIP jsonschema not installed — compliance-report instances not validated")
+        return 0, 0
+
+    files = sorted(reports_dir.glob("*.json")) if reports_dir.is_dir() else []
+    if not files:
+        print("NOTE no compliance-report instances on disk (gitignored runtime state) — nothing to validate")
+        return 0, 0
+
+    body = json.loads((CONTRACTS_DIR / "compliance-report.schema.json").read_text(encoding="utf-8"))
+    body.pop("allOf", None)  # relative $ref to integrity-fields — validated separately below
+    integrity = json.loads((CONTRACTS_DIR / "integrity-fields.schema.json").read_text(encoding="utf-8"))
+    body_validator = jsonschema.Draft202012Validator(body)
+    integrity_validator = jsonschema.Draft202012Validator(integrity)
+
+    ok = bad = 0
+    for path in files:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            bad += 1
+            print(f"FAIL {path.name}")
+            print(f"  - not valid JSON: {exc}")
+            continue
+        issues = [e.message for e in body_validator.iter_errors(data)]
+        issues += [f"integrity: {e.message}" for e in integrity_validator.iter_errors(data)]
+        if issues:
+            bad += 1
+            print(f"FAIL {path.name}")
+            for issue in issues:
+                print(f"  - {issue}")
+        else:
+            ok += 1
+            print(f"OK   {path.name}")
+    return ok, bad
+
+
 def main() -> int:
     print("=== Evolution log: schema enum validation ===")
     e_ok, e_bad = check_evolution_enums()
     print(f"Result: {e_ok} valid, {e_bad} invalid\n")
 
-    if e_bad:
-        print(f"FAILED: {e_bad} violation(s) — see above.")
+    print("=== Compliance reports: contract instance validation ===")
+    c_ok, c_bad = check_compliance_reports()
+    print(f"Result: {c_ok} valid, {c_bad} invalid\n")
+
+    total_bad = e_bad + c_bad
+    if total_bad:
+        print(f"FAILED: {total_bad} violation(s) — see above.")
         return 1
     print("PASSED: all checks green.")
     return 0


### PR DESCRIPTION
## What the audits found

Two completed audits (spec survey + usage audit) of `contracts/galactic-protocol.md` v1.2.0 established:

- **One live flow, end to end:** `scripts/compliance_report.py` → `state/oversight/compliance-reports/*.json` (111 real instances, daily) → ix `violation_pattern_detector` → `state/oversight/ml-recommendations/` → `scripts/apply_ml_feedback.py`.
- **Five of six message types are fiction:** belief-snapshot, knowledge-package, learning-outcome, external-sync-envelope, and directive-as-JSON have zero instances and zero emitters, ever.
- **The Message Integrity layer is entirely unimplemented:** no replay protection, no hash verification, no `state/security/processed-messages.json` — and the spec's "hard-reject after 2026-04-15" deadline passed with nothing ever enforced.
- **Rule 1 was violated by 100% of real traffic:** every live message carries `origin_agent: "compliance-reporter"`, which is an emitter script, not a persona. Reports set `origin_repo` to ix/tars/ga while actually being synthesized by Demerzel from local consumer mirrors (observer model).
- Version drift (header v1.2.0 vs embedded template "v1.1") and **no CI validated any protocol message instance**.

## What this changes

1. **Spec honesty amendment → v1.3.0** (`contracts/galactic-protocol.md`): normative Implementation Status table (IMPLEMENTED / DRAFT — NO EMITTER / SPECIFIED — NOT IMPLEMENTED); the lapsed 2026-04-15 deadline declared void until reissued; Rule 1 amended to admit registered machine emitters, with an emitter table (one row: `compliance-reporter`); the observer model documented (`origin_repo` = observed repo, not author); v1.1 template drift fixed. Append-only: nothing removed, status labels added.
2. **First contract-instance gate** (`scripts/validate_governance.py`): every `state/oversight/compliance-reports/*.json` is validated against `schemas/contracts/compliance-report.schema.json` (body + integrity-fields schema, together the full contract). Ran against all 111 live instances first: **111 valid, 0 invalid** — the emitter already attaches integrity fields, so the gate enforces the full contract with no weakening. Degrades gracefully when `jsonschema` is absent or the (gitignored) instances directory is empty. CI `validate` job now installs `jsonschema`. Unit tests added (`scripts/test_validate_governance.py`).

## What this does NOT do

- **No new message types or emitters** — no-artifact-without-consumer rule; the five dead types stay DRAFT until something real needs them.
- **No security implementation** — the Message Integrity layer remains unimplemented; the spec now says so explicitly instead of claiming protections code does not provide.
- No schema changes, no deletion of spec sections (append-only discipline).

## Verification

- `python scripts/validate_governance.py` — PASSED (13 evolution logs + compliance-report gate).
- Gate run against the 111 real instances: 111 valid, 0 invalid.
- `python -m unittest discover -s scripts -p "test_*.py"` — Ran 272 tests, OK.
- `python scripts/build_manifest.py` — PASSED; only derived timestamp in `governance-health.json` changed (committed).

Note: the `risk-report` job is expected to fail closed because this PR touches `.github/` — that is the intended human-merge-review gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpXX3JapDxPYFsuCENton2