### PR TITLE
docs: relax "no runtime code" to "no consumer or product runtime"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,13 @@ Demerzel contains **no consumer or product runtime**. It is primarily a collecti
 - Skills (`.claude/skills/<name>/SKILL.md`) — Markdown
 - Examples, templates, docs — Markdown + JSON
 
+**"Repository-local tooling" is not a blanket exemption.** Its boundary is the `scripts/`
+adjudication below (CL-817-12), not the sentence above: tooling must serve the governance
+of artifacts in *this* repo. Anything that becomes a dependency of a **consumer repo's**
+runtime belongs in that consumer, with Demerzel keeping only the contract — and that
+includes a client library generated here for a sibling to compile. Generating one is not
+the same as owning its runtime.
+
 **Do not add executable code** (Python, TypeScript, Rust, etc.) outside `scripts/`. If you need a script to support governance work, raise an issue first.
 
 **The `scripts/` exception (owner adjudication, 2026-07-23 — CL-817-12):** `scripts/` is the sanctioned home for governance *tooling*: emitters, linters, validators, CI gates, orchestrators, and local coordination transports (e.g. the Galactic live-session bridge). This codifies long-standing practice (~58 scripts referenced by CI and CLAUDE.md at adjudication time). The boundary is purpose, not language: a script must serve the governance of artifacts in this repo or the fleet sessions working on it — Demerzel still ships no product/runtime code, and nothing in `scripts/` may become a dependency of a consumer repo's runtime. Tooling that outgrows this (a long-running service, a product feature, a consumer-facing library) moves to a sibling repo, with Demerzel keeping only the contract and behavioral tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for contributing to Demerzel — an AI governance framework. Before su
 
 ## What Demerzel Is (and Is Not)
 
-Demerzel contains **no runtime code**. It is a collection of governance artifacts:
+Demerzel contains **no consumer or product runtime**. It is primarily a collection of governance artifacts:
 
 - Personas (`personas/`) — YAML
 - Constitutions (`constitutions/`) — Markdown
@@ -126,7 +126,7 @@ Before opening a PR, confirm:
 
 - [ ] Artifacts validated against their schemas
 - [ ] Behavioral tests added or updated (if persona changed)
-- [ ] No runtime code introduced
+- [ ] No consumer/product runtime introduced; repository-local tooling is issue-backed and tested
 - [ ] No secrets committed
 - [ ] Conventional commit messages used
 - [ ] Constitutional implications noted (which article does this touch?)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Agent governance for the GuitarAlchemist ecosystem — reusable constitutions, personas, alignment policies, tetravalent logic, behavioral tests, and cross-repo loop control. Part of a four-repo ecosystem (`Demerzel` + [`ga`](https://github.com/GuitarAlchemist/ga) .NET + [`ix`](https://github.com/GuitarAlchemist/ix) Rust ML + [`tars`](https://github.com/GuitarAlchemist/tars) F# theory validator).
 
-> Named after [Eto Demerzel](https://asimov.fandom.com/wiki/R._Daneel_Olivaw) — the guardian who shapes policy without wielding direct power. This repo is deliberately separate from runtime code: it defines *how agents should behave*, not *how they compute*.
+> Named after [Eto Demerzel](https://asimov.fandom.com/wiki/R._Daneel_Olivaw) — the guardian who shapes policy without wielding direct power. This repo is deliberately separate from consumer and product runtime code: it defines *how agents should behave* and includes only the repository-local tooling needed to validate and operate that governance.
 
 > **Agent-facing canonical docs:** [`CLAUDE.md`](./CLAUDE.md) (breadcrumb-style) and [`AGENTS.md`](./AGENTS.md) (full development guidelines).
 

--- a/docs/prd/01-demerzel.md
+++ b/docs/prd/01-demerzel.md
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-Demerzel is a specification-only governance framework for AI agents, providing constitutions, personas, policies, behavioral tests, and cross-repo communication contracts. It contains no runtime code -- only YAML, Markdown, and JSON Schema artifacts that consumer repos (ix, tars, ga) adopt via git submodule. Named after Asimov's R. Daneel Olivaw, it enforces a constitutional hierarchy rooted in the Laws of Robotics.
+Demerzel is a governance framework for AI agents, providing constitutions, personas, policies, behavioral tests, cross-repo communication contracts, and bounded repository-local tooling that validates or operates those artifacts. It contains no consumer or product runtime; consumer repos (ix, tars, ga) adopt its governance artifacts via git submodule. Named after Asimov's R. Daneel Olivaw, it enforces a constitutional hierarchy rooted in the Laws of Robotics.
 
 ## Problem Statement
 


### PR DESCRIPTION
Split out of #791 at the owner's request. This is a **normative** change and deserves to be judged on its own merits rather than merged as a side effect of a schema-validation PR.

## The problem

Three documents state that Demerzel contains **"no runtime code"**:

- `CONTRIBUTING.md` — the statement, and the PR checklist item `- [ ] No runtime code introduced`
- `README.md` — "deliberately separate from runtime code"
- `docs/prd/01-demerzel.md` — "specification-only ... contains no runtime code"

That has not been literally true for some time. `scripts/` holds the governance tooling — `validate_governance.py`, `build_manifest.py`, `run_afk_cycle.py`, `aiw_budget_gate.py`, `quality_trend.py` and their test suites — and `CLAUDE.md` already documents the exception verbatim:

> **Demerzel contains no runtime code** — only governance artifacts. (Exception: `scripts/` and `.github/` hold the CI/harness tooling that validates them.)

So the docs contradict `CLAUDE.md` and the tree. The practical consequence is that the checklist item is unanswerable for any PR touching `scripts/` — an author either lies or ignores it, and a checklist item everyone ignores trains people to ignore the rest.

## The change

| | before | after |
|---|---|---|
| statement | "no runtime code" | "no consumer or product runtime" |
| checklist | `No runtime code introduced` | `No consumer/product runtime introduced; repository-local tooling is issue-backed and tested` |

## What this does not do

It does not license consumer or product runtime in this repo. The invariant that matters — Demerzel ships governance, not product — is unchanged. The checklist now asks a narrower, answerable question.

## The honest argument against

This is a relaxation, and relaxations compound. "Repository-local tooling" is a boundary someone must keep enforcing; it is vaguer than "no runtime code", which had the virtue of being unambiguous even while false. The counter-argument is that an unambiguous rule nobody can satisfy is not enforcement, it is decoration — and this repo has spent considerable effort this cycle on exactly that failure mode.

`validate_governance.py` passes. Docs-only; no schema, workflow, or policy paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)