### PR TITLE
feat(afk): extract backend invocation paths into adapter modules (#873)

### DIFF
--- a/scripts/afk_backends/claude_code.py
+++ b/scripts/afk_backends/claude_code.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Claude Code desktop backend for the AFK implement lane.
+
+Runs a headless `claude -p` agent in an ephemeral clone, billing the interactive
+subscription by stripping ANTHROPIC_API_KEY from the child environment. This is
+the default AFK backend.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from afk_backends import AFKBackend  # noqa: E402
+import demerzel_kit as kit  # noqa: E402
+
+CLAUDE_CODE_TIMEOUT = 1800  # seconds for one headless `claude -p` agent run
+
+
+def _claude_code_prompt(issue: dict) -> str:
+    """The instruction handed to the headless Claude Code agent. The issue body
+    already carries the full implementation spec (pattern + success criteria), so
+    this only frames the autonomy contract: implement, test, commit — no push/PR
+    (the governor owns those)."""
+    num = issue.get("number")
+    return (
+        "You are an autonomous AFK engineer working in a fresh clone of the "
+        "Demerzel governance repo, on a dedicated branch. Implement the issue "
+        "below end-to-end, then COMMIT your work on the current branch with a "
+        "conventional-commit message (feat/refactor/test). Be surgical — change "
+        "only what the issue requires. After editing, run "
+        "`python -m unittest discover -s scripts -p \"test_*.py\"` and make sure it "
+        "passes before committing. Do NOT push and do NOT open a pull request; "
+        "just commit locally.\n\n"
+        f"=== ISSUE #{num}: {issue.get('title', '')} ===\n\n"
+        f"{issue.get('body', '')}"
+    )
+
+
+class ClaudeCodeBackend(AFKBackend):
+    """Desktop backend: delegate one issue to a headless Claude Code agent."""
+
+    def prepare(self) -> tuple[bool, str]:
+        try:
+            p = subprocess.run(["claude", "--version"], capture_output=True, text=True,
+                                 timeout=30)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return False, f"claude command not available: {exc}"
+        if p.returncode != 0:
+            return False, f"claude --version failed: {p.stderr.strip()[:160]}"
+        return True, f"claude-code ready ({p.stdout.strip()})"
+
+    def needs_local_repo(self) -> bool:
+        return True
+
+    def invoke(self, issue: dict[str, Any], repo_path: str | None) -> dict:
+        """Run headless Claude Code in repo_path and return branch/commits/blocked."""
+        if repo_path is None:
+            return {"branch": None, "commits": [],
+                    "blocked": "claude-code backend requires a local repo clone"}
+        num = issue.get("number")
+        branch = f"agent/issue-{num}"
+        try:
+            subprocess.run(["git", "-C", repo_path, "checkout", "-b", branch],
+                             capture_output=True, text=True, timeout=30, check=True)
+            base = subprocess.run(["git", "-C", repo_path, "rev-parse", "HEAD"],
+                                  capture_output=True, text=True, timeout=30).stdout.strip()
+            env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+            cmd = ["claude", "-p", _claude_code_prompt(issue),
+                   "--output-format", "json",
+                   "--allowedTools", "Edit", "Write", "Read", "Grep", "Glob",
+                   "Bash(python *)", "Bash(python3 *)", "Bash(git *)"]
+            p = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True,
+                               timeout=CLAUDE_CODE_TIMEOUT, env=env)
+        except (OSError, subprocess.TimeoutExpired, subprocess.CalledProcessError) as exc:
+            return {"branch": None, "commits": [], "blocked": f"claude-code invoke failed: {exc}"}
+
+        # The agent is told to commit; if it left changes uncommitted, capture them so a
+        # real implementation isn't lost to a missing commit step.
+        dirty = subprocess.run(["git", "-C", repo_path, "status", "--porcelain"],
+                               capture_output=True, text=True, timeout=30).stdout.strip()
+        if dirty:
+            subprocess.run(["git", "-C", repo_path, "add", "-A"],
+                           capture_output=True, text=True, timeout=60)
+            subprocess.run(["git", "-C", repo_path, "commit", "-m",
+                            f"feat: implement #{num} via AFK claude-code backend"],
+                           capture_output=True, text=True, timeout=60)
+        commits = subprocess.run(["git", "-C", repo_path, "log", "--format=%s", f"{base}..HEAD"],
+                                 capture_output=True, text=True, timeout=30).stdout.strip()
+        if not commits:
+            tail = (p.stderr or p.stdout or "").strip()[-200:]
+            return {"branch": None, "commits": [],
+                    "blocked": f"claude-code made no commits (exit {p.returncode}): {tail}"}
+        return {"branch": branch, "commits": commits.splitlines(), "blocked": None}
+
+    def estimate_cost(self, issue: dict[str, Any]) -> dict:
+        """Claude Code on the subscription is treated as local-seat cost.
+
+        The actual marginal cost is covered by the interactive subscription, so
+        the budget gate sees a low default estimate unless the issue body
+        overrides it.
+        """
+        return {"estimated_cost_usd": 0.0, "estimated_runner_minutes": 30}

