### PR TITLE
feat(harness): add fleet compaction telemetry

### DIFF
--- a/docs/design/2026-07-22-claude-compaction-telemetry.md
+++ b/docs/design/2026-07-22-claude-compaction-telemetry.md
@@ -1,0 +1,38 @@
+# Claude Fleet Compaction Telemetry — Tracer Slice
+
+## Outcome
+
+Every local Claude Code repo inherits the supported 40% auto-compaction
+threshold. `PreCompact`, `PostCompact`, and compact-driven `SessionStart`
+events append privacy-safe metadata to `~/.agents/compaction-events.jsonl`.
+
+The slice closes one real feedback loop:
+
+1. Claude Code emits lifecycle evidence.
+2. IX/DuckDB queries compaction and recovery rates by repo.
+3. TARS retains task meaning in the existing per-repo session digest.
+4. Demerzel flags obsolete project settings and governs threshold changes.
+5. The fleet Project carries the verified remediation work.
+
+## Privacy boundary
+
+Transcript paths and compact summaries are never stored. The event contains
+only their SHA-256 hashes and summary character count. This supports replay,
+deduplication, and trend analysis without turning the fleet ledger into a
+second transcript store.
+
+## Gate
+
+- The user setting must use `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`.
+- Repo-local use of `CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE` is reported as
+  `obsolete-key`.
+- Hook failures never block a Claude session.
+- DuckDB must query a synthetic event end to end before installation is
+  considered complete.
+
+## Installation
+
+Run `pwsh scripts/install-claude-compaction-hook.ps1`. The idempotent installer
+backs up the user settings, removes the obsolete environment key, installs the
+hook and DuckDB reader under `~/.claude/hooks`, and merges the three lifecycle
+events without replacing unrelated hooks.

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -5,7 +5,7 @@
   "counts": {
     "behavioral_test": 115,
     "constitution": 5,
-    "contract_schema": 9,
+    "contract_schema": 10,
     "grammar": 20,
     "persona": 17,
     "pipeline": 23,
@@ -588,6 +588,10 @@
       {
         "name": "belief-snapshot.schema",
         "path": "schemas/contracts/belief-snapshot.schema.json"
+      },
+      {
+        "name": "claude-compaction-event.schema",
+        "path": "schemas/contracts/claude-compaction-event.schema.json"
       },
       {
         "name": "compliance-report.schema",

--- a/schemas/contracts/claude-compaction-event.schema.json
+++ b/schemas/contracts/claude-compaction-event.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://guitaralchemist.github.io/schemas/contracts/claude-compaction-event.schema.json",
+  "title": "Claude fleet compaction lifecycle event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "ts",
+    "event",
+    "session_id",
+    "repo",
+    "branch",
+    "trigger",
+    "source",
+    "project_setting",
+    "transcript_path_sha256",
+    "summary_chars",
+    "summary_sha256"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "ts": { "type": "string", "format": "date-time" },
+    "event": {
+      "enum": ["pre_compact", "post_compact", "session_rehydrated"]
+    },
+    "session_id": { "type": "string", "minLength": 1, "maxLength": 160 },
+    "repo": { "type": "string", "minLength": 1, "maxLength": 160 },
+    "branch": { "type": "string", "minLength": 1, "maxLength": 240 },
+    "trigger": { "type": ["string", "null"], "maxLength": 32 },
+    "source": { "type": ["string", "null"], "maxLength": 32 },
+    "project_setting": {
+      "enum": ["supported", "obsolete-key", "inherited", "invalid-json"]
+    },
+    "transcript_path_sha256": {
+      "type": ["string", "null"],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "summary_chars": { "type": ["integer", "null"], "minimum": 0 },
+    "summary_sha256": {
+      "type": ["string", "null"],
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/scripts/claude_compaction_hook.py
+++ b/scripts/claude_compaction_hook.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Privacy-safe Claude Code compaction telemetry hook.
+
+The hook records lifecycle metadata, hashes sensitive strings, and never stores
+the compacted summary or transcript contents. The JSONL output is designed for
+direct ingestion by DuckDB/IX.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Iterator
+
+
+SCHEMA_VERSION = "1.0.0"
+SUPPORTED_KEY = "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
+OBSOLETE_KEY = "CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _git(cwd: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+
+
+def repository_identity(cwd: Path) -> tuple[str, str, Path]:
+    root_text = _git(cwd, "rev-parse", "--show-toplevel")
+    root = Path(root_text) if root_text else cwd
+    remote = _git(cwd, "config", "--get", "remote.origin.url")
+    repo = root.name
+    if remote:
+        repo = remote.rstrip("/").rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+        repo = repo.removesuffix(".git") or root.name
+    branch = _git(cwd, "branch", "--show-current") or "detached"
+    return repo.lower(), branch, root
+
+
+def project_setting_status(root: Path) -> str:
+    settings = root / ".claude" / "settings.json"
+    if not settings.exists():
+        return "inherited"
+    try:
+        data = json.loads(settings.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return "invalid-json"
+    env = data.get("env") if isinstance(data, dict) else None
+    if not isinstance(env, dict):
+        return "inherited"
+    if SUPPORTED_KEY in env:
+        return "supported"
+    if OBSOLETE_KEY in env:
+        return "obsolete-key"
+    return "inherited"
+
+
+@contextmanager
+def file_lock(path: Path) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+b")
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"0")
+                handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        if os.name == "nt":
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+
+def build_event(payload: dict[str, Any]) -> dict[str, Any] | None:
+    hook_name = str(payload.get("hook_event_name", ""))
+    source = str(payload.get("source", ""))
+    if hook_name == "PreCompact":
+        event_name = "pre_compact"
+    elif hook_name == "PostCompact":
+        event_name = "post_compact"
+    elif hook_name == "SessionStart" and source == "compact":
+        event_name = "session_rehydrated"
+    else:
+        return None
+
+    cwd = Path(str(payload.get("cwd") or os.getcwd())).resolve()
+    repo, branch, root = repository_identity(cwd)
+    transcript = str(payload.get("transcript_path", ""))
+    summary = str(payload.get("compact_summary", ""))
+    row: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "ts": utc_now(),
+        "event": event_name,
+        "session_id": str(payload.get("session_id", "unknown"))[:160],
+        "repo": repo[:160],
+        "branch": branch[:240],
+        "trigger": str(payload.get("trigger", ""))[:32] or None,
+        "source": source[:32] or None,
+        "project_setting": project_setting_status(root),
+        "transcript_path_sha256": sha256_text(transcript) if transcript else None,
+        "summary_chars": len(summary) if summary else None,
+        "summary_sha256": sha256_text(summary) if summary else None,
+    }
+    return row
+
+
+def append_event(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n"
+    with file_lock(path.with_suffix(path.suffix + ".lock")):
+        with path.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+
+def handle(payload: dict[str, Any], log_path: Path | None = None) -> dict[str, Any] | None:
+    row = build_event(payload)
+    if row is None:
+        return None
+    target = log_path or Path(
+        os.environ.get(
+            "CLAUDE_FLEET_COMPACTION_LOG",
+            str(Path.home() / ".agents" / "compaction-events.jsonl"),
+        )
+    )
+    append_event(target, row)
+    return row
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        row = handle(payload)
+        if row and row["event"] == "session_rehydrated":
+            sys.stdout.write(
+                "Fleet recovery: read state/digests/latest.md when present and "
+                "check ~/.agents/claims.jsonl before resuming implementation.\n"
+            )
+    except Exception as exc:  # Hook must never block a Claude session.
+        sys.stderr.write(f"fleet compaction telemetry unavailable: {exc}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/claude_compaction_hook.py
+++ b/scripts/claude_compaction_hook.py
@@ -69,10 +69,10 @@ def project_setting_status(root: Path) -> str:
     env = data.get("env") if isinstance(data, dict) else None
     if not isinstance(env, dict):
         return "inherited"
-    if SUPPORTED_KEY in env:
-        return "supported"
     if OBSOLETE_KEY in env:
         return "obsolete-key"
+    if SUPPORTED_KEY in env:
+        return "supported"
     return "inherited"
 
 

--- a/scripts/install-claude-compaction-hook.ps1
+++ b/scripts/install-claude-compaction-hook.ps1
@@ -1,0 +1,110 @@
+[CmdletBinding()]
+param(
+    [string]$Threshold = "40",
+    [string]$ClaudeDirectory = (Join-Path ([Environment]::GetFolderPath("UserProfile")) ".claude")
+)
+
+$ErrorActionPreference = "Stop"
+$hookSource = Join-Path $PSScriptRoot "claude_compaction_hook.py"
+$querySource = Join-Path $PSScriptRoot "query_compaction_telemetry.py"
+$hookDirectory = Join-Path $ClaudeDirectory "hooks"
+$hookTarget = Join-Path $hookDirectory "fleet_compaction_hook.py"
+$queryTarget = Join-Path $hookDirectory "query_compaction_telemetry.py"
+$settingsPath = Join-Path $ClaudeDirectory "settings.json"
+
+if (-not (Test-Path -LiteralPath $hookSource)) {
+    throw "Hook source not found: $hookSource"
+}
+
+New-Item -ItemType Directory -Path $hookDirectory -Force | Out-Null
+Copy-Item -LiteralPath $hookSource -Destination $hookTarget -Force
+Copy-Item -LiteralPath $querySource -Destination $queryTarget -Force
+
+if (Test-Path -LiteralPath $settingsPath) {
+    $settings = Get-Content -LiteralPath $settingsPath -Raw | ConvertFrom-Json
+    $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    Copy-Item -LiteralPath $settingsPath -Destination "$settingsPath.pre-fleet-compact-$stamp.bak" -Force
+} else {
+    $settings = [pscustomobject]@{}
+}
+
+if (-not $settings.PSObject.Properties["env"]) {
+    $settings | Add-Member -NotePropertyName env -NotePropertyValue ([pscustomobject]@{})
+}
+$settings.env | Add-Member -NotePropertyName CLAUDE_AUTOCOMPACT_PCT_OVERRIDE -NotePropertyValue $Threshold -Force
+$settings.env.PSObject.Properties.Remove("CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE")
+
+if (-not $settings.PSObject.Properties["hooks"]) {
+    $settings | Add-Member -NotePropertyName hooks -NotePropertyValue ([pscustomobject]@{})
+}
+
+$escapedHook = $hookTarget.Replace("\", "/")
+$command = "python `"$escapedHook`""
+
+function Add-FleetHook {
+    param(
+        [Parameter(Mandatory)][string]$EventName,
+        [Parameter(Mandatory)][string]$Matcher
+    )
+
+    $entry = [pscustomobject]@{
+        matcher = $Matcher
+        hooks = @(
+            [pscustomobject]@{
+                type = "command"
+                command = $command
+                timeout = 10
+            }
+        )
+    }
+    $property = $settings.hooks.PSObject.Properties[$EventName]
+    $current = if ($property) { @($property.Value) } else { @() }
+    $current = @($current | Where-Object {
+        $commands = @($_.hooks | ForEach-Object { $_.command })
+        $commands -notcontains $command
+    })
+    $settings.hooks | Add-Member -NotePropertyName $EventName -NotePropertyValue @($current + $entry) -Force
+}
+
+Add-FleetHook -EventName "PreCompact" -Matcher "auto|manual"
+Add-FleetHook -EventName "PostCompact" -Matcher "auto|manual"
+Add-FleetHook -EventName "SessionStart" -Matcher "compact"
+
+$settings | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $settingsPath -Encoding utf8
+Get-Content -LiteralPath $settingsPath -Raw | ConvertFrom-Json | Out-Null
+
+$smokeLog = Join-Path $hookDirectory "fleet_compaction_smoke.jsonl"
+$smokeLock = "$smokeLog.lock"
+Remove-Item -LiteralPath $smokeLog, $smokeLock -Force -ErrorAction SilentlyContinue
+$previousLog = [Environment]::GetEnvironmentVariable("CLAUDE_FLEET_COMPACTION_LOG", "Process")
+try {
+    [Environment]::SetEnvironmentVariable("CLAUDE_FLEET_COMPACTION_LOG", $smokeLog, "Process")
+    $payload = [pscustomobject]@{
+        hook_event_name = "PostCompact"
+        session_id = "fleet-install-smoke"
+        cwd = $PSScriptRoot
+        trigger = "manual"
+        transcript_path = "private-smoke-transcript"
+        compact_summary = "private smoke summary"
+    } | ConvertTo-Json -Compress
+    $payload | & python $hookTarget
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $smokeLog)) {
+        throw "Installed hook smoke test failed"
+    }
+    $smokeMetrics = & python $queryTarget --log-path $smokeLog | ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0 -or @($smokeMetrics).Count -ne 1) {
+        throw "Installed DuckDB telemetry query smoke test failed"
+    }
+} finally {
+    [Environment]::SetEnvironmentVariable("CLAUDE_FLEET_COMPACTION_LOG", $previousLog, "Process")
+    Remove-Item -LiteralPath $smokeLog, $smokeLock -Force -ErrorAction SilentlyContinue
+}
+
+[pscustomobject]@{
+    settings = $settingsPath
+    hook = $hookTarget
+    query = $queryTarget
+    threshold = $Threshold
+    events = @("PreCompact", "PostCompact", "SessionStart:compact")
+    smoke_test = "passed"
+} | ConvertTo-Json -Depth 4

--- a/scripts/query_compaction_telemetry.py
+++ b/scripts/query_compaction_telemetry.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Query Claude compaction JSONL through DuckDB and emit fleet metrics as JSON."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+
+def sql_literal(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--log-path",
+        type=Path,
+        default=Path.home() / ".agents" / "compaction-events.jsonl",
+    )
+    args = parser.parse_args()
+    if not args.log_path.exists():
+        parser.error(f"telemetry log does not exist: {args.log_path}")
+    duckdb = shutil.which("duckdb")
+    if not duckdb:
+        parser.error("duckdb CLI is required")
+    source = sql_literal(args.log_path.resolve().as_posix())
+    query = f"""
+WITH events AS (
+  SELECT * FROM read_json_auto('{source}', format='newline_delimited', union_by_name=true)
+)
+SELECT
+  repo,
+  count(*) AS lifecycle_events,
+  count(*) FILTER (event = 'post_compact') AS completed_compactions,
+  count(*) FILTER (event = 'session_rehydrated') AS recoveries,
+  max(ts) AS latest_event,
+  max(project_setting) FILTER (project_setting = 'obsolete-key') AS obsolete_project_setting
+FROM events
+GROUP BY repo
+ORDER BY latest_event DESC, repo;
+"""
+    result = subprocess.run(
+        [duckdb, "-json", "-c", query],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        return result.returncode
+    sys.stdout.write(result.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/query_compaction_telemetry.py
+++ b/scripts/query_compaction_telemetry.py
@@ -14,6 +14,24 @@ def sql_literal(value: str) -> str:
     return value.replace("'", "''")
 
 
+def build_query(source: str) -> str:
+    return f"""
+WITH events AS (
+  SELECT * FROM read_json_auto('{source}', format='newline_delimited', union_by_name=true)
+)
+SELECT
+  repo,
+  count(*) AS lifecycle_events,
+  count(*) FILTER (WHERE event = 'post_compact') AS completed_compactions,
+  count(*) FILTER (WHERE event = 'session_rehydrated') AS recoveries,
+  max(ts) AS latest_event,
+  max(project_setting) FILTER (WHERE project_setting = 'obsolete-key') AS obsolete_project_setting
+FROM events
+GROUP BY repo
+ORDER BY latest_event DESC, repo;
+"""
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -28,21 +46,7 @@ def main() -> int:
     if not duckdb:
         parser.error("duckdb CLI is required")
     source = sql_literal(args.log_path.resolve().as_posix())
-    query = f"""
-WITH events AS (
-  SELECT * FROM read_json_auto('{source}', format='newline_delimited', union_by_name=true)
-)
-SELECT
-  repo,
-  count(*) AS lifecycle_events,
-  count(*) FILTER (event = 'post_compact') AS completed_compactions,
-  count(*) FILTER (event = 'session_rehydrated') AS recoveries,
-  max(ts) AS latest_event,
-  max(project_setting) FILTER (project_setting = 'obsolete-key') AS obsolete_project_setting
-FROM events
-GROUP BY repo
-ORDER BY latest_event DESC, repo;
-"""
+    query = build_query(source)
     result = subprocess.run(
         [duckdb, "-json", "-c", query],
         check=False,

--- a/scripts/test_claude_compaction_hook.py
+++ b/scripts/test_claude_compaction_hook.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import shutil
+import subprocess
 import tempfile
 import unittest
 from unittest.mock import patch
 
-from claude_compaction_hook import handle, sha256_text
+from claude_compaction_hook import handle, project_setting_status, sha256_text
+from query_compaction_telemetry import build_query
 
 
 class ClaudeCompactionHookTests(unittest.TestCase):
@@ -69,6 +72,60 @@ class ClaudeCompactionHookTests(unittest.TestCase):
                 )
             assert row is not None
             self.assertEqual(row["project_setting"], "obsolete-key")
+
+    def test_obsolete_project_setting_wins_when_both_keys_exist(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / ".claude").mkdir()
+            (root / ".claude" / "settings.json").write_text(
+                json.dumps(
+                    {
+                        "env": {
+                            "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "40",
+                            "CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE": "40",
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(project_setting_status(root), "obsolete-key")
+
+    def test_duckdb_filter_query_executes(self) -> None:
+        duckdb = shutil.which("duckdb")
+        if not duckdb:
+            self.skipTest("duckdb CLI is not installed")
+        with tempfile.TemporaryDirectory() as temp:
+            log_path = Path(temp) / "events.jsonl"
+            rows = [
+                {
+                    "repo": "ix",
+                    "event": "post_compact",
+                    "ts": "2026-07-22T00:00:00Z",
+                    "project_setting": "supported",
+                },
+                {
+                    "repo": "ix",
+                    "event": "session_rehydrated",
+                    "ts": "2026-07-22T00:01:00Z",
+                    "project_setting": "obsolete-key",
+                },
+            ]
+            log_path.write_text(
+                "".join(json.dumps(row) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+            query = build_query(log_path.resolve().as_posix().replace("'", "''"))
+            result = subprocess.run(
+                [duckdb, "-json", "-c", query],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            metrics = json.loads(result.stdout)
+            self.assertEqual(metrics[0]["completed_compactions"], 1)
+            self.assertEqual(metrics[0]["recoveries"], 1)
+            self.assertEqual(metrics[0]["obsolete_project_setting"], "obsolete-key")
 
     def test_unrelated_hook_is_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/test_claude_compaction_hook.py
+++ b/scripts/test_claude_compaction_hook.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from claude_compaction_hook import handle, sha256_text
+
+
+class ClaudeCompactionHookTests(unittest.TestCase):
+    def test_summary_is_hashed_not_persisted_and_duckdb_can_query(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / ".claude").mkdir()
+            (root / ".claude" / "settings.json").write_text(
+                json.dumps({"env": {"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "40"}}),
+                encoding="utf-8",
+            )
+            log_path = root / "events.jsonl"
+            payload = {
+                "hook_event_name": "PostCompact",
+                "session_id": "ix-live",
+                "cwd": str(root),
+                "trigger": "auto",
+                "transcript_path": "C:/private/transcript.jsonl",
+                "compact_summary": "secret summary body",
+            }
+            with patch(
+                "claude_compaction_hook.repository_identity",
+                return_value=("ix", "feat/fleet", root),
+            ):
+                row = handle(payload, log_path)
+
+            self.assertIsNotNone(row)
+            assert row is not None
+            self.assertEqual(row["project_setting"], "supported")
+            self.assertEqual(row["summary_chars"], len("secret summary body"))
+            self.assertEqual(row["summary_sha256"], sha256_text("secret summary body"))
+            persisted = log_path.read_text(encoding="utf-8")
+            self.assertNotIn("secret summary body", persisted)
+            self.assertNotIn("C:/private/transcript.jsonl", persisted)
+
+    def test_obsolete_project_setting_is_detected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / ".claude").mkdir()
+            (root / ".claude" / "settings.json").write_text(
+                json.dumps(
+                    {"env": {"CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE": "40"}}
+                ),
+                encoding="utf-8",
+            )
+            with patch(
+                "claude_compaction_hook.repository_identity",
+                return_value=("ga", "main", root),
+            ):
+                row = handle(
+                    {
+                        "hook_event_name": "PreCompact",
+                        "session_id": "ga-live",
+                        "cwd": str(root),
+                        "trigger": "auto",
+                    },
+                    root / "events.jsonl",
+                )
+            assert row is not None
+            self.assertEqual(row["project_setting"], "obsolete-key")
+
+    def test_unrelated_hook_is_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            result = handle(
+                {"hook_event_name": "PostToolUse", "session_id": "noop"},
+                Path(temp) / "events.jsonl",
+            )
+            self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Adds a tested Claude Code lifecycle slice: PreCompact/PostCompact/compact SessionStart events are recorded as privacy-safe JSONL, queried with DuckDB, and surfaced as fleet evidence.

## Boundaries

- Stores only SHA-256 hashes and character counts; never transcript paths or compact summaries.
- Detects the obsolete repo-local CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE spelling.
- Installs idempotently at user scope while preserving unrelated Claude settings/hooks.
- Hook failures never block sessions.

## Verification

- python scripts/test_claude_compaction_hook.py -v (3/3)
- pwsh scripts/verify.ps1
- production-location installer smoke: hook -> JSONL -> DuckDB passed

Global dogfood installation is active on this Windows host at a 40% threshold.