### PR TITLE
fix(afk-prompt): require the unit-test suite as an oracle, not just validate_governance

### DIFF
--- a/prompts/afk-implement.prompt.md
+++ b/prompts/afk-implement.prompt.md
@@ -27,9 +27,14 @@ You are operating in the **Cherny lane** (agentic loop), executing a task that h
 ## Definition of done
 1. Make the change.
 2. Run the oracle: `python scripts/validate_governance.py`. It must exit 0.
-3. If it fails, fix your change until it passes (max 5 attempts), or emit
+3. Run the unit tests: `python -m unittest discover -s scripts -p 'test_*.py'`.
+   It must exit 0. `validate_governance.py` checks schemas and the manifest — it
+   does NOT execute the suite, so a signature change can leave it green while CI
+   is red. If you changed a function in `scripts/`, update its `test_*.py`
+   callers in the same commit.
+4. If either fails, fix your change until both pass (max 5 attempts), or emit
    `BLOCKED: oracle failing — <reason>` and stop without committing.
-4. Commit with a conventional-commit message referencing the issue:
+5. Commit with a conventional-commit message referencing the issue:
    `<type>(<scope>): <summary> (#{{ISSUE_NUMBER}})` and the trailer
    `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
-5. When done, print: `<promise>COMPLETE</promise>`.
+6. When done, print: `<promise>COMPLETE</promise>`.


### PR DESCRIPTION
## Problem

`prompts/afk-implement.prompt.md` gave the dispatched agent one oracle:

```
2. Run the oracle: `python scripts/validate_governance.py`. It must exit 0.
```

`validate_governance.py` validates schemas and the manifest. It does **not**
execute `python -m unittest discover -s scripts -p 'test_*.py'`. So an agent
editing `scripts/` can change a function signature, watch its own gate go
green, commit, and open a PR with a red suite.

## Evidence

First governed AFK dispatch, this session: #848 → #857.

The agent's fix was correct — it found the real root cause (`effectiveness` is
a dict in the canonical shape and a free-text string in a legacy record) and
added a per-record isolation guard that reports skips by filename instead of
swallowing them. Mutation-tested locally: the guard fires and names the bad
record.

But `build_rows()` gained a `(rows, skips)` return. `main()` was updated.
`scripts/test_quality_trend.py:43` — `build_rows(...)[0]` — was not. 299 tests
went red. `validate_governance.py` exited 0 throughout.

## Fix

Adds the suite as a second required oracle, states explicitly why the first one
is insufficient, and tells the agent to update `test_*.py` callers in the same
commit.

The constraint already existed in CI. It had no enforcement path inside the
agent's loop, which is the only place it could have prevented the defect.

Related: #776 (nothing schedules this governor at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)