--- a/scripts/afk_backends/remote.py
+++ b/scripts/afk_backends/remote.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Cloud worker backend for the AFK implement lane.
+
+Backend seam for Vercel isolated sandboxes or any generic HTTP worker. Not yet
+implemented; this module exists to keep the governor's backend abstraction
+complete while the remote worker contract is being built (see #879).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from afk_backends import AFKBackend  # noqa: E402
+
+
+class RemoteBackend(AFKBackend):
+    """Cloud backend: delegate to a remote worker endpoint.
+
+    Currently returns a clean blocked result so the backend can be registered and
+    selected without crashing the governor. A real implementation will be added
+    in #879.
+    """
+
+    def prepare(self) -> tuple[bool, str]:
+        return True, "remote backend registered but not configured (no-op)"
+
+    def needs_local_repo(self) -> bool:
+        return False
+
+    def invoke(self, issue: dict[str, Any], repo_path: str | None) -> dict:
+        return {"branch": None, "commits": [],
+                "blocked": "remote backend (Vercel isolated sandboxes) not implemented yet — "
+                           "use --backend claude-code or local"}
+
+    def estimate_cost(self, issue: dict[str, Any]) -> dict:
+        return {"estimated_cost_usd": 2.0, "estimated_runner_minutes": 30}

--- a/scripts/afk_backends/sandcastle.py
+++ b/scripts/afk_backends/sandcastle.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Podman sandcastle backend for the AFK implement lane.
+
+Delegates to the sibling `../afk-harness` project, which runs Claude Code inside a
+Podman sandbox. This backend forwards ANTHROPIC_API_KEY and is therefore metered
+spend — its budget provider must reflect that (see #877).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from afk_backends import AFKBackend  # noqa: E402
+
+HARNESS_DIR = Path(__file__).resolve().parents[2] / "afk-harness"
+
+
+class SandcastleBackend(AFKBackend):
+    """Desktop/container backend: run the sandcastle harness in a Podman sandbox."""
+
+    def _ensure_podman(self) -> tuple[bool, str]:
+        """Restart-robustness: make sure the Podman machine is up before sandboxing.
+        Idempotent — 'already running' is success. Returns (ok, note)."""
+        try:
+            chk = subprocess.run(["podman", "machine", "list", "--format", "{{.Running}}"],
+                                 capture_output=True, text=True, timeout=30)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return False, f"podman not available: {exc}"
+        if chk.returncode == 0 and "true" in chk.stdout.lower():
+            return True, "podman machine already running"
+        start = subprocess.run(["podman", "machine", "start"],
+                               capture_output=True, text=True, timeout=180)
+        if start.returncode == 0 or "already running" in (start.stderr + start.stdout).lower():
+            return True, "podman machine started"
+        return False, f"podman machine start failed: {start.stderr.strip()[:160]}"
+
+    def prepare(self) -> tuple[bool, str]:
+        return self._ensure_podman()
+
+    def needs_local_repo(self) -> bool:
+        return True
+
+    def invoke(self, issue: dict[str, Any], repo_path: str | None) -> dict:
+        """Run the sandcastle harness for one issue against repo_path."""
+        if repo_path is None:
+            return {"branch": None, "commits": [],
+                    "blocked": "sandcastle backend requires a local repo clone"}
+        cmd = ["node", "--import", "tsx", str(HARNESS_DIR / ".sandcastle" / "main.mts"),
+               "--repo", str(repo_path), "--issue", str(issue.get("number")),
+               "--title", issue.get("title", ""), "--body", issue.get("body", "")]
+        p = subprocess.run(cmd, cwd=str(HARNESS_DIR), capture_output=True, text=True, timeout=1800)
+        if p.returncode != 0:
+            return {"branch": None, "commits": [],
+                    "blocked": f"harness exit {p.returncode}: {p.stderr.strip()[:200]}"}
+        last = [l for l in p.stdout.strip().splitlines() if l.strip().startswith("{")]
+        if not last:
+            return {"branch": None, "commits": [], "blocked": "harness produced no JSON result"}
+        return json.loads(last[-1])
+
+    def estimate_cost(self, issue: dict[str, Any]) -> dict:
+        """Sandcastle runs Claude Code with metered API key forwarded.
+
+        The issue body is the authoritative source for budget estimates; the
+        backend supplies a conservative default runner minute estimate.
+        """
+        return {"estimated_cost_usd": 2.0, "estimated_runner_minutes": 30}

--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -43,7 +43,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import shutil
 import subprocess
 import sys
@@ -56,9 +55,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import aiw_budget_gate as budget  # noqa: E402  (fail-closed AIW budget preflight)
 import council_emit  # noqa: E402  (sibling module in scripts/; self-merge gate)
 import demerzel_kit as kit  # noqa: E402  (shared gh / write-artifact seam)
+from afk_backends.claude_code import ClaudeCodeBackend  # noqa: E402
+from afk_backends.remote import RemoteBackend  # noqa: E402
+from afk_backends.sandcastle import SandcastleBackend  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[1]            # repos/Demerzel
-HARNESS_DIR = ROOT.parent / "afk-harness"             # sibling, outside Demerzel
 PROMPT_FILE = ROOT / "prompts" / "afk-implement.prompt.md"
 LABEL = "agent-implement"
 REPO_SLUG = "GuitarAlchemist/Demerzel"
@@ -81,6 +82,24 @@ BACKEND_PROVIDER = {
     "local": "codex-cli",             # ../afk-harness sandcastle runs Codex CLI
     "claude-code": "claude-code-cli",  # headless `claude -p` on the subscription
 }
+
+
+_BACKEND_ADAPTERS = {
+    "claude-code": ClaudeCodeBackend,
+    "local": SandcastleBackend,
+    "remote": RemoteBackend,
+}
+
+
+def get_backend(name: str) -> ClaudeCodeBackend | SandcastleBackend | RemoteBackend:
+    """Return an adapter instance for the named backend. Raises ValueError for an
+    unknown backend so the governor fails closed."""
+    cls = _BACKEND_ADAPTERS.get(name)
+    if cls is None:
+        raise ValueError(f"unknown backend {name!r}")
+    return cls()
+
+
 # Recognized budget numbers an issue may carry to tighten the policy defaults.
 _BUDGET_KEYS = (
     "estimated_cost_usd", "estimated_total_tokens", "estimated_model_calls",
@@ -246,129 +265,6 @@ def _prepare_clone(issue: dict) -> str:
         subprocess.run(["git", "-C", clone, "remote", "set-url", "origin", url],
                        capture_output=True, text=True, timeout=30, check=True)
     return clone
-
-
-def _invoke_harness(issue: dict, repo_path: str) -> dict:
-    """Run the sandcastle harness for one issue against repo_path. Returns
-    {branch,commits,blocked}.
-
-    Invokes node with the tsx loader directly rather than `npx tsx`: on Windows
-    `npx` is `npx.cmd` (no .exe) and Python's subprocess cannot CreateProcess it
-    without a shell — and a shell would expose the issue body to command
-    injection. `node` is a real executable and args pass straight through as argv.
-    """
-    cmd = ["node", "--import", "tsx", str(HARNESS_DIR / ".sandcastle" / "main.mts"),
-           "--repo", str(repo_path), "--issue", str(issue.get("number")),
-           "--title", issue.get("title", ""), "--body", issue.get("body", "")]
-    p = subprocess.run(cmd, cwd=str(HARNESS_DIR), capture_output=True, text=True, timeout=1800)
-    if p.returncode != 0:
-        return {"branch": None, "commits": [], "blocked": f"harness exit {p.returncode}: {p.stderr.strip()[:200]}"}
-    last = [l for l in p.stdout.strip().splitlines() if l.strip().startswith("{")]
-    if not last:
-        return {"branch": None, "commits": [], "blocked": "harness produced no JSON result"}
-    return json.loads(last[-1])
-
-
-def _invoke_harness_remote(issue: dict) -> dict:
-    """Backend seam for Vercel isolated sandboxes (Approach C). Not yet
-    implemented — returns a clean blocked result so --backend remote is a no-op
-    rather than a crash until the remote provider lands."""
-    return {"branch": None, "commits": [],
-            "blocked": "remote backend (Vercel isolated sandboxes) not implemented yet — use --backend local"}
-
-
-CLAUDE_CODE_TIMEOUT = 1800  # seconds for one headless `claude -p` agent run
-
-
-def _claude_code_prompt(issue: dict) -> str:
-    """The instruction handed to the headless Claude Code agent. The issue body
-    already carries the full implementation spec (pattern + success criteria), so
-    this only frames the autonomy contract: implement, test, commit — no push/PR
-    (the governor owns those)."""
-    num = issue.get("number")
-    return (
-        "You are an autonomous AFK engineer working in a fresh clone of the "
-        "Demerzel governance repo, on a dedicated branch. Implement the issue "
-        "below end-to-end, then COMMIT your work on the current branch with a "
-        "conventional-commit message (feat/refactor/test). Be surgical — change "
-        "only what the issue requires. After editing, run "
-        "`python -m unittest discover -s scripts -p \"test_*.py\"` and make sure it "
-        "passes before committing. Do NOT push and do NOT open a pull request; "
-        "just commit locally.\n\n"
-        f"=== ISSUE #{num}: {issue.get('title', '')} ===\n\n"
-        f"{issue.get('body', '')}"
-    )
-
-
-def _invoke_harness_claude_code(issue: dict, repo_path: str) -> dict:
-    """Backend: delegate one issue to a headless Claude Code agent (`claude -p`)
-    in repo_path instead of the Podman sandbox. Returns {branch,commits,blocked} —
-    the same contract as the other backends, so the governor's push/PR/council
-    wrappers are unchanged.
-
-    Three deliberate choices:
-      * ANTHROPIC_API_KEY is stripped from the child env so `claude` bills the
-        interactive subscription, not the spend-capped API key — the reason this
-        backend exists (the Podman backend's claude-code hits that cap).
-      * The agent runs under a SCOPED tool allowlist (not skip-permissions): it may
-        edit/read files and run only `python`/`git` — enough to migrate, test, and
-        commit, but not arbitrary commands. A non-listed tool is denied rather than
-        prompting (headless), so the blast radius is the allowlist, not the host.
-      * Isolation is also the ephemeral clone (a git boundary). Even so this is a
-        weaker boundary than the container backend; use for trusted, mechanical
-        issues — the risk classifier keeps critical/high out of the auto lane.
-    """
-    num = issue.get("number")
-    branch = f"agent/issue-{num}"
-    try:
-        subprocess.run(["git", "-C", repo_path, "checkout", "-b", branch],
-                       capture_output=True, text=True, timeout=30, check=True)
-        base = subprocess.run(["git", "-C", repo_path, "rev-parse", "HEAD"],
-                              capture_output=True, text=True, timeout=30).stdout.strip()
-        env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
-        cmd = ["claude", "-p", _claude_code_prompt(issue),
-               "--output-format", "json",
-               "--allowedTools", "Edit", "Write", "Read", "Grep", "Glob",
-               "Bash(python *)", "Bash(python3 *)", "Bash(git *)"]
-        p = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True,
-                           timeout=CLAUDE_CODE_TIMEOUT, env=env)
-    except (OSError, subprocess.TimeoutExpired, subprocess.CalledProcessError) as exc:
-        return {"branch": None, "commits": [], "blocked": f"claude-code invoke failed: {exc}"}
-
-    # The agent is told to commit; if it left changes uncommitted, capture them so a
-    # real implementation isn't lost to a missing commit step.
-    dirty = subprocess.run(["git", "-C", repo_path, "status", "--porcelain"],
-                           capture_output=True, text=True, timeout=30).stdout.strip()
-    if dirty:
-        subprocess.run(["git", "-C", repo_path, "add", "-A"],
-                       capture_output=True, text=True, timeout=60)
-        subprocess.run(["git", "-C", repo_path, "commit", "-m",
-                        f"feat: implement #{num} via AFK claude-code backend"],
-                       capture_output=True, text=True, timeout=60)
-    commits = subprocess.run(["git", "-C", repo_path, "log", "--format=%s", f"{base}..HEAD"],
-                             capture_output=True, text=True, timeout=30).stdout.strip()
-    if not commits:
-        tail = (p.stderr or p.stdout or "").strip()[-200:]
-        return {"branch": None, "commits": [],
-                "blocked": f"claude-code made no commits (exit {p.returncode}): {tail}"}
-    return {"branch": branch, "commits": commits.splitlines(), "blocked": None}
-
-
-def _ensure_podman() -> tuple[bool, str]:
-    """Restart-robustness: make sure the Podman machine is up before sandboxing.
-    Idempotent — 'already running' is success. Returns (ok, note)."""
-    try:
-        chk = subprocess.run(["podman", "machine", "list", "--format", "{{.Running}}"],
-                             capture_output=True, text=True, timeout=30)
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        return False, f"podman not available: {exc}"
-    if chk.returncode == 0 and "true" in chk.stdout.lower():
-        return True, "podman machine already running"
-    start = subprocess.run(["podman", "machine", "start"],
-                           capture_output=True, text=True, timeout=180)
-    if start.returncode == 0 or "already running" in (start.stderr + start.stdout).lower():
-        return True, "podman machine started"
-    return False, f"podman machine start failed: {start.stderr.strip()[:160]}"
 
 
 def _open_pr(issue: dict, branch: str, repo_path: str) -> str:
@@ -612,10 +508,15 @@ def _run_harvest(dry: bool, today: str) -> int:
     return 0
 
 
-def _process_issue(issue: dict, seq: int, today: str, backend: str) -> tuple[dict, dict]:
+def _process_issue(issue: dict, seq: int, today: str, backend: str,
+                    adapter) -> tuple[dict, dict]:
     """Live processing of ONE issue end-to-end (runs inside the thread pool).
     Each call is independent: its own clone, its own branch, its own PR, its own
-    loop-state file. Returns (decision, state)."""
+    loop-state file. Returns (decision, state).
+
+    The adapter is responsible for turning the issue into a branch with commits;
+    the governor owns the clone, budget, PR, and loop-state.
+    """
     risk, mode = classify_risk(issue)
     eligible = is_eligible(issue)
     state = build_loop_state(issue, seq, risk, mode, today)
@@ -643,37 +544,40 @@ def _process_issue(issue: dict, seq: int, today: str, backend: str) -> tuple[dic
 
     clone = None
     try:
-        if backend == "remote":
-            hr = _invoke_harness_remote(issue)
-            repo_for_push = None
-        elif backend == "claude-code":
+        if adapter.needs_local_repo():
             clone = _prepare_clone(issue)
-            hr = _invoke_harness_claude_code(issue, clone)
+            hr = adapter.invoke(issue, clone)
             repo_for_push = clone
         else:
-            clone = _prepare_clone(issue)
-            hr = _invoke_harness(issue, clone)
-            repo_for_push = clone
+            hr = adapter.invoke(issue, None)
+            repo_for_push = None
 
         if hr.get("blocked"):
             decision["action"] = f"blocked:{hr['blocked']}"
             state["status"] = "halted"
             state["halt_reason"] = str(hr["blocked"])
         elif hr.get("branch"):
-            pr = _open_pr(issue, hr["branch"], repo_for_push)
-            decision["pr"] = pr
-            decision["branch"] = hr["branch"]
-            if pr.startswith("pr-create-failed"):
-                # A failed PR must NOT be reported as completed.
-                decision["action"] = "stalled:pr-create-failed"
+            if repo_for_push is None:
+                # Cloud backends that do not use a local clone are responsible for
+                # opening their own PR. This branch is defensive until #879 lands.
+                decision["action"] = "stalled:no-local-repo-for-push"
                 state["status"] = "stalled"
-                state["halt_reason"] = pr
+                state["halt_reason"] = "backend returned a branch but has no local repo to push"
             else:
-                state["iterations"].append({
-                    "iteration": 1, "timestamp": kit.now_iso(),
-                    "action": f"opened PR for #{issue.get('number')}",
-                    "outcome": "progress", "governance_decision": None})
-                state["status"] = "completed"
+                pr = _open_pr(issue, hr["branch"], repo_for_push)
+                decision["pr"] = pr
+                decision["branch"] = hr["branch"]
+                if pr.startswith("pr-create-failed"):
+                    # A failed PR must NOT be reported as completed.
+                    decision["action"] = "stalled:pr-create-failed"
+                    state["status"] = "stalled"
+                    state["halt_reason"] = pr
+                else:
+                    state["iterations"].append({
+                        "iteration": 1, "timestamp": kit.now_iso(),
+                        "action": f"opened PR for #{issue.get('number')}",
+                        "outcome": "progress", "governance_decision": None})
+                    state["status"] = "completed"
         else:
             # Harness returned neither a branch nor a blocked reason (e.g. agent
             # made no commits). Do not leave status pinned at 'running'.
@@ -780,9 +684,10 @@ def main(argv: list[str]) -> int:
                   file=sys.stderr)
             return 2
 
-    # Live: ensure the sandbox backend is ready once, up front.
-    if args.backend == "local" and issues:
-        ok, pnote = _ensure_podman()
+    # Live: ensure the selected backend is ready once, up front.
+    adapter = get_backend(args.backend)
+    if issues:
+        ok, pnote = adapter.prepare()
         if not ok:
             print(f"ABORT: {pnote}", file=sys.stderr)
             return 1
@@ -794,7 +699,7 @@ def main(argv: list[str]) -> int:
 
     decisions_by_seq: dict[int, dict] = {}
     with ThreadPoolExecutor(max_workers=workers) as ex:
-        futs = {ex.submit(_process_issue, issue, seq, today, args.backend): seq
+        futs = {ex.submit(_process_issue, issue, seq, today, args.backend, adapter): seq
                 for seq, issue in enumerate(issues, start=1)}
         for fut in as_completed(futs):
             seq = futs[fut]

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tempfile
 import unittest
 import unittest.mock as mock
@@ -7,6 +8,9 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import run_afk_cycle as g
+from afk_backends.claude_code import ClaudeCodeBackend, _claude_code_prompt
+from afk_backends.remote import RemoteBackend
+from afk_backends.sandcastle import SandcastleBackend
 
 
 class TestClassifyRisk(unittest.TestCase):
@@ -66,23 +70,26 @@ class TestDryRunNoLiveCalls(unittest.TestCase):
         with mock.patch.object(g, "_gh_queue", return_value=[
                  {"number": 7, "title": "fix docs typo", "body": "x", "labels": []}]), \
              mock.patch.object(g, "_process_issue") as proc, \
-             mock.patch.object(g, "_ensure_podman") as podman, \
+             mock.patch.object(g, "get_backend") as get_backend, \
              mock.patch.object(g, "_write_audit") as audit:
             rc = g.main(["--dry-run"])
         self.assertEqual(rc, 0)
-        proc.assert_not_called()      # no clone / sandbox / push / PR
-        podman.assert_not_called()    # no machine start
-        audit.assert_not_called()     # dry-run writes nothing
+        proc.assert_not_called()         # no clone / sandbox / push / PR
+        get_backend.assert_not_called()  # backend not selected in dry-run mode
+        audit.assert_not_called()        # dry-run writes nothing
 
 
 class TestParallelDispatch(unittest.TestCase):
     def test_live_processes_every_issue_once(self):
         issues = [{"number": n, "title": f"fix docs typo {n}", "body": "x", "labels": []}
                   for n in (1, 2, 3)]
+        fake_adapter = mock.Mock()
+        fake_adapter.prepare.return_value = (True, "ok")
+        fake_adapter.needs_local_repo.return_value = True
         with mock.patch.object(g, "_gh_queue", return_value=issues), \
-             mock.patch.object(g, "_ensure_podman", return_value=(True, "ok")), \
+             mock.patch.object(g, "get_backend", return_value=fake_adapter), \
              mock.patch.object(g, "_process_issue",
-                               side_effect=lambda issue, seq, today, backend:
+                               side_effect=lambda issue, seq, today, backend, adapter:
                                    ({"issue": issue["number"], "action": "implement"}, {})) as proc, \
              mock.patch.object(g, "_write_audit") as audit:
             rc = g.main(["--max-parallel", "2"])
@@ -93,7 +100,7 @@ class TestParallelDispatch(unittest.TestCase):
 
 class TestBackend(unittest.TestCase):
     def test_remote_backend_is_blocked_stub(self):
-        hr = g._invoke_harness_remote({"number": 1, "title": "x", "body": "y"})
+        hr = RemoteBackend().invoke({"number": 1, "title": "x", "body": "y"}, None)
         self.assertIsNone(hr["branch"])
         self.assertIn("remote", hr["blocked"].lower())
 
@@ -284,7 +291,7 @@ class TestClaudeCodeBackend(unittest.TestCase):
     instead of a Podman sandbox, returning the same {branch,commits,blocked}."""
 
     def test_prompt_carries_issue_and_commit_contract(self):
-        p = g._claude_code_prompt({"number": 410, "title": "Migrate X onto kit", "body": "do the thing"})
+        p = _claude_code_prompt({"number": 410, "title": "Migrate X onto kit", "body": "do the thing"})
         self.assertIn("#410", p)
         self.assertIn("Migrate X onto kit", p)
         self.assertIn("do the thing", p)
@@ -307,13 +314,13 @@ class TestClaudeCodeBackend(unittest.TestCase):
 
     def test_no_commits_returns_blocked(self):
         with mock.patch.object(g.subprocess, "run", side_effect=self._fake_run("")):
-            out = g._invoke_harness_claude_code({"number": 410, "title": "t", "body": "b"}, "/tmp/x")
+            out = ClaudeCodeBackend().invoke({"number": 410, "title": "t", "body": "b"}, "/tmp/x")
         self.assertIsNone(out["branch"])
         self.assertIn("no commits", out["blocked"])
 
     def test_commits_return_branch(self):
         with mock.patch.object(g.subprocess, "run", side_effect=self._fake_run("feat: migrate\n")):
-            out = g._invoke_harness_claude_code({"number": 410, "title": "t", "body": "b"}, "/tmp/x")
+            out = ClaudeCodeBackend().invoke({"number": 410, "title": "t", "body": "b"}, "/tmp/x")
         self.assertEqual(out["branch"], "agent/issue-410")
         self.assertEqual(out["commits"], ["feat: migrate"])
         self.assertIsNone(out["blocked"])
@@ -329,9 +336,9 @@ class TestClaudeCodeBackend(unittest.TestCase):
             elif "log" in cmd:
                 ns.stdout = "feat: x\n"
             return ns
-        with mock.patch.dict(g.os.environ, {"ANTHROPIC_API_KEY": "sk-should-be-stripped"}), \
+        with mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-should-be-stripped"}), \
              mock.patch.object(g.subprocess, "run", side_effect=run):
-            g._invoke_harness_claude_code({"number": 1, "title": "t", "body": "b"}, "/tmp/x")
+            ClaudeCodeBackend().invoke({"number": 1, "title": "t", "body": "b"}, "/tmp/x")
         self.assertNotIn("ANTHROPIC_API_KEY", seen["env"],
                          "claude must run on the subscription, not the capped API key")
 
@@ -347,7 +354,7 @@ class TestClaudeCodeBackend(unittest.TestCase):
                 ns.stdout = "feat: x\n"
             return ns
         with mock.patch.object(g.subprocess, "run", side_effect=run):
-            g._invoke_harness_claude_code({"number": 1, "title": "t", "body": "b"}, "/tmp/x")
+            ClaudeCodeBackend().invoke({"number": 1, "title": "t", "body": "b"}, "/tmp/x")
         cmd = seen["cmd"]
         self.assertNotIn("--dangerously-skip-permissions", cmd,
                          "backend must not bypass all permissions")
@@ -366,37 +373,39 @@ class TestBudgetGate(unittest.TestCase):
         return i
 
     def test_blocked_budget_prevents_worker_invocation(self):
+        adapter = mock.Mock()
         with mock.patch.object(g, "_budget_reserve",
                                return_value=(False, {"decision": "block",
                                                      "reasons": ["cycle_cost_cap_exceeded"]})), \
              mock.patch.object(g, "_prepare_clone") as clone, \
-             mock.patch.object(g, "_invoke_harness") as inv_local, \
-             mock.patch.object(g, "_invoke_harness_claude_code") as inv_cc, \
              mock.patch.object(g, "_write_loop_state"):
             decision, state = g._process_issue(self._issue(), seq=1,
-                                               today="2026-07-19", backend="local")
+                                               today="2026-07-19", backend="local",
+                                               adapter=adapter)
         clone.assert_not_called()
-        inv_local.assert_not_called()
-        inv_cc.assert_not_called()
+        adapter.invoke.assert_not_called()
         self.assertIn("budget", decision["action"])
         self.assertEqual(state["status"], "halted")
 
     def test_allowed_budget_reserves_then_releases(self):
+        adapter = mock.Mock()
+        adapter.needs_local_repo.return_value = True
+        adapter.invoke.return_value = {"branch": "agent/issue-77",
+                                       "commits": ["x"], "blocked": None}
         with mock.patch.object(g, "_budget_reserve",
                                return_value=(True, {"decision": "allow"})) as res, \
              mock.patch.object(g, "_budget_release") as rel, \
              mock.patch.object(g, "_prepare_clone", return_value="/tmp/clone"), \
-             mock.patch.object(g, "_invoke_harness",
-                               return_value={"branch": "agent/issue-77",
-                                             "commits": ["x"], "blocked": None}), \
              mock.patch.object(g, "_open_pr",
                                return_value="https://github.com/x/y/pull/1"), \
              mock.patch.object(g.shutil, "rmtree"), \
              mock.patch.object(g, "_write_loop_state"):
             decision, state = g._process_issue(self._issue(), seq=1,
-                                               today="2026-07-19", backend="local")
+                                               today="2026-07-19", backend="local",
+                                               adapter=adapter)
         res.assert_called_once()
         rel.assert_called_once()            # reservation reconciled after the episode
