### PR TITLE
fix(afk): attribute the local backend to the API it bills (#863)

### DIFF
--- a/config/afk-backends.yaml
+++ b/config/afk-backends.yaml
@@ -16,8 +16,13 @@ backends:
 
   local:
     adapter: "afk_backends.sandcastle.SandcastleBackend"
-    provider: "claude-code-cli"
-    description: "Podman sandcastle via the sibling ../afk-harness project. Forwards ANTHROPIC_API_KEY, so it is metered Claude API spend."
+    # Attribute a backend to the provider it ACTUALLY BILLS. This line was
+    # codex-cli, then claude-code-cli (#877) -- both local-seat with
+    # requires_manual_approval: false, so metered spend cleared the gate either
+    # way. The description below was correct the whole time; only the value was
+    # wrong. See #863.
+    provider: "anthropic-api"
+    description: "Podman sandcastle via the sibling ../afk-harness project. Forwards ANTHROPIC_API_KEY and runs claudeCode(opus), so it is metered Anthropic API spend and requires a manual approval artifact."
     enabled: true
 
   remote:

--- a/docs/solutions/harness/2026-07-29-a-guard-is-only-as-good-as-its-subject.md
+++ b/docs/solutions/harness/2026-07-29-a-guard-is-only-as-good-as-its-subject.md
@@ -29,9 +29,19 @@ forwards `ANTHROPIC_API_KEY` into the sandbox — metered API spend. But
 precisely to stop unapproved metered spend. It ran, it passed, and it was correct
 about `codex-cli` — a provider that was not being used. (#863)
 
-Fixed in #877 by moving the provider mapping to `config/afk-backends.yaml` and
-attributing the `local` backend to `claude-code-cli`, so the gate now applies the
-right provider caps and approval rules.
+**And then it happened a second time, to this very instance.** #877 "fixed" it by
+moving the mapping into `config/afk-backends.yaml` and changing `codex-cli` to
+`claude-code-cli` — a *different* `local-seat`, `requires_manual_approval: false`
+provider. The gate's answer never changed. The commit closed #863, and this
+paragraph was edited to record the fix. Both were wrong.
+
+That is the pattern eating its own tail: the note about guards bound to the wrong
+subject was amended to certify a guard bound to a different wrong subject. The
+tell was available the whole time — the registry entry's own `description` said
+"metered Claude API spend" one line under a free-tier provider id. **When a
+config value and its adjacent description disagree, the description is usually
+the one written by someone who understood the system.** Actually fixed by
+attributing `local` to `anthropic-api` (metered-cloud, approval required).
 
 **2. The agent's oracle checked schemas, not the suite.**
 `prompts/afk-implement.prompt.md` required `validate_governance.py` and nothing

--- a/docs/workflows/aiw-operating-doctrine.md
+++ b/docs/workflows/aiw-operating-doctrine.md
@@ -394,14 +394,14 @@ adapter:
 
 The AFK implement governor is tool-agnostic: it loads backends from `config/afk-backends.yaml` and drives them through the `AFKBackend` contract in `scripts/afk_backends/`. A new backend is added by creating an adapter module and a registry entry; the governor does not change.
 
-Registry entries declare the adapter class, the AIW budget provider used for cost gating, an `enabled` flag, and an optional `config` block. The provider must match the actual API or compute that will be billed (for example, the local Podman sandcastle forwards `ANTHROPIC_API_KEY` and is therefore attributed to `claude-code-cli`, not a free local provider).
+Registry entries declare the adapter class, the AIW budget provider used for cost gating, an `enabled` flag, and an optional `config` block. The provider must match the actual API or compute that will be billed. The local Podman sandcastle forwards `ANTHROPIC_API_KEY` and runs `claudeCode(opus)`, so it is attributed to `anthropic-api` (`metered-cloud`, `requires_manual_approval: true`) — **not** to `claude-code-cli`, which is a `local-seat` subscription provider that requires no approval. #863 was mis-fixed twice by naming a free `local-seat` id here (`codex-cli`, then `claude-code-cli`); both were well-formed and allowlisted, so nothing caught either. When a backend forwards a metered key, name the metered provider.
 
 Current shipped backends:
 
 | Name | Adapter | Provider | Execution environment |
 |------|---------|----------|----------------------|
 | `claude-code` | `afk_backends.claude_code.ClaudeCodeBackend` | `claude-code-cli` | Local Claude Code desktop subscription |
-| `local` | `afk_backends.sandcastle.SandcastleBackend` | `claude-code-cli` | Podman sandcastle in sibling `../afk-harness` |
+| `local` | `afk_backends.sandcastle.SandcastleBackend` | `anthropic-api` | Podman sandcastle in sibling `../afk-harness`; forwards `ANTHROPIC_API_KEY`, so metered and approval-gated |
 | `remote` | `afk_backends.remote.RemoteBackend` | `claude-code-cli` | HTTP cloud worker (Vercel, Codespaces, etc.) |
 | `shell` | `afk_backends.shell.ShellBackend` | `generic-shell` | Configurable local command; proves non-Claude abstraction |
 

--- a/schemas/aiw-budget-policy.schema.json
+++ b/schemas/aiw-budget-policy.schema.json
@@ -4,7 +4,7 @@
   "definitions": {
     "providerId": {
       "type": "string",
-      "enum": ["claude-code-cli", "codex-cli", "antigravity", "augment-code", "gemini-cli", "jules", "notebooklm"],
+      "enum": ["claude-code-cli", "codex-cli", "antigravity", "augment-code", "anthropic-api", "gemini-cli", "jules", "notebooklm"],
       "description": "Closed allowlist. Adding a provider must be a deliberate schema change."
     }
   },
@@ -125,6 +125,19 @@
                 "cost_model": {"const": "provider-billing"},
                 "requires_manual_approval": {"const": true},
                 "trusted_receipt_issuer": {"const": "notebooklm.google.com"}
+              },
+              "required": ["trusted_receipt_issuer"]
+            }
+          },
+          {
+            "description": "anthropic-api bills real money: it is the Anthropic Messages API consuming ANTHROPIC_API_KEY, NOT a Claude subscription seat. Pinned by id because #863 was exactly this confusion, twice. First the AFK `local` backend was attributed to codex-cli; then #877 'fixed' it by swapping to claude-code-cli -- a DIFFERENT local-seat, no-approval provider -- so the observable behaviour never changed. Both wrong values were well-formed and allowlisted, which is why nothing caught either. Pinning by id means a later diff cannot re-open the hole by editing tier alone. Do NOT reuse this id for claude-code-cli, which strips the key and rides the subscription.",
+            "if": {"properties": {"id": {"const": "anthropic-api"}}, "required": ["id"]},
+            "then": {
+              "properties": {
+                "tier": {"const": "metered-cloud"},
+                "cost_model": {"const": "provider-billing"},
+                "requires_manual_approval": {"const": true},
+                "trusted_receipt_issuer": {"const": "api.anthropic.com"}
               },
               "required": ["trusted_receipt_issuer"]
             }

--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -22,9 +22,17 @@ Backends (--backend):
                  the CLI falls back to the interactive subscription.
   local        — per-agent ephemeral clone + Podman sandbox. Runs on this box and
                  FORWARDS ANTHROPIC_API_KEY into the sandbox, i.e. it bills
-                 metered Claude API spend. It is attributed to `claude-code-cli`
-                 by config/afk-backends.yaml so the AIW budget gate applies the
-                 right provider caps and approval rules. Opt in explicitly.
+                 metered Anthropic API spend. Attributed to `anthropic-api`
+                 (metered-cloud, requires_manual_approval) by
+                 config/afk-backends.yaml, so the AIW gate BLOCKS it. The governor
+                 can never clear that gate on its own: _budget_reserve calls
+                 reserve() with approval=None, and only the gate's own CLI reads
+                 .octo/aiw-approval.json. To run this lane, pre-reserve the job via
+                 the aiw_budget_gate CLI with a bound approval artifact; the
+                 governor then clears via job-id reuse. The release leg is NOT
+                 plumbed -- a metered job needs a trusted receipt that
+                 _budget_release never passes, so every approved run leaves an open
+                 reservation (#896). Treat `local` as operator-driven.
   remote       — Vercel isolated sandboxes (NOT yet implemented; seam reserved)
 
 Usage:
@@ -609,8 +617,10 @@ def main(argv: list[str]) -> int:
                          "container, bills the interactive subscription because "
                          "ANTHROPIC_API_KEY is stripped from the child env); "
                          "local = per-agent clone + Podman sandbox — NOTE this forwards "
-                         "ANTHROPIC_API_KEY and bills metered API spend, currently "
-                         "misattributed to codex-cli by the budget gate (#863); "
+                         "ANTHROPIC_API_KEY and bills metered API spend; attributed to "
+                         "anthropic-api (metered-cloud) so the gate blocks it from the "
+                         "governor unless the job was pre-reserved via the "
+                         "aiw_budget_gate CLI with an approval artifact (#863); "
                          "remote = Vercel isolated sandboxes (not yet implemented)")
     ap.add_argument("--harvest", action="store_true",
                     help="self-merge pass: gate already-open AFK PRs through the "

--- a/scripts/test_afk_registry.py
+++ b/scripts/test_afk_registry.py
@@ -21,7 +21,7 @@ class TestLoadRegistry(unittest.TestCase):
         self.assertIn("remote", reg)
         self.assertIn("shell", reg)
         self.assertEqual(reg["claude-code"]["provider"], "claude-code-cli")
-        self.assertEqual(reg["local"]["provider"], "claude-code-cli")
+        self.assertEqual(reg["local"]["provider"], "anthropic-api")
         self.assertEqual(reg["shell"]["provider"], "generic-shell")
         self.assertFalse(reg["shell"]["enabled"])
 

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -419,10 +419,80 @@ class TestBudgetGate(unittest.TestCase):
 
     def test_budget_request_maps_backend_provider(self):
         self.assertEqual(
-            g._budget_request({"number": 5, "body": ""}, "local")["provider"], "claude-code-cli")
+            g._budget_request({"number": 5, "body": ""}, "local")["provider"],
+            "anthropic-api")
         self.assertEqual(
             g._budget_request({"number": 5, "body": ""}, "claude-code")["provider"],
             "claude-code-cli")
+
+    def test_local_backend_is_blocked_without_approval(self):
+        """#863 regression, stated as the behaviour that was missing. `local`
+        forwards ANTHROPIC_API_KEY and runs claudeCode(opus), so the gate must
+        REFUSE it with no approval artifact.
+
+        Two prior values passed this lane silently: codex-cli, then
+        claude-code-cli (#877). Both are local-seat/no-approval, so swapping
+        between them changed nothing observable. Assert the DECISION and the
+        TIER, not the provider string -- a test that only pins the id would have
+        gone green on that swap too.
+
+        Asserts against the REAL policy and registry, not fixtures: the defect
+        lived in the mapping BETWEEN config and policy, so a fixture would
+        reproduce the bug rather than catch it."""
+        policy = g.budget.load_policy(g.budget.POLICY_PATH)
+        with tempfile.TemporaryDirectory() as d:
+            result = g.budget.reserve(
+                policy, g._budget_request({"number": 5, "body": ""}, "local"),
+                Path(d) / "cycle.json")
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("provider_requires_manual_approval", result["reasons"])
+        self.assertEqual(result["tier"], "metered-cloud")
+
+    def test_claude_code_backend_still_allowed_without_approval(self):
+        """The other half: tightening `local` must not block the subscription
+        lane, or the fix is indistinguishable from breaking the loop."""
+        policy = g.budget.load_policy(g.budget.POLICY_PATH)
+        with tempfile.TemporaryDirectory() as d:
+            result = g.budget.reserve(
+                policy, g._budget_request({"number": 5, "body": ""}, "claude-code"),
+                Path(d) / "cycle.json")
+        self.assertEqual(result["decision"], "allow")
+        self.assertEqual(result["tier"], "local-seat")
+
+    def test_every_registry_provider_is_declared_in_policy(self):
+        """config/afk-backends.yaml has no schema, so an unvalidated YAML edit
+        is all that stands between a correct and an incorrect attribution. Bind
+        it to the policy allowlist at least."""
+        from afk_backends.registry import load_registry
+        declared = {p["id"] for p in
+                    g.budget.load_policy(g.budget.POLICY_PATH)["providers"]}
+        for backend, cfg in load_registry().items():
+            if not cfg.get("enabled"):
+                # A disabled backend cannot spend. `shell` (#882) currently names
+                # `generic-shell`, which no policy declares -- _provider() raises
+                # and _budget_reserve fails closed, so it is safe but unrunnable.
+                # Filed rather than fixed here: choosing its tier is #882's call.
+                continue
+            self.assertIn(cfg["provider"], declared,
+                          f"backend {backend!r} names undeclared provider "
+                          f"{cfg['provider']!r}")
+
+    def test_process_issue_forwards_its_own_backend_to_the_gate(self):
+        """Pinning the registry is not enough: if _process_issue reserves under
+        a hardcoded backend, `local` reserves as the subscription lane and #863
+        re-opens with the whole suite green. An adversarial review proved that
+        exact one-line edit survived 360 passing tests. Assert the forwarded
+        ARGUMENT, not the call count."""
+        for backend in ("local", "claude-code"):
+            issue = self._issue()
+            with mock.patch.object(
+                    g, "_budget_reserve",
+                    return_value=(False, {"decision": "block",
+                                          "reasons": ["cycle_cost_cap_exceeded"]})) as res, \
+                 mock.patch.object(g, "_write_loop_state"):
+                g._process_issue(issue, seq=1, today="2026-07-19", backend=backend,
+                                 adapter=mock.Mock())
+            res.assert_called_once_with(issue, backend)
 
     def test_unmapped_backend_fails_closed(self):
         allowed, result = g._budget_reserve({"number": 5, "body": ""}, "not-a-backend")

--- a/state/beliefs/2026-07-29-afk-backend-adapter.belief.json
+++ b/state/beliefs/2026-07-29-afk-backend-adapter.belief.json
@@ -1,7 +1,7 @@
 {
   "proposition": "The Demerzel AFK implement governor uses a backend-adapter abstraction so that desktop, container, and cloud AI tools can be plugged in without changing the governor.",
   "truth_value": "T",
-  "confidence": 0.92,
+  "confidence": 0.82,
   "evidence": {
     "supporting": [
       {
@@ -53,9 +53,15 @@
         "claim": "CORRECTION to the #877/#895 entry above. That entry states the local backend 'must be gated as claude-code-cli rather than the free local-seat codex-cli'. This asserts a distinction that does not exist: state/driver/aiw-budget-policy.json declares BOTH claude-code-cli and codex-cli as tier 'local-seat' with requires_manual_approval false. The swap changed no observable behaviour -- provider_for('local') still returns a local-seat id, the gate still returns allow, and metered ANTHROPIC_API_KEY spend still clears it. #863 was closed on that basis and has been reopened. The adapter abstraction itself is real and works; only the attribution claim was false.",
         "timestamp": "2026-07-29T04:45:00Z",
         "reliability": 0.99
+      },
+      {
+        "source": "fix/afk-863-spend-attribution (#887)",
+        "claim": "CORRECTION to the #877/#895 supporting entry. It states the local backend 'must be gated as claude-code-cli rather than the free local-seat codex-cli'. That distinction does not exist: aiw-budget-policy.json declares BOTH as tier 'local-seat' with requires_manual_approval false, so provider_for('local') still returned a free-tier id and the gate still returned allow. #863 was closed on that basis. The #884 entry then wrote the same error into docs/workflows/aiw-operating-doctrine.md and policies/autonomous-loop-policy.yaml, whose own stated rule ('a backend that forwards a metered API key is attributed to that metered provider, not to a free local provider') the example contradicts. Corrected by attributing local to anthropic-api (metered-cloud, approval required). The adapter abstraction itself is real and works; only the attribution claims were false.",
+        "timestamp": "2026-07-29T13:00:00Z",
+        "reliability": 0.99
       }
     ]
   },
-  "last_updated": "2026-07-29T12:55:00Z",
+  "last_updated": "2026-07-29T13:05:00Z",
   "evaluated_by": "demerzel"
 }

--- a/state/beliefs/2026-07-29-afk-backend-adapter.belief.json
+++ b/state/beliefs/2026-07-29-afk-backend-adapter.belief.json
@@ -46,6 +46,14 @@
         "timestamp": "2026-07-29T12:55:00Z",
         "reliability": 0.98
       }
+    ],
+    "contradicting": [
+      {
+        "source": "fix/afk-863-spend-attribution (#887)",
+        "claim": "CORRECTION to the #877/#895 entry above. That entry states the local backend 'must be gated as claude-code-cli rather than the free local-seat codex-cli'. This asserts a distinction that does not exist: state/driver/aiw-budget-policy.json declares BOTH claude-code-cli and codex-cli as tier 'local-seat' with requires_manual_approval false. The swap changed no observable behaviour -- provider_for('local') still returns a local-seat id, the gate still returns allow, and metered ANTHROPIC_API_KEY spend still clears it. #863 was closed on that basis and has been reopened. The adapter abstraction itself is real and works; only the attribution claim was false.",
+        "timestamp": "2026-07-29T04:45:00Z",
+        "reliability": 0.99
+      }
     ]
   },
   "last_updated": "2026-07-29T12:55:00Z",

--- a/state/driver/aiw-budget-policy.json
+++ b/state/driver/aiw-budget-policy.json
@@ -38,6 +38,13 @@
       "requires_manual_approval": false
     },
     {
+      "id": "anthropic-api",
+      "tier": "metered-cloud",
+      "cost_model": "provider-billing",
+      "requires_manual_approval": true,
+      "trusted_receipt_issuer": "api.anthropic.com"
+    },
+    {
       "id": "gemini-cli",
       "tier": "metered-cloud",
       "cost_model": "provider-billing",
@@ -64,6 +71,7 @@
     "codex-cli",
     "antigravity",
     "augment-code",
+    "anthropic-api",
     "gemini-cli",
     "jules",
     "notebooklm"


### PR DESCRIPTION
Closes #863.

## The defect

`--backend local` runs `claudeCode("claude-opus-4-8")` and forwards `ANTHROPIC_API_KEY` into the Podman sandbox — real metered Anthropic spend. `BACKEND_PROVIDER` mapped it to `codex-cli`:

```python
"local": "codex-cli",   # ../afk-harness sandcastle runs Codex CLI
```

`codex-cli` is `tier: local-seat`, `requires_manual_approval: false`. So metered spend cleared the AIW budget gate as free subscription work — the gate that exists to stop precisely that.

The gate was never broken. It ran, it passed, and it was correct **about a provider that was not being used**. The defect is in the binding: the map named the tool the harness is *named after*, not the API the harness *charges*.

## The fix

| | before | after |
|---|---|---|
| `local` | `codex-cli` — local-seat, no approval | `anthropic-api` — metered-cloud, approval required |
| `claude-code` | `claude-code-cli` — local-seat | unchanged (strips the key at `run_afk_cycle.py:304`) |

- adds `anthropic-api` to the closed provider allowlist (`schemas/`) and declares it in `state/driver/aiw-budget-policy.json`
- **pins it by id** in the schema, as `gemini-cli`/`jules`/`notebooklm` already are. The tier-keyed guards constrain shape *given* a tier — and tier is editable in the same diff that would downgrade it. Without the pin, one line silently re-opens this hole.
- corrects the module docstring, which had written the bug down as a standing caveat

## Verification — by mutation, not by reading the diff

| mutation | result |
|---|---|
| restore `"local": "codex-cli"` | **2 tests fail**, incl. the new `test_local_backend_is_blocked_without_approval` |
| downgrade `anthropic-api` to `local-seat` in policy | **11 failures/errors** |
| unmodified | 360 pass |

Live gate decisions:

```
local        -> provider=anthropic-api    tier=metered-cloud  decision=block  reasons=['provider_requires_manual_approval']
claude-code  -> provider=claude-code-cli  tier=local-seat     decision=allow  reasons=[]
```

Both halves matter: `local` now blocks, and the subscription lane still runs — a fix that blocked everything would be indistinguishable from breaking the loop.

The new tests assert against the **real policy file**, not a fixture. The defect lived in the mapping *between* code and policy, so a fixture would have reproduced the bug rather than caught it.

## Noted, not fixed here

`validate_governance.py` reports `PASSED: all checks green` under the tier-downgrade mutation — it does not cover `state/driver/`. The unit suite is what catches it. That is a real gap, and it is the same shape as #858 (an oracle checking schemas but not the suite); left out of scope rather than folded in silently.

## Review

Touches `schemas/` — **blocked path**. `risk-report` will fail closed. Per `docs/review-independence.md` this needs explicit human attestation; I have not applied `agent-blackbox-reviewed` and will not.

Scope is deliberately the defect only. The `AFK-v0.2` adapter epic (#873/#875/#877/#879/#882/#884) is a separate decision — this fix does not depend on it and does not presume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)