### PR TITLE
fix(aiw): distinguish an invalid policy from a governed block (#794)

### DIFF
--- a/scripts/aiw_budget_gate.py
+++ b/scripts/aiw_budget_gate.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 import hashlib
 import json
 import math
@@ -33,6 +33,18 @@ def _load(path: Path) -> dict[str, Any]:
     return value
 
 
+class PolicyInvalid(ValueError):
+    """The budget policy file itself is malformed or out of bounds.
+
+    Distinct from an ordinary budget block. "We are out of budget" and "the file
+    that decides the budget is broken" need opposite responses — the first is the
+    gate working, the second is the gate being unable to work — and collapsing
+    both into one reason code leaves an operator unable to tell them apart (#794).
+
+    Subclasses ValueError so main()'s existing exit-2 mapping is unchanged.
+    """
+
+
 def load_policy(path: Path | None = None) -> dict[str, Any]:
     """Load the budget policy and validate it against its schema, fail-closed.
 
@@ -41,14 +53,19 @@ def load_policy(path: Path | None = None) -> dict[str, Any]:
     error rather than a silent no-op. Every failure is raised as ValueError so
     main() maps it to exit 2 (invalid) rather than exit 1 (governed block).
     """
-    policy = _load(POLICY_PATH if path is None else path)
+    # An absent or unparseable policy file is the same class of failure as one
+    # that fails schema validation: the gate cannot establish what it may spend.
+    try:
+        policy = _load(POLICY_PATH if path is None else path)
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        raise PolicyInvalid(f"policy could not be loaded: {error}") from error
     try:
         import jsonschema  # noqa: PLC0415 — optional dependency, imported lazily
     except ImportError as error:
         # demerzel_kit.validate() degrades to a warning when jsonschema is
         # absent. That is right for a reporting emitter and wrong for a spend
         # gate, so this caller refuses instead.
-        raise ValueError(
+        raise PolicyInvalid(
             "jsonschema is required to validate the AIW budget policy") from error
     try:
         demerzel_kit.validate(policy, "aiw-budget-policy")
@@ -56,17 +73,17 @@ def load_policy(path: Path | None = None) -> dict[str, Any]:
         # json_path locates the offending key. Without it the message alone
         # ("True was expected") names neither field nor provider, which is not
         # enough to find the key in a 7-provider file under time pressure.
-        raise ValueError(
+        raise PolicyInvalid(
             f"policy is invalid at {error.json_path}: {error.message}") from error
 
     # JSON Schema cannot express these cross-references within one document.
     ids = [provider["id"] for provider in policy["providers"]]
     duplicates = {name for name in ids if ids.count(name) > 1}
     if duplicates:
-        raise ValueError(f"policy declares duplicate provider ids: {sorted(duplicates)}")
+        raise PolicyInvalid(f"policy declares duplicate provider ids: {sorted(duplicates)}")
     undeclared = [name for name in policy["selection_order"] if name not in ids]
     if undeclared:
-        raise ValueError(f"selection_order names undeclared providers: {undeclared}")
+        raise PolicyInvalid(f"selection_order names undeclared providers: {undeclared}")
     return policy
 
 
@@ -262,6 +279,44 @@ def reserve(policy: dict[str, Any], request: dict[str, Any], cycle_path: Path,
             cycle_path.write_text(json.dumps(cycle, indent=2, sort_keys=True,
                                              allow_nan=False) + "\n", encoding="utf-8")
         return result
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+
+def note_release_failure(cycle_path: Path, job_id: str, error: str) -> bool:
+    """Record that a release was attempted and swallowed, leaving a reservation open.
+
+    The caller's ``except Exception`` around release is deliberate — a
+    reconciliation hiccup must never break the loop — but the consequence is that
+    reservations silently stop clearing while the cycle ledger keeps counting them
+    as committed spend, and ``max_parallel_packets`` fills with reservations that
+    will never clear. Fail-closed in the money direction, but a liveness failure:
+    the cycle wedges quietly rather than stopping loudly (#794).
+
+    Writing the swallow down makes that state detectable afterwards. Returns True
+    if the note was recorded. Never raises: a failure to record a failure must not
+    become a second failure.
+    """
+    try:
+        lock_path = _lock(cycle_path)
+    except ValueError:
+        return False
+    try:
+        cycle = _read_cycle(cycle_path)
+        notes = cycle.setdefault("release_failures", [])
+        if not isinstance(notes, list):
+            return False
+        notes.append({
+            "job_id": job_id,
+            "error": str(error)[:200],
+            "at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "reservation_open": job_id in cycle.get("reservations", {}),
+        })
+        cycle_path.write_text(json.dumps(cycle, indent=2, sort_keys=True,
+                                         allow_nan=False) + "\n", encoding="utf-8")
+        return True
+    except Exception:  # noqa: BLE001 — recording is best-effort by construction
+        return False
     finally:
         lock_path.unlink(missing_ok=True)
 

--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -123,7 +123,14 @@ def _budget_reserve(issue: dict, backend: str) -> tuple[bool, dict]:
         policy = budget.load_policy(budget.POLICY_PATH)
         result = budget.reserve(policy, _budget_request(issue, backend),
                                 budget.CYCLE_LEDGER_PATH)
-    except Exception as exc:  # a broken/absent policy must fail closed
+    except budget.PolicyInvalid as exc:
+        # Distinct from budget_preflight_error on purpose: "the policy file is
+        # broken" and "this job does not fit the budget" demand opposite
+        # responses, and an operator reading the cycle output could not tell
+        # them apart when both surfaced as the same reason (#794).
+        return False, {"decision": "block", "reasons": ["policy_invalid"],
+                       "error": str(exc)[:200]}
+    except Exception as exc:  # any other preflight failure must also fail closed
         return False, {"decision": "block", "reasons": ["budget_preflight_error"],
                        "error": str(exc)[:200]}
     return result.get("decision") == "allow", result
@@ -132,11 +139,22 @@ def _budget_reserve(issue: dict, backend: str) -> tuple[bool, dict]:
 def _budget_release(issue: dict, actual_cost_usd: float = 0.0) -> None:
     """Best-effort reservation release after an episode; a reconciliation hiccup
     must never break the loop. Local-seat backends carry no marginal spend."""
+    job_id = f"aiw-{issue.get('number')}"
     try:
-        budget.release(budget.CYCLE_LEDGER_PATH, f"aiw-{issue.get('number')}",
-                       actual_cost_usd, policy=budget.load_policy(budget.POLICY_PATH))
+        budget.release(budget.CYCLE_LEDGER_PATH, job_id, actual_cost_usd,
+                       policy=budget.load_policy(budget.POLICY_PATH))
     except Exception as exc:
-        print(f"budget release skipped for #{issue.get('number')}: {exc}",
+        # The breadth here is deliberate — release failure must never break the
+        # loop. But a swallowed release leaves the reservation open, so the
+        # ledger over-reports committed spend and max_parallel_packets fills with
+        # reservations that never clear. Write the swallow down so that state is
+        # detectable afterwards instead of silent (#794).
+        try:
+            noted = budget.note_release_failure(budget.CYCLE_LEDGER_PATH, job_id, str(exc))
+        except Exception:  # noqa: BLE001 — recording a failure must never become one
+            noted = False
+        print(f"budget release skipped for #{issue.get('number')}: {exc}"
+              f"{'' if noted else ' (and the ledger note could not be written)'}",
               file=sys.stderr)
 
 
@@ -739,6 +757,18 @@ def main(argv: list[str]) -> int:
                               "action": "implement" if eligible else "skip:needs-human-preapproval"})
         _print_summary(decisions, len(issues), True, args.max_parallel, args.backend, today)
         return 0
+
+    # Live: an invalid policy is not a per-job condition, so discovering it once
+    # per reservation is both noisy and too late — the first job blocks, every
+    # subsequent job blocks for the same reason, and any release in flight is
+    # swallowed. Establish that the gate can function before starting work (#794).
+    if issues:
+        try:
+            budget.load_policy(budget.POLICY_PATH)
+        except budget.PolicyInvalid as exc:
+            print(f"ABORT: budget policy is invalid, refusing to start a cycle: {exc}",
+                  file=sys.stderr)
+            return 2
 
     # Live: ensure the sandbox backend is ready once, up front.
     if args.backend == "local" and issues:

--- a/scripts/test_aiw_budget_gate.py
+++ b/scripts/test_aiw_budget_gate.py
@@ -529,3 +529,98 @@ class PolicySchemaTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPolicyInvalidIsDistinct(unittest.TestCase):
+    """#794: a corrupt policy and an ordinary budget block need opposite
+    responses, so they must not be the same exception class."""
+
+    def _load_mutated(self, mutator):
+        policy = json.loads(json.dumps(POLICY))
+        mutator(policy)
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "policy.json"
+        path.write_text(json.dumps(policy), encoding="utf-8")
+        return load_policy(path)
+
+    def test_schema_violation_raises_policy_invalid(self):
+        def mutate(policy):
+            policy["defaults"]["max_cost_usd_per_job"] = -999
+        with self.assertRaises(aiw_budget_gate.PolicyInvalid):
+            self._load_mutated(mutate)
+
+    def test_undeclared_selection_order_raises_policy_invalid(self):
+        def mutate(policy):
+            policy["selection_order"].append("no-such-provider")
+        with self.assertRaises(aiw_budget_gate.PolicyInvalid):
+            self._load_mutated(mutate)
+
+    def test_missing_file_raises_policy_invalid(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        with self.assertRaises(aiw_budget_gate.PolicyInvalid):
+            load_policy(Path(directory.name) / "absent.json")
+
+    def test_unparseable_file_raises_policy_invalid(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "policy.json"
+        path.write_text("{not json", encoding="utf-8")
+        with self.assertRaises(aiw_budget_gate.PolicyInvalid):
+            load_policy(path)
+
+    def test_policy_invalid_is_still_a_value_error(self):
+        # main() maps ValueError to exit 2; that mapping must not change.
+        self.assertTrue(issubclass(aiw_budget_gate.PolicyInvalid, ValueError))
+
+    def test_shipped_policy_does_not_raise(self):
+        self.assertEqual(POLICY, load_policy(aiw_budget_gate.POLICY_PATH))
+
+
+class TestNoteReleaseFailure(unittest.TestCase):
+    """#794: a swallowed release leaves the reservation open. Record it, so an
+    unreconciled reservation is detectable instead of silent."""
+
+    def _ledger(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        return Path(directory.name) / "cycle.json"
+
+    def test_records_the_swallow_against_an_open_reservation(self):
+        path = self._ledger()
+        aiw_budget_gate.reserve(POLICY, request(job_id="aiw-1"), path)
+        self.assertTrue(aiw_budget_gate.note_release_failure(path, "aiw-1", "boom"))
+        cycle = json.loads(path.read_text())
+        note = cycle["release_failures"][0]
+        self.assertEqual(note["job_id"], "aiw-1")
+        self.assertIn("boom", note["error"])
+        self.assertTrue(note["reservation_open"])
+        self.assertTrue(note["at"].endswith("Z"))
+
+    def test_note_does_not_disturb_ledger_invariants(self):
+        # _read_cycle asserts reserved_cost == sum(reservations) and
+        # active_packets == len(reservations). A note must not perturb either,
+        # or the next reserve() would fail closed on a ledger it wrote itself.
+        path = self._ledger()
+        aiw_budget_gate.reserve(POLICY, request(job_id="aiw-1"), path)
+        before = json.loads(path.read_text())
+        aiw_budget_gate.note_release_failure(path, "aiw-1", "boom")
+        after = json.loads(path.read_text())
+        self.assertEqual(before["reserved_cost_usd"], after["reserved_cost_usd"])
+        self.assertEqual(before["active_packets"], after["active_packets"])
+        self.assertEqual(before["reservations"], after["reservations"])
+        aiw_budget_gate.reserve(POLICY, request(job_id="aiw-2"), path)  # still loadable
+
+    def test_notes_accumulate(self):
+        path = self._ledger()
+        aiw_budget_gate.reserve(POLICY, request(job_id="aiw-1"), path)
+        aiw_budget_gate.note_release_failure(path, "aiw-1", "first")
+        aiw_budget_gate.note_release_failure(path, "aiw-1", "second")
+        self.assertEqual(len(json.loads(path.read_text())["release_failures"]), 2)
+
+    def test_never_raises_when_the_ledger_is_unwritable(self):
+        # Recording a failure must not become a second failure.
+        path = self._ledger()
+        path.write_text("{not json", encoding="utf-8")
+        self.assertFalse(aiw_budget_gate.note_release_failure(path, "aiw-1", "boom"))

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -423,3 +423,93 @@ class TestBudgetGate(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPolicyInvalidDistinctFromBlock(unittest.TestCase):
+    """#794: on the AFK path an invalid policy was indistinguishable from an
+    ordinary governed block, and a release failure vanished entirely."""
+
+    def _issue(self):
+        return {"number": 77, "title": "fix docs typo", "body": "x", "labels": []}
+
+    def test_invalid_policy_reserves_with_its_own_reason_code(self):
+        # Measured in the issue: reasons=['budget_preflight_error'] for a corrupt
+        # policy — the same code an out-of-budget job gets.
+        with mock.patch.object(g.budget, "load_policy",
+                               side_effect=g.budget.PolicyInvalid(
+                                   "-999 is less than or equal to the minimum of 0")):
+            allowed, result = g._budget_reserve(self._issue(), "local")
+        self.assertFalse(allowed)
+        self.assertEqual(result["reasons"], ["policy_invalid"])
+        self.assertNotIn("budget_preflight_error", result["reasons"])
+        self.assertIn("-999", result["error"])
+
+    def test_other_preflight_errors_keep_the_original_reason_code(self):
+        # The distinction must be narrow: only policy validity moves.
+        with mock.patch.object(g.budget, "load_policy",
+                               side_effect=RuntimeError("ledger is busy")):
+            allowed, result = g._budget_reserve(self._issue(), "local")
+        self.assertFalse(allowed)
+        self.assertEqual(result["reasons"], ["budget_preflight_error"])
+
+    def test_reserve_still_fails_closed_for_both(self):
+        for exc in (g.budget.PolicyInvalid("bad"), RuntimeError("other")):
+            with mock.patch.object(g.budget, "load_policy", side_effect=exc):
+                allowed, result = g._budget_reserve(self._issue(), "local")
+            self.assertFalse(allowed, f"{type(exc).__name__} must never allow")
+            self.assertEqual(result["decision"], "block")
+
+    def test_release_failure_is_recorded_not_just_swallowed(self):
+        # Measured in the issue: "_budget_release returned normally (swallowed)".
+        # It must still return normally, but leave a trace.
+        with mock.patch.object(g.budget, "load_policy",
+                               side_effect=g.budget.PolicyInvalid("bad")), \
+             mock.patch.object(g.budget, "note_release_failure",
+                               return_value=True) as note:
+            g._budget_release(self._issue(), actual_cost_usd=0.0)   # must not raise
+        note.assert_called_once()
+        self.assertEqual(note.call_args[0][1], "aiw-77")
+        self.assertIn("bad", note.call_args[0][2])
+
+    def test_release_survives_a_failure_to_record_the_failure(self):
+        # The reason release swallows at all is that a reconciliation hiccup must
+        # never break the loop. Adding bookkeeping must not smuggle a new way for
+        # it to break: if the note itself fails, release still returns normally.
+        with mock.patch.object(g.budget, "load_policy",
+                               side_effect=g.budget.PolicyInvalid("bad")), \
+             mock.patch.object(g.budget, "note_release_failure",
+                               side_effect=OSError("ledger gone")):
+            g._budget_release(self._issue(), actual_cost_usd=0.0)   # must not raise
+
+    def test_cycle_refuses_to_start_on_an_invalid_policy(self):
+        # An invalid policy is not a per-job condition: validate once, up front,
+        # and refuse — rather than blocking every job for the same reason while
+        # swallowing every release in flight.
+        with mock.patch.object(g, "_gh_queue", return_value=[self._issue()]), \
+             mock.patch.object(g.budget, "load_policy",
+                               side_effect=g.budget.PolicyInvalid("bad policy")), \
+             mock.patch.object(g, "_ensure_podman") as podman, \
+             mock.patch.object(g, "_process_issue") as proc:
+            rc = g.main([])
+        self.assertEqual(rc, 2)          # distinct from 1 (error) and 3 (halted)
+        proc.assert_not_called()         # no work started
+        podman.assert_not_called()       # not even the sandbox came up
+
+    def test_valid_policy_does_not_block_the_cycle(self):
+        with mock.patch.object(g, "_gh_queue", return_value=[self._issue()]), \
+             mock.patch.object(g.budget, "load_policy", return_value={"ok": True}), \
+             mock.patch.object(g, "_ensure_podman", return_value=(True, "")), \
+             mock.patch.object(g, "_process_issue",
+                               return_value=({"issue": 77, "action": "x"}, {})), \
+             mock.patch.object(g, "_write_audit"):
+            rc = g.main([])
+        self.assertEqual(rc, 0)
+
+    def test_dry_run_is_unaffected_by_policy_validity(self):
+        # Dry-run plans only and reserves nothing, so a broken policy must not
+        # stop an operator inspecting the queue.
+        with mock.patch.object(g, "_gh_queue", return_value=[self._issue()]), \
+             mock.patch.object(g.budget, "load_policy",
+                               side_effect=g.budget.PolicyInvalid("bad policy")):
+            rc = g.main(["--dry-run"])
+        self.assertEqual(rc, 0)


### PR DESCRIPTION
Closes #794. **Stacked on #791** (base is `feat/budget-policy-schema`) — it needs that schema to exist for a policy to be *detectably* invalid at all. Retarget to `master` once #791 lands.

## The problem, as measured in the issue

```
=== AFK path: invalid policy -> _budget_reserve ===
  allowed=False  decision=block  reasons=['budget_preflight_error']

=== AFK path: invalid policy -> _budget_release ===
  _budget_release returned normally (swallowed)
```

**Reserve** is safe in the money direction — nothing is granted — but `budget_preflight_error` was emitted for a corrupt policy and an ordinary budget block alike. An operator cannot tell "we are out of budget" from "the policy file is broken", and those need opposite responses.

**Release** is the sharper problem. The broad `except Exception` is deliberate — release failure must never break the loop — but the consequence was that if the policy went invalid mid-cycle, releases silently stopped reconciling while reservations stayed open. The ledger then over-reports committed spend and `max_parallel_packets` fills with reservations that will never clear. Fail-closed in the money direction, but a **liveness** failure: the cycle wedges quietly rather than stopping loudly.

## The fix — all three suggestions, none by removing the broad except

**1. Distinguish the causes.** New `budget.PolicyInvalid` (subclasses `ValueError`, so `main()`'s exit-2 mapping is unchanged) is raised for schema violations, the cross-reference checks, and an absent or unparseable policy file — all of them "the gate cannot establish what it may spend". `_budget_reserve` maps it to its own `policy_invalid` code. Every other preflight failure keeps `budget_preflight_error`, so the distinction stays narrow — there's a test pinning exactly that.

**2. Validate once at cycle start.** An invalid policy is not a per-job condition, so `main()` loads it once on the live path and refuses to begin with **exit 2** (distinct from 1 = error, 3 = halted), rather than blocking every job in turn for the same reason while swallowing every release in flight.

Dry-run is deliberately *unaffected*: it reserves nothing, so a broken policy must not stop an operator inspecting the queue.

**3. Record the swallow.** New `budget.note_release_failure()` appends an entry naming the job, the error, and whether the reservation is still open. Release still swallows and still returns normally — but the unreconciled reservation is now detectable afterwards instead of silent.

Two details worth review:

- The note leaves `reserved_cost_usd`, `active_packets`, and `reservations` untouched, so `_read_cycle`'s invariants still hold on the next read (a reserve immediately after a note is tested).
- `note_release_failure` never raises by construction, **and** `_budget_release` guards the call anyway. Adding bookkeeping must not smuggle in a new way for release to break the loop. My first draft got this wrong — a failing note propagated — and the test that caught it now asserts the correct contract.

## Evidence (run, not assumed)

The issue's own scenario, against a real corrupted policy file, post-fix:

| Path | Before | After |
|---|---|---|
| `_budget_reserve` | `reasons=['budget_preflight_error']` | `reasons=['policy_invalid']` |
| `_budget_release` | returns normally, no trace | returns normally, **ledger records 1 swallowed release** |
| cycle start | discovers per-job, blocks each | `main()` returns **2**, `_process_issue` never called |

Mutation-tested — each claim reverted and the suite observed to fail:

| Mutation | Result |
|---|---|
| Collapse `policy_invalid` back into `budget_preflight_error` | 1 failure |
| Remove the cycle-start preflight | 1 error |
| Stop recording the swallowed release | 1 failure |
| Restored | green |

18 new tests. Full suite **341 pass**; `validate_governance.py` and `build_manifest.py --check` both PASSED.

## Note for review

Touches `scripts/` only — not a blocked path — so `risk-report` should pass on its own merits here. It will still evaluate against the stacked base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)