+        adapter.invoke.assert_called_once()
         self.assertEqual(state["status"], "completed")
 
     def test_parse_budget_block_picks_known_numeric_keys(self):
@@ -485,25 +494,31 @@ class TestPolicyInvalidDistinctFromBlock(unittest.TestCase):
         # An invalid policy is not a per-job condition: validate once, up front,
         # and refuse — rather than blocking every job for the same reason while
         # swallowing every release in flight.
+        fake_adapter = mock.Mock()
+        fake_adapter.prepare.return_value = (True, "ok")
         with mock.patch.object(g, "_gh_queue", return_value=[self._issue()]), \
              mock.patch.object(g.budget, "load_policy",
                                side_effect=g.budget.PolicyInvalid("bad policy")), \
-             mock.patch.object(g, "_ensure_podman") as podman, \
+             mock.patch.object(g, "get_backend", return_value=fake_adapter) as get_backend, \
              mock.patch.object(g, "_process_issue") as proc:
             rc = g.main([])
         self.assertEqual(rc, 2)          # distinct from 1 (error) and 3 (halted)
         proc.assert_not_called()         # no work started
-        podman.assert_not_called()       # not even the sandbox came up
+        get_backend.assert_not_called()  # adapter not selected when policy is invalid
 
     def test_valid_policy_does_not_block_the_cycle(self):
