### PR TITLE
feat(afk): define backend adapter contract (#872)

### DIFF
--- a/docs/solutions/harness/2026-07-29-afk-backend-adapter-contract.md
+++ b/docs/solutions/harness/2026-07-29-afk-backend-adapter-contract.md
@@ -1,0 +1,112 @@
+# AFK Backend Adapter Contract
+
+**Date:** 2026-07-29  
+**Status:** Proposed / design complete, awaiting implementation  
+**Related:** #872, #873, #471, #863, #776
+
+## Problem
+
+`scripts/run_afk_cycle.py` today hardcodes three invocation paths:
+
+- `claude-code` — headless `claude -p` on the subscription
+- `local` — Podman sandcastle running `../afk-harness/.sandcastle/main.mts`
+- `remote` — a stub that returns "not implemented"
+
+Each path is wired directly into `_process_issue`, with branching logic for whether the backend needs a local clone, how it prepares the environment, and how it maps to the AIW budget provider. Adding a new tool (e.g., GitHub Copilot CLI, JetBrains AI, a cloud OpenAI worker) means editing the governor and adding more branches. That is the opposite of tool-agnostic.
+
+## Goal
+
+Make the AFK governor backend-agnostic. Any AI tool that can implement a GitHub issue and return a branch with commits should be pluggable through a small adapter module, with no changes to the governor. The same backend abstraction should work for:
+
+- **desktop tools** (local CLI, IDE agent, container) that run on this host;
+- **cloud tools** (remote sandbox, API endpoint, serverless worker) that do not need a local clone.
+
+## Decision
+
+Introduce an abstract `AFKBackend` contract in `scripts/afk_backends/__init__.py` and load concrete adapters through a registry in `config/afk-backends.yaml`. The governor calls every adapter through the same methods.
+
+### Contract
+
+```python
+class AFKBackend(ABC):
+    @abstractmethod
+    def prepare(self) -> tuple[bool, str]: ...
+    @abstractmethod
+    def needs_local_repo(self) -> bool: ...
+    @abstractmethod
+    def invoke(self, issue: dict, repo_path: str | None) -> dict: ...
+    @abstractmethod
+    def estimate_cost(self, issue: dict) -> dict: ...
+    def cancel(self) -> None: ...
+```
+
+### Return shape of `invoke`
+
+Every adapter returns the same dict, which the governor already understands:
+
+```python
+{
+  "branch": str | None,
+  "commits": list[str],
+  "blocked": str | None,
+}
+```
+
+This is the same shape produced by the sandcastle harness and the headless Claude Code path today. The governor's push/PR/loop-state logic remains unchanged.
+
+### `needs_local_repo`
+
+- **True** for desktop/container backends: the governor prepares an ephemeral clone, checks out a branch, and passes the path.
+- **False** for cloud backends: the adapter receives `repo_path=None` and may pass the GitHub origin URL to the worker instead.
+
+### `prepare`
+
+Called once per cycle before any issue is processed. It is the adapter's responsibility to check prerequisites such as:
+
+- the CLI tool is installed;
+- Podman machine is running;
+- the cloud endpoint is reachable;
+- required credentials are present.
+
+A failed `prepare` aborts the whole cycle deterministically, before any budget is spent.
+
+### `estimate_cost`
+
+Used by the AIW budget gate to reserve budget before invocation. The adapter returns a dict with recognized keys such as `estimated_cost_usd`, `estimated_total_tokens`, `estimated_runner_minutes`. The budget gate already parses these from the issue body; the adapter's estimate can supplement or override them.
+
+### Registry mapping
+
+A declarative registry file will map backend names to adapter classes, execution mode, and budget provider:
+
+```yaml
+backends:
+  claude-code:
+    adapter: scripts.afk_backends.claude_code.ClaudeCodeBackend
+    execution_mode: desktop
+    provider: claude-code-cli
+  local:
+    adapter: scripts.afk_backends.sandcastle.SandcastleBackend
+    execution_mode: desktop
+    provider: anthropic-api
+  remote:
+    adapter: scripts.afk_backends.remote.RemoteBackend
+    execution_mode: cloud
+    provider: cloud-worker
+```
+
+This removes the hardcoded `BACKEND_PROVIDER` dict from `run_afk_cycle.py` and fixes the spend-attribution bug in #863 at the config/policy layer.
+
+## Consequences
+
+- **Pros:** New tools are added without touching the governor. Cloud and desktop backends share the same governance path. The budget provider mapping is visible and version-controlled.
+- **Cons:** A small amount of upfront refactoring is required before the first new tool is added. The registry adds a new file to validate and maintain.
+
+## First steps
+
+1. Land the contract in `scripts/afk_backends/__init__.py` (#872).
+2. Extract the existing `claude-code` and `local` paths into adapter modules (#873).
+3. Add the registry loader and `config/afk-backends.yaml` (#875).
+4. Fix the `local` backend provider mapping to close #863 (#877).
+5. Implement the `remote` cloud-worker adapter (#879).
+6. Add a generic `shell` adapter as proof of abstraction (#882).
+7. Update docs and policy (#884).

--- a/scripts/afk_backends/__init__.py
+++ b/scripts/afk_backends/__init__.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+AFK backend adapter contract.
+
+Every AFK implementation backend — whether it runs Claude Code on the desktop, a
+Podman sandcastle, a cloud worker, or any other AI tool — must satisfy the
+AFKBackend protocol in this module. The governor (scripts/run_afk_cycle.py)
+selects a backend by name and drives it through this contract, so new tools can be
+added without changing the governor.
+
+The contract is intentionally narrow:
+
+- prepare()      → check prerequisites before any work is started
+- needs_local_repo() → declare whether the governor must prepare an ephemeral clone
+- invoke()       → run the tool and return branch/commits/blocked
+- estimate_cost() → rough cost estimate for the AIW budget gate
+- cancel()       → best-effort abort of an in-flight invocation
+
+See docs/solutions/harness/2026-07-29-afk-backend-adapter-contract.md for the
+full design rationale.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class AFKBackend(ABC):
+    """Abstract contract for an AFK implementation backend.
+
+    Concrete implementations live in sibling modules under scripts/afk_backends/.
+    The governor loads them through the registry (scripts/afk_backends/registry.py)
+    and treats them as interchangeable workers.
+    """
+
+    @abstractmethod
+    def prepare(self) -> tuple[bool, str]:
+        """Check that the backend is ready to run.
+
+        This is called once per cycle before any issue is processed. It should
+        verify prerequisites such as: the tool is installed, a daemon is
+        running, a cloud endpoint is reachable, credentials are present, etc.
+
+        Returns:
+            (ok, note): ok is True if the backend can proceed; note is a human-
+            readable status string. A failed prepare is a hard abort for the cycle.
+        """
+
+    @abstractmethod
+    def needs_local_repo(self) -> bool:
+        """Return True if the backend needs an ephemeral clone on this host.
+
+        Desktop/container backends typically return True because they run the
+        tool against a local filesystem. Cloud worker backends can return False
+        and receive repo_path=None in invoke().
+        """
+
+    @abstractmethod
+    def invoke(self, issue: dict[str, Any], repo_path: str | None) -> dict:
+        """Run the backend for a single issue.
+
+        Args:
+            issue: The GitHub issue dict with keys such as number, title, body,
+                and labels. The backend must not mutate it.
+            repo_path: Path to the ephemeral clone, or None if
+                needs_local_repo() returns False.
+
+        Returns:
+            A dict with the exact keys:
+                branch: str | None — the branch name produced by the agent, or None
+                commits: list[str] — commit subject lines produced by the agent
+                blocked: str | None — a human-readable reason the issue could not
+                    be implemented, or None on success
+
+            If both branch and blocked are None, the governor treats the issue as
+            stalled (no progress and no explicit block reason).
+        """
+
+    @abstractmethod
+    def estimate_cost(self, issue: dict[str, Any]) -> dict:
+        """Return a rough cost estimate for the AIW budget gate.
+
+        The estimate should use the recognized budget keys from
+        scripts/aiw_budget_gate.py, such as:
+            estimated_cost_usd
+            estimated_total_tokens
+            estimated_model_calls
+            estimated_runner_minutes
+        Missing keys are treated as zero/unbounded by the gate.
+        """
+
+    def cancel(self) -> None:
+        """Best-effort cancel of an in-flight invocation.
+
+        The default implementation is a no-op. Backends that support
+        cancellation (e.g., cloud workers with a job ID) may override this.
+        """
+        return None

--- a/scripts/test_afk_backends.py
+++ b/scripts/test_afk_backends.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Tests for the AFK backend adapter contract (scripts/afk_backends/__init__.py)."""
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from afk_backends import AFKBackend  # noqa: E402
+
+
+class TestAFKBackendContract(unittest.TestCase):
+    """The AFKBackend protocol is an abstract base class. It cannot be used
+    directly, and concrete implementations must return the exact shape the
+    governor expects."""
+
+    def test_abstract_class_cannot_be_instantiated(self):
+        with self.assertRaises(TypeError):
+            AFKBackend()
+
+    def test_concrete_backend_implements_contract(self):
+        class DummyBackend(AFKBackend):
+            def prepare(self) -> tuple[bool, str]:
+                return True, "ok"
+
+            def needs_local_repo(self) -> bool:
+                return True
+
+            def invoke(self, issue: dict[str, Any], repo_path: str | None) -> dict:
+                return {"branch": "agent/issue-1", "commits": ["feat: do it"],
+                        "blocked": None}
+
+            def estimate_cost(self, issue: dict[str, Any]) -> dict:
+                return {"estimated_cost_usd": 0.5}
+
+        backend = DummyBackend()
+        self.assertTrue(backend.prepare()[0])
+        self.assertTrue(backend.needs_local_repo())
+        self.assertIsNone(backend.cancel())
+        result = backend.invoke({"number": 1}, "/tmp/repo")
+        self.assertEqual(set(result.keys()), {"branch", "commits", "blocked"})
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #872.

## What

Defines the AFK backend adapter contract so the governor can treat any AI tool (desktop or cloud) identically.

## Changes

- `scripts/afk_backends/__init__.py` — new abstract `AFKBackend` class with methods:
  - `prepare()` — check prerequisites before a cycle starts
  - `needs_local_repo()` — declare whether the governor must prepare an ephemeral clone
  - `invoke(issue, repo_path)` — run the tool and return `{branch, commits, blocked}`
  - `estimate_cost(issue)` — rough cost estimate for the AIW budget gate
  - `cancel()` — best-effort abort (default no-op)
- `docs/solutions/harness/2026-07-29-afk-backend-adapter-contract.md` — design ADR explaining the contract, the registry plan, and the mapping to existing backends.
- `scripts/test_afk_backends.py` — contract tests verifying the ABC cannot be instantiated and a concrete implementation satisfies the protocol.

## Verification

- `python -m unittest scripts.test_afk_backends` → 2 tests pass
- `python scripts/validate_governance.py` → 146 valid, 0 invalid
- `pwsh scripts/verify.ps1` → passes
- `python scripts/build_manifest.py` → green

## Next steps

- #873 — extract existing backends into adapter modules
- #875 — add backend registry loader
- #877 — fix local backend spend attribution
- #879 — implement cloud-worker backend
- #882 — add shell adapter as proof of abstraction
- #884 — update docs and policy
