### PR TITLE
fix(ci): risk-report must not fail closed on a comment-POST flake (#773)

### DIFF
--- a/.github/workflows/agent-blackbox.yml
+++ b/.github/workflows/agent-blackbox.yml
@@ -107,9 +107,14 @@ jobs:
           fi
           PYTHONPATH=.agent-blackbox python -m cli.agent_blackbox "${analyze_args[@]}"
 
+      # Reporting must never decide the gate. A transient 5xx on the comments API
+      # says nothing about the risk of the change, so this step retries and is
+      # allowed to fail; the verdict is enforced below, and stays fail-closed.
       - name: Comment risk report
         uses: actions/github-script@v7
+        continue-on-error: true
         with:
+          retries: 3
           script: |
             const fs = require('fs');
             const marker = '<!-- agent-blackbox-risk-report -->';

--- a/scripts/test_agent_blackbox_gate.py
+++ b/scripts/test_agent_blackbox_gate.py
@@ -1,0 +1,109 @@
+"""Invariant tests for the agent-blackbox risk-report merge gate.
+
+The gate conflates nothing: *reporting* the risk and *enforcing* the verdict are
+separate steps with opposite failure policies. Reporting may fail (a 5xx on the
+comments API says nothing about the risk of a change — see #773); enforcement may
+not (it is the merge gate itself).
+
+These tests pin that asymmetry against the workflow YAML so a later edit cannot
+quietly invert it — the concern #641 raises about PRs that weaken the guardrail
+gating them.
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "agent-blackbox.yml"
+
+COMMENT_STEP = "Comment risk report"
+ENFORCE_STEP = "Enforce verdict"
+
+
+def _steps() -> list[dict]:
+    # PyYAML parses the unquoted `on:` key as boolean True; irrelevant here, we
+    # only read jobs.
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return doc["jobs"]["risk-report"]["steps"]
+
+
+def _step(name: str) -> dict:
+    for step in _steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"step {name!r} not found in risk-report job")
+
+
+class TestReportingIsNonBlocking(unittest.TestCase):
+    """Reporting is best-effort: it retries, and it may not fail the job."""
+
+    def test_comment_step_exists(self):
+        self.assertIsNotNone(_step(COMMENT_STEP))
+
+    def test_comment_step_is_continue_on_error(self):
+        step = _step(COMMENT_STEP)
+        self.assertIs(
+            step.get("continue-on-error"),
+            True,
+            "the comment step must not be able to fail the gate; a transient 5xx "
+            "on POST /issues/{n}/comments is not a risk signal (#773)",
+        )
+
+    def test_comment_step_retries_5xx(self):
+        step = _step(COMMENT_STEP)
+        retries = step.get("with", {}).get("retries")
+        self.assertIsNotNone(retries, "comment step must set an explicit retries count")
+        self.assertGreaterEqual(
+            int(retries), 1, "retries: 0 is what made a platform outage block a merge (#773)"
+        )
+
+    def test_comment_step_does_not_exempt_5xx_from_retry(self):
+        # github-script's default retry-exempt list is 400,401,403,404,422 — all 4xx.
+        # If someone adds 5xx codes here, retries stop covering the outage case.
+        exempt = str(_step(COMMENT_STEP).get("with", {}).get("retry-exempt-status-codes", ""))
+        for code in exempt.replace(" ", "").split(","):
+            if code:
+                self.assertLess(
+                    int(code), 500, f"{code} is exempted from retry, defeating the #773 fix"
+                )
+
+
+class TestEnforcementStaysFailClosed(unittest.TestCase):
+    """Enforcement is the gate. It must be able to fail the job."""
+
+    def test_enforce_step_exists(self):
+        self.assertIsNotNone(_step(ENFORCE_STEP))
+
+    def test_enforce_step_is_not_continue_on_error(self):
+        step = _step(ENFORCE_STEP)
+        self.assertNotEqual(
+            step.get("continue-on-error"),
+            True,
+            "the verdict path must stay fail-closed — a 'block' verdict has to fail "
+            "the job, or risk-report is no longer a merge gate (#773 non-goal)",
+        )
+
+    def test_enforce_step_runs_after_comment_step(self):
+        names = [s.get("name") for s in _steps()]
+        self.assertLess(
+            names.index(COMMENT_STEP),
+            names.index(ENFORCE_STEP),
+            "enforcement must run after reporting, so a skipped comment still reaches the gate",
+        )
+
+    def test_only_the_reviewed_label_can_bypass_enforcement(self):
+        # The single sanctioned bypass is the human-attestation label. If another
+        # escape hatch appears in this step, it is a new way to merge unreviewed.
+        run = _step(ENFORCE_STEP).get("run", "")
+        self.assertIn("AGENT_BLACKBOX_REVIEWED", run)
+        self.assertEqual(
+            run.count("exit 0"),
+            1,
+            "exactly one unconditional-success path (the reviewed-label override) "
+            "should exist in the enforcement step",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #773.

## The problem

`risk-report` is a fail-closed merge gate, and it conflated two different outcomes:

1. **"the change is risky"** — a real, blocking signal
2. **"we could not post a comment about the change"** — an infrastructure flake

On PR #772 the risk assessment *passed* (verdict `pass`, score 0.00, 7/7 evidence sources healthy) but the job failed, because `POST /issues/772/comments` returned a 503 during a wider GitHub API outage. The failure mode is mildly perverse: the more degraded GitHub is, the more likely *reporting* fails while the *verdict* is fine.

## The fix

Cause was visible in the run log — the comment step ran `github-script` with `retries: 0`, while its default `retry-exempt-status-codes` (`400,401,403,404,422`) already excludes 5xx. Retries alone would have ridden the outage out transparently.

Scoped to the **reporting path only**:

- `retries: 3` on the *Comment risk report* step
- `continue-on-error: true` on that step, so reporting can never decide the gate

## The verdict path is untouched

Per the issue's explicit non-goal, the gate is not weakened:

- *Enforce verdict* still runs (after the comment step) and still fails the job on a `block` verdict
- `agent-blackbox-reviewed` remains the single sanctioned bypass — it is a human review attestation and is explicitly **not** the remedy for an infra flake

## Regression test

`scripts/test_agent_blackbox_gate.py` pins the asymmetry so a later edit cannot quietly invert it — the concern #641 raises about PRs weakening the guardrail that gates them:

| Reporting (best-effort) | Enforcement (fail-closed) |
|---|---|
| must be `continue-on-error` | must **not** be `continue-on-error` |
| must set `retries >= 1` | must run after reporting |
| must not exempt 5xx from retry | must keep exactly one unconditional-success path |

**Evidence the tests are not born dead** — both mutations were run and observed, not assumed:

| Mutation | Result |
|---|---|
| Revert the fix (drop `retries` + `continue-on-error`) | 2 failures |
| Weaken the gate (add `continue-on-error` to *Enforce verdict*) | 1 failure |
| Restored | 8/8 pass |

Full suite as CI runs it (`python -m unittest discover -s scripts -p 'test_*.py'`): **307 pass**. CI picks the file up automatically via `governance-validate.yml`'s `unit-tests` job; `pyyaml` is already installed there.

## Acceptance, against the issue

- [x] A 5xx from the comment API does not fail the `risk-report` job — the step retries 3×, and cannot fail the job even if all retries are exhausted
- [x] A genuine risk verdict of `block` still fails it — *Enforce verdict* unchanged, and now guarded by a test

## Note for review

This PR touches `.github/workflows/**`, a blocked path, so `risk-report` will fail on it **by design**. It needs your `agent-blackbox-reviewed` label to merge — I have deliberately not applied it to my own change to a guardrail path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)