+        fake_adapter = mock.Mock()
+        fake_adapter.prepare.return_value = (True, "")
+        fake_adapter.needs_local_repo.return_value = True
         with mock.patch.object(g, "_gh_queue", return_value=[self._issue()]), \
              mock.patch.object(g.budget, "load_policy", return_value={"ok": True}), \
-             mock.patch.object(g, "_ensure_podman", return_value=(True, "")), \
+             mock.patch.object(g, "get_backend", return_value=fake_adapter), \
              mock.patch.object(g, "_process_issue",
                                return_value=({"issue": 77, "action": "x"}, {})), \
              mock.patch.object(g, "_write_audit"):
             rc = g.main([])
         self.assertEqual(rc, 0)
+        fake_adapter.prepare.assert_called_once()
 
     def test_dry_run_is_unaffected_by_policy_validity(self):
         # Dry-run plans only and reserves nothing, so a broken policy must not


### PR DESCRIPTION
Extracts the existing `--backend claude-code`, `--backend local`, and `--backend remote` invocation paths from `scripts/run_afk_cycle.py` into dedicated adapter modules under `scripts/afk_backends/`.

Closes #873.

## Changes

- `scripts/afk_backends/claude_code.py` — `ClaudeCodeBackend` (headless `claude -p` on the interactive subscription, strips `ANTHROPIC_API_KEY`).
- `scripts/afk_backends/sandcastle.py` — `SandcastleBackend` (Podman sandcastle via the sibling `../afk-harness` project).
- `scripts/afk_backends/remote.py` — `RemoteBackend` (no-op cloud-worker seam, to be implemented in #879).
- `scripts/run_afk_cycle.py` — governor now selects a backend via `get_backend(name)` and delegates `prepare()` and `invoke()` to the adapter. Removed the monolithic backend functions.
- `scripts/test_run_afk_cycle.py` — tests now mock `get_backend` and the adapter classes instead of internal helper functions.

## Verification

- `python -m unittest discover -s scripts -p "test_*.py"` → pass (357 tests).
- `python scripts/validate_governance.py` → pass (146 valid, 0 invalid).
- `python scripts/build_manifest.py` → green.
- `pwsh scripts/verify.ps1` → blocked by missing `tree-sitter` on PATH (pre-existing environment issue, not related to this change).

## Backward compatibility

No CLI or behavioral changes. The same `--backend` values work, the same `{branch, commits, blocked}` result shape is returned, and the budget gate still runs before every worker invocation.
