### PR TITLE
fix(afk): default to the subscription backend, not the metered one

### DIFF
--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -17,9 +17,15 @@ origin; PRs are independent. The whole queue is always processed — concurrency
 a throughput cap, not a truncation (waves of --max-parallel at a time).
 
 Backends (--backend):
-  local        — per-agent ephemeral clone + Podman sandbox (default; runs on this box)
-  claude-code  — per-agent ephemeral clone + headless `claude -p` (no container;
-                 bills the interactive subscription, not the spend-capped API key)
+  claude-code  — DEFAULT. Per-agent ephemeral clone + headless `claude -p`, no
+                 container. ANTHROPIC_API_KEY is stripped from the child env, so
+                 the CLI falls back to the interactive subscription.
+  local        — per-agent ephemeral clone + Podman sandbox. Runs on this box and
+                 FORWARDS ANTHROPIC_API_KEY into the sandbox, i.e. it bills
+                 metered API spend. It is currently attributed to `codex-cli`
+                 (local-seat, no approval required) by BACKEND_PROVIDER below, so
+                 that spend passes the AIW budget gate as if it were free
+                 subscription work — see #863. Opt in explicitly, knowing that.
   remote       — Vercel isolated sandboxes (NOT yet implemented; seam reserved)
 
 Usage:
@@ -717,10 +723,14 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--max-parallel", type=int, default=3,
                     help="max concurrent AFK agents (default 3); the whole queue is "
                          "still processed in waves of this size")
-    ap.add_argument("--backend", choices=["local", "remote", "claude-code"], default="local",
-                    help="local = per-agent clone + Podman (default); "
-                         "claude-code = per-agent clone + headless `claude -p` (no container, "
-                         "bills the subscription not the spend-capped API key); "
+    ap.add_argument("--backend", choices=["local", "remote", "claude-code"],
+                    default="claude-code",
+                    help="claude-code = per-agent clone + headless `claude -p` (default; no "
+                         "container, bills the interactive subscription because "
+                         "ANTHROPIC_API_KEY is stripped from the child env); "
+                         "local = per-agent clone + Podman sandbox — NOTE this forwards "
+                         "ANTHROPIC_API_KEY and bills metered API spend, currently "
+                         "misattributed to codex-cli by the budget gate (#863); "
                          "remote = Vercel isolated sandboxes (not yet implemented)")
     ap.add_argument("--harvest", action="store_true",
                     help="self-merge pass: gate already-open AFK PRs through the "


### PR DESCRIPTION
## Problem

`scripts/run_afk_cycle.py --backend` defaulted to **`local`** — the backend that forwards `ANTHROPIC_API_KEY` into the Podman sandbox and bills metered API spend on Opus.

The safe backend already existed. `claude-code` strips the key from the child env so the CLI falls back to the interactive subscription:

```python
env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
cmd = ["claude", "-p", ...]
```

You had to know to ask for it. Running the governor with no flags spent money.

## Why the budget gate didn't catch it

`BACKEND_PROVIDER` maps `local` → `codex-cli`, which `state/driver/aiw-budget-policy.json` classifies as `tier: local-seat`, `cost_model: subscription-or-local`, `requires_manual_approval: false`. So metered Anthropic spend was evaluated against the policy entry for a free subscription provider and waved through.

That misattribution is **#863** and is not fixed here — this PR only makes the safe path the default. The two are independent: even once attribution is correct, defaulting to the spending backend would still be the wrong default.

## Change

- `--backend` default `local` → `claude-code`
- Both the module docstring and the `--help` text now state what `local` actually costs, rather than describing it as merely "runs on this box"

`local` is unchanged and still selectable.

## Verification

Not defaulted on faith — the `claude-code` backend was proven end-to-end first. It implemented #860 in an ephemeral clone and opened #865 with `unit-tests: SUCCESS`.

352/352 tests pass. `--dry-run` reports `backend: claude-code`.

`scripts/` only — no blocked paths.

Related: #863 (attribution), #776 (nothing schedules this governor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)