### PR TITLE
fix(harness): use supported auto-compaction key

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE": "40"
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "40"
   },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,


### PR DESCRIPTION
Corrects the repo-local Claude Code auto-compaction environment key. The previous CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE spelling is unsupported and therefore a no-op; CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=40 is the documented key. Scope is one JSON property. Verification: settings parse successfully, supported value equals 40, obsolete property is absent. This complements the installed fleet compaction lifecycle telemetry and makes the intended threshold portable to every contributor/session.