### PR TITLE
fix(submodule-notify): fail loud + title-scoped staleness matching

### DIFF
--- a/.github/workflows/submodule-notify.yml
+++ b/.github/workflows/submodule-notify.yml
@@ -38,13 +38,17 @@ jobs:
 
           echo "Demerzel HEAD: $DEMERZEL_HEAD ($COMMIT_MSG)"
 
-          for REPO in ix tars ga; do
-            # Get the submodule commit in the consumer repo
-            SUB_SHA=$(gh api "repos/GuitarAlchemist/$REPO/contents/governance/demerzel" \
-              --jq '.sha' 2>/dev/null || echo "none")
+          # Fail loud: any API failure below increments this and fails the job at
+          # the end, after all repos are processed. A swallowed failure here hid
+          # months of red (see docs/research/2026-07-21-staleness-downstream-verdict.md).
+          FAILURES=0
 
-            if [ "$SUB_SHA" = "none" ]; then
-              echo "$REPO: no submodule found, skipping"
+          for REPO in ix tars ga; do
+            # Get the submodule commit in the consumer repo. An API error must not
+            # read as "no submodule" — that silently skips the repo forever.
+            if ! SUB_SHA=$(gh api "repos/GuitarAlchemist/$REPO/contents/governance/demerzel" --jq '.sha'); then
+              echo "::error::$REPO: could not read submodule pin (API failure, not absence)"
+              FAILURES=$((FAILURES+1))
               continue
             fi
 
@@ -56,19 +60,29 @@ jobs:
             echo "$REPO: submodule at $SUB_SHORT, $BEHIND commits behind"
 
             # Dispatch auto-update event (consumer decides whether to auto-commit or PR)
-            gh api "repos/GuitarAlchemist/$REPO/dispatches" \
+            if gh api "repos/GuitarAlchemist/$REPO/dispatches" \
               --method POST \
               -f event_type="demerzel-updated" \
               -f "client_payload[demerzel_head]=$DEMERZEL_HEAD" \
               -f "client_payload[commit_msg]=$COMMIT_MSG" \
-              -f "client_payload[behind]=$BEHIND" \
-              2>/dev/null && echo "  Dispatched auto-update to $REPO" || echo "  Failed to dispatch to $REPO"
+              -f "client_payload[behind]=$BEHIND"; then
+              echo "  Dispatched auto-update to $REPO"
+            else
+              echo "::error::$REPO: dispatch failed"
+              FAILURES=$((FAILURES+1))
+            fi
 
-            # Only create issue if significantly behind (>5 commits) AND no existing issue
+            # Only create issue if significantly behind (>5 commits) AND no existing issue.
+            # in:title is load-bearing: a full-text search matches any open issue whose
+            # BODY mentions the submodule (ga #47 did), muting staleness alerts forever.
             if [ "$BEHIND" -gt 5 ] 2>/dev/null; then
-              EXISTING=$(gh issue list --repo "GuitarAlchemist/$REPO" \
-                --search "Demerzel submodule" --state open \
-                --json number --jq 'length' 2>/dev/null || echo "0")
+              if ! EXISTING=$(gh issue list --repo "GuitarAlchemist/$REPO" \
+                --search "Demerzel submodule in:title" --state open \
+                --json number --jq 'length'); then
+                echo "::error::$REPO: issue list failed; cannot tell if an alert already exists"
+                FAILURES=$((FAILURES+1))
+                EXISTING="skip"
+              fi
 
               if [ "$EXISTING" = "0" ]; then
                 gh issue create --repo "GuitarAlchemist/$REPO" \
@@ -92,9 +106,14 @@ jobs:
           ---
           *Automated by Demerzel submodule staleness detection.*
           ISSUEEOF
-          )" 2>/dev/null && echo "  Created issue for $REPO" || echo "  Failed to create issue for $REPO"
-              else
+          )" && echo "  Created issue for $REPO" || { echo "::error::$REPO: issue creation failed"; FAILURES=$((FAILURES+1)); }
+              elif [ "$EXISTING" != "skip" ]; then
                 echo "  $REPO: staleness issue already exists, skipping"
               fi
             fi
           done
+
+          if [ "$FAILURES" -gt 0 ]; then
+            echo "::error::$FAILURES notification hop(s) failed — see errors above"
+            exit 1
+          fi

--- a/docs/research/2026-07-21-staleness-downstream-verdict.md
+++ b/docs/research/2026-07-21-staleness-downstream-verdict.md
@@ -1,0 +1,37 @@
+# Slice A verdict: the embed IS delivery — three broken hops, all identified
+
+**Date:** 2026-07-21 (deadline was 2026-07-28)
+**Plan:** `docs/superpowers/plans/2026-07-21-galactic-protocol-followups.md` Slice A
+**Method:** zero-code investigation via GitHub API — dispatch handlers, issue disposition, run logs, branch/PR inventory per consumer.
+
+## Verdict
+
+**The submodule embed is a real delivery channel and should keep its spec claim.** A full remediation pipeline exists and fires: Demerzel's `submodule-notify.yml` (green, 4 runs today) → `demerzel-updated` repository_dispatch → each consumer's `submodule-auto-update.yml` (exists in all three; triggered by dispatch AND cron ~3×/day) → bump branch + PR. Consumers are months stale not because the signal is missing but because the **last hop fails differently in each repo, red for months, unwatched**.
+
+## Per-consumer evidence
+
+| Consumer | Pin age | Handler | Failure | Evidence |
+|---|---|---|---|---|
+| ix | 2026-05-17 (515 commits behind per today's run) | runs 4×/day, fails every run | **SIGPIPE exit 141** after force-pushing the bump branch, at/before `gh pr create` | 28 orphan `chore/update-demerzel-*` branches; last bump PR April (#26, closed unmerged); staleness issue #52 open since 05-24 |
+| tars | 2026-05-16 | runs 3×/day, fails (same workflow shape) | same exit-141 flakiness; occasionally completes | 23 orphan branches; PR #201 **merged 07-13** (the one success — closed issue #51); issue #205 open since 07-18 |
+| ga | 2026-04-04 (most stale) | runs 4×/day, fails every run | **exit 128 at recursive checkout**: `mcp-servers/meshy-ai` pinned to nonexistent commit `0efc525…` ("not our ref") — dies before any Demerzel step | zero bump branches, zero PRs ever since failure began; **also** no staleness issues since 03-29 (see finding 4) |
+
+## Findings
+
+1. **ix/tars hop:** exit 141 = SIGPIPE under `pipefail`, almost certainly the `$CHANGES` cosmetic pipe (`git log … | head`-style) in the PR-body heredoc, executed after the force-push succeeds. One-line fix in each consumer's `submodule-auto-update.yml`; then prune the orphan branch pileup (28 + 23) and let the next run open a real PR.
+2. **ga hop:** unrelated broken submodule pin (`mcp-servers/meshy-ai` → force-pushed/rewritten upstream history). Fix or unpin that submodule, or scope the workflow's checkout to `governance/demerzel` only (non-recursive), which also decouples the governance bump from every other submodule's health.
+3. **Demerzel-side defect (our repo):** `submodule-notify.yml` line ~95 swallows issue-creation failures (`2>/dev/null … || echo "Failed"`). The exact swallowed-exit-code pattern from `docs/solutions/harness/2026-07-20-powershell-native-exit-codes.md`. Fail-loud fix, one line, `.github/` = human-gated PR.
+4. **ga issue silence since 03-29 — SOLVED (follow-up probe):** the notifier's existing-issue guard uses *full-text* search (`--search "Demerzel submodule"`), and ga's open issue #47 ("Prime Radiant: integrate ix governance.graph…") mentions the submodule in its body — so `EXISTING=1` and ga's staleness alerts have been muted since #47 opened. Fixed alongside finding 3 by scoping the search `in:title` (PR #814).
+5. **Meta:** every hop that failed did so *visibly* in its own repo's Actions tab and *invisibly* to the ecosystem — red runs 3-4×/day for months with no consumer of the failure signal. The loop-health registry pattern (proof-of-success, not absence-of-alarm) is the general cure; consumers don't have it yet.
+
+## Named next actions (one per lane, coordination via ~/.agents/claims.jsonl)
+
+- **ix session:** fix SIGPIPE in `submodule-auto-update.yml`, prune 28 orphan branches, merge the resulting bump PR (515 commits of governance including PR #808/#813 once merged).
+- **tars session:** same fix, prune 23 branches, action issue #205.
+- **ga session:** repair/unpin `mcp-servers/meshy-ai` or make the bump checkout non-recursive; then bump a 3.5-month-stale pin.
+- **Demerzel (this session):** fail-loud fix to `submodule-notify.yml` (separate small PR, human-gated).
+- **Spec:** no change needed — the delivery claim stands; the v1.3.0 status table needs no edit for this.
+
+## Consumer of this verdict
+
+Repo owner, next governance review (per plan Slice A acceptance). This doc is the plan's Slice A deliverable, complete 7 days ahead of deadline.


### PR DESCRIPTION
## What

Two surgical fixes to `.github/workflows/submodule-notify.yml`, both diagnosed in today's Slice A investigation (`docs/research/2026-07-21-staleness-downstream-verdict.md`, plan: `docs/superpowers/plans/2026-07-21-galactic-protocol-followups.md`):

1. **Fail loud.** Every notification hop (submodule-pin read, repository_dispatch, issue list, issue create) swallowed failures via `2>/dev/null … || echo`. The workflow has been green regardless of whether anything was delivered — the exact swallowed-exit-code pattern from `docs/solutions/harness/2026-07-20-powershell-native-exit-codes.md`. Now: each failure emits `::error` and increments a counter; all repos still get processed; the job exits 1 at the end if any hop failed. An API failure no longer reads as "no submodule" / "no existing issue".
2. **Title-scoped issue matching.** The existing-issue guard used full-text search, so any open consumer issue whose *body* mentions "Demerzel submodule" muted staleness alerts forever — ga #47 has been doing exactly this since March, which is why ga (the most-stale consumer, pinned 2026-04-04) stopped receiving alerts. Now `in:title`.

## Why it matters

The staleness pipeline's consumer-side hops are also broken (SIGPIPE in ix/tars auto-update, broken meshy-ai pin in ga — lanes opened for those repos' sessions in the fleet claim ledger). This PR fixes the Demerzel-side hop so the notifier itself can never again fail invisibly.

## Verification

- YAML parses; extracted run-block passes `bash -n`.
- Expected first-run behavior: ga gets its first staleness issue since March (it is >5 commits behind and #47 no longer matches).

Blocked-path note: touches `.github/` → risk-report fails closed by design; human merge review expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpXX3JapDxPYFsuCENton2