### PR TITLE
fix(ci): cross-model review must fail loudly, not post a placeholder

### DIFF
--- a/.github/workflows/cross-model-review.yml
+++ b/.github/workflows/cross-model-review.yml
@@ -184,8 +184,21 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
+          # A failed review must not masquerade as a review. The previous form
+          # (`|| echo <placeholder> > /tmp/review_result.txt`) discarded
+          # llm_call's stderr, wrote that placeholder into the review body,
+          # and exited 0 -- so an absent OPENAI_API_KEY and a retired
+          # model id both read as green runs for a week while every PR went
+          # unreviewed. Surface the real diagnostic and let the run go red.
+          # rc carries llm_call's classification: 2 usage, 3 API/transport,
+          # 4 empty/blocked response.
+          rc=0
           bash .github/scripts/llm_call.sh claude "$(cat /tmp/review_prompt.txt)" 2048 \
-            > /tmp/review_result.txt || echo "Review failed: no response" > /tmp/review_result.txt
+            > /tmp/review_result.txt 2> /tmp/review_error.txt || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::Claude review failed (llm_call exit $rc): $(tr '\n' ' ' < /tmp/review_error.txt)"
+            exit "$rc"
+          fi
 
       - name: Run Gemini review
         if: env.SKIP_REVIEW != 'true' && steps.reviewer.outputs.reviewer == 'gemini'
@@ -194,8 +207,17 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GOOGLE_AI_KEY }}
           LLM_GEMINI_MODEL: gemini-2.5-flash
         run: |
+          # NOTE: GOOGLE_AI_KEY is not currently set on this repo, so this step
+          # fails every time gemini is selected. That is now visible instead of
+          # silent -- deliberately left in rotation per owner decision; add the
+          # secret or drop gemini from "Select reviewer model" to resolve.
+          rc=0
           bash .github/scripts/llm_call.sh gemini "$(cat /tmp/review_prompt.txt)" 2048 \
-            > /tmp/review_result.txt || echo "Review failed: no response" > /tmp/review_result.txt
+            > /tmp/review_result.txt 2> /tmp/review_error.txt || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::Gemini review failed (llm_call exit $rc): $(tr '\n' ' ' < /tmp/review_error.txt)"
+            exit "$rc"
+          fi
 
       - name: Run Codex review
         if: env.SKIP_REVIEW != 'true' && steps.reviewer.outputs.reviewer == 'codex'
@@ -203,8 +225,13 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
+          rc=0
           bash .github/scripts/llm_call.sh codex "$(cat /tmp/review_prompt.txt)" 2048 \
-            > /tmp/review_result.txt || echo "Review failed: no response" > /tmp/review_result.txt
+            > /tmp/review_result.txt 2> /tmp/review_error.txt || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::Codex review failed (llm_call exit $rc): $(tr '\n' ' ' < /tmp/review_error.txt)"
+            exit "$rc"
+          fi
 
       - name: Post review to PR
         if: env.SKIP_REVIEW != 'true'


### PR DESCRIPTION
## The loop has never worked

Every cross-model review this repo has run has failed, and every run reported `success`.

| PR | Reviews | Result |
|---|---|---|
| #791 | 8 | `Review failed: no response` |
| #808 | 4 | `Review failed: no response` |
| #809 #813 #817 #829 #833 #836 #839 | 1 each | `Review failed: no response` |

All three reviewer identities — codex, gemini, claude.

## Why it was invisible

Each reviewer step ended:

```bash
bash .github/scripts/llm_call.sh codex "$(cat /tmp/review_prompt.txt)" 2048 \
  > /tmp/review_result.txt || echo <placeholder> > /tmp/review_result.txt
```

`llm_call.sh` writes a precise diagnostic to stderr and exits **2** (usage) / **3** (API or transport) / **4** (empty or blocked). The `||` discarded all of it, wrote a fixed string into the review body, and exited **0** — so the placeholder was posted to the PR *as the review* and the check went green. Same swallow that hid #703 for four weeks.

## Why they were failing

The repo had no `OPENAI_API_KEY`, so `${{ secrets.OPENAI_API_KEY }}` expanded to empty. Run [30267084242](https://github.com/GuitarAlchemist/Demerzel/actions/runs/30267084242) — from #839, ~1h ago:

```
llm_call: API error: You didn't provide an API key.
```

**The secret is now set.** The claude path additionally pins `claude-sonnet-4-20250514`, retired 2026-06-15 — that's #833, still open.

## The structural part

`cross-model-review.yml:90` enforces that no model reviews its own work, so a **claude-authored PR routes to codex or gemini** — both uncredentialed. Claude-authored PRs could never be reviewed. Not flaky; dead by construction, and the swallow is why nobody saw it.

## The fix

All three steps capture stderr, emit `::error::` with the real diagnostic, and exit with llm_call's classification. `Post review to PR` carries a plain `if:`, which GitHub implicitly ANDs with `success()`, so it's skipped on failure — no misleading review gets posted.

Gemini stays in rotation per owner decision. `GOOGLE_AI_KEY` is still unset, so picking gemini now fails **visibly**; the step carries a note saying so.

## Verification

The shipped Codex step body was extracted from the YAML (not retyped) and run under `bash -eo pipefail` both ways:

```
A: invalid key -> ::error::Codex review failed (llm_call exit 3): Incorrect API key provided...
                  exit 3                                                          # red
B: real key    -> exit 0 | review_result.txt = [SEAM OK]                          # posts
```

## Guard gap

`scripts/ecosystem_freshness.py` enumerates workflows with a cron `schedule` block. This one is `pull_request`-triggered, so it sits outside the guard's scope — no freshness check could ever have caught it. Worth a follow-up; not in this PR.

## Merge note

Touches `.github/workflows/**` — blocked path, `risk-report` fails **by design**. Needs the human `agent-blackbox-reviewed` attestation; not self-applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
