### PR TITLE
feat(afk): add backend registry loader (config/afk-backends.yaml) (#875)

### DIFF
--- a/config/afk-backends.yaml
+++ b/config/afk-backends.yaml
@@ -1,0 +1,27 @@
+schema_version: "1.0"
+
+# AFK backend registry.
+# Each entry maps a backend name (the value passed to --backend) to the Python
+# adapter class that implements the AFKBackend contract and to the AIW budget
+# provider used for cost gating.
+#
+# The adapter path is relative to the scripts/ directory, because
+# scripts/run_afk_cycle.py adds scripts/ to sys.path before loading backends.
+backends:
+  claude-code:
+    adapter: "afk_backends.claude_code.ClaudeCodeBackend"
+    provider: "claude-code-cli"
+    description: "Headless Claude Code on the interactive subscription (no container)."
+    enabled: true
+
+  local:
+    adapter: "afk_backends.sandcastle.SandcastleBackend"
+    provider: "codex-cli"
+    description: "Podman sandcastle via the sibling ../afk-harness project."
+    enabled: true
+
+  remote:
+    adapter: "afk_backends.remote.RemoteBackend"
+    provider: "claude-code-cli"
+    description: "Cloud-worker backend (Vercel isolated sandboxes). Not yet implemented."
+    enabled: false

--- a/scripts/afk_backends/registry.py
+++ b/scripts/afk_backends/registry.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Backend registry loader for the AFK implement lane.
+
+The registry maps backend names to adapter classes and AIW budget providers. It
+lives in config/afk-backends.yaml so that new tools, providers, and cost
+attributions can be added without editing the governor.
+"""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from afk_backends import AFKBackend
+
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "afk-backends.yaml"
+
+
+class RegistryError(ValueError):
+    """The backend registry is missing, malformed, or names an unknown adapter."""
+
+
+def load_registry(path: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Load the backend registry from YAML.
+
+    Returns a dict keyed by backend name. Raises RegistryError on any problem so
+    the governor fails closed.
+    """
+    p = path or CONFIG_PATH
+    try:
+        with p.open(encoding="utf-8") as stream:
+            data = yaml.safe_load(stream)
+    except (OSError, yaml.YAMLError) as exc:
+        raise RegistryError(f"could not load backend registry from {p}: {exc}") from exc
+
+    if not isinstance(data, dict) or data.get("schema_version") != "1.0":
+        raise RegistryError(f"{p}: expected schema_version '1.0'")
+    backends = data.get("backends")
+    if not isinstance(backends, dict) or not backends:
+        raise RegistryError(f"{p}: missing or empty 'backends' section")
+
+    for name, cfg in backends.items():
+        if not isinstance(cfg, dict):
+            raise RegistryError(f"{p}: backend {name!r} must be a mapping")
+        for key in ("adapter", "provider"):
+            if not isinstance(cfg.get(key), str) or not cfg[key].strip():
+                raise RegistryError(f"{p}: backend {name!r} missing required {key}")
+        if "enabled" not in cfg:
+            cfg["enabled"] = False
+        elif not isinstance(cfg["enabled"], bool):
+            raise RegistryError(f"{p}: backend {name!r} enabled must be a boolean")
+
+    return backends
+
+
+def _resolve_class(dotted_path: str) -> type[AFKBackend]:
+    """Import a dotted class path and verify it is an AFKBackend subclass."""
+    try:
+        module_path, class_name = dotted_path.rsplit(".", 1)
+    except ValueError as exc:
+        raise RegistryError(f"adapter path must be dotted.module.ClassName: {dotted_path}") from exc
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as exc:
+        raise RegistryError(f"could not import adapter module {module_path}: {exc}") from exc
+    cls = getattr(module, class_name, None)
+    if not isinstance(cls, type):
+        raise RegistryError(f"adapter {dotted_path} is not a class")
+    if not issubclass(cls, AFKBackend):
+        raise RegistryError(f"adapter {dotted_path} does not implement AFKBackend")
+    return cls
+
+
+def get_backend(name: str, registry: dict[str, dict[str, Any]] | None = None) -> AFKBackend:
+    """Return an adapter instance for the named backend.
+
+    Raises RegistryError if the backend is unknown, disabled, or misconfigured.
+    """
+    reg = load_registry() if registry is None else registry
+    cfg = reg.get(name)
+    if cfg is None:
+        raise RegistryError(f"unknown backend {name!r}")
+    if not cfg.get("enabled", False):
+        raise RegistryError(f"backend {name!r} is disabled in the registry")
+    cls = _resolve_class(cfg["adapter"])
+    return cls()
+
+
+def provider_for(name: str, registry: dict[str, dict[str, Any]] | None = None) -> str:
+    """Return the AIW budget provider id for the named backend."""
+    reg = load_registry() if registry is None else registry
+    cfg = reg.get(name)
+    if cfg is None:
+        raise RegistryError(f"unknown backend {name!r}")
+    return cfg["provider"]

--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -23,9 +23,9 @@ Backends (--backend):
   local        — per-agent ephemeral clone + Podman sandbox. Runs on this box and
                  FORWARDS ANTHROPIC_API_KEY into the sandbox, i.e. it bills
                  metered API spend. It is currently attributed to `codex-cli`
-                 (local-seat, no approval required) by BACKEND_PROVIDER below, so
+                 (local-seat, no approval required) by config/afk-backends.yaml, so
                  that spend passes the AIW budget gate as if it were free
-                 subscription work — see #863. Opt in explicitly, knowing that.
+                 subscription work — see #863/#877. Opt in explicitly, knowing that.
   remote       — Vercel isolated sandboxes (NOT yet implemented; seam reserved)
 
 Usage:
@@ -55,9 +55,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import aiw_budget_gate as budget  # noqa: E402  (fail-closed AIW budget preflight)
 import council_emit  # noqa: E402  (sibling module in scripts/; self-merge gate)
 import demerzel_kit as kit  # noqa: E402  (shared gh / write-artifact seam)
-from afk_backends.claude_code import ClaudeCodeBackend  # noqa: E402
-from afk_backends.remote import RemoteBackend  # noqa: E402
-from afk_backends.sandcastle import SandcastleBackend  # noqa: E402
+from afk_backends import AFKBackend  # noqa: E402
+from afk_backends.registry import RegistryError, get_backend, provider_for  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[1]            # repos/Demerzel
 PROMPT_FILE = ROOT / "prompts" / "afk-implement.prompt.md"
@@ -76,29 +75,9 @@ SELF_MERGE_MIN_CONFIDENCE = 0.7       # minimum post_council_confidence
 
 # ── AIW budget enforcement (#471) ──────────────────────────────────────────
 # Every worker invocation goes through the fail-closed budget gate first: no
-# granted reservation, no invocation. Each backend maps to an allowlisted
-# provider so the gate applies its per-job / per-cycle caps and local-first rule.
-BACKEND_PROVIDER = {
-    "local": "codex-cli",             # ../afk-harness sandcastle runs Codex CLI
-    "claude-code": "claude-code-cli",  # headless `claude -p` on the subscription
-}
-
-
-_BACKEND_ADAPTERS = {
-    "claude-code": ClaudeCodeBackend,
-    "local": SandcastleBackend,
-    "remote": RemoteBackend,
-}
-
-
-def get_backend(name: str) -> ClaudeCodeBackend | SandcastleBackend | RemoteBackend:
-    """Return an adapter instance for the named backend. Raises ValueError for an
-    unknown backend so the governor fails closed."""
-    cls = _BACKEND_ADAPTERS.get(name)
-    if cls is None:
-        raise ValueError(f"unknown backend {name!r}")
-    return cls()
-
+# granted reservation, no invocation. The backend registry (config/afk-backends.yaml)
+# maps each backend to an allowlisted provider so the gate applies its per-job /
+# per-cycle caps and local-first rule.
 
 # Recognized budget numbers an issue may carry to tighten the policy defaults.
 _BUDGET_KEYS = (
@@ -133,9 +112,7 @@ def _budget_request(issue: dict, backend: str) -> dict:
     """Build an AIW budget request for one issue+backend. Raises for a backend
     with no budgeted provider mapping (fail closed — an unmapped worker is never
     reserved)."""
-    provider = BACKEND_PROVIDER.get(backend)
-    if provider is None:
-        raise ValueError(f"backend {backend!r} has no budgeted provider mapping")
+    provider = provider_for(backend)
     req = {"job_id": f"aiw-{issue.get('number')}", "provider": provider}
     req.update(_parse_budget_block(issue.get("body") or ""))
     return req
@@ -509,7 +486,7 @@ def _run_harvest(dry: bool, today: str) -> int:
 
 
 def _process_issue(issue: dict, seq: int, today: str, backend: str,
-                    adapter) -> tuple[dict, dict]:
+                    adapter: AFKBackend) -> tuple[dict, dict]:
     """Live processing of ONE issue end-to-end (runs inside the thread pool).
     Each call is independent: its own clone, its own branch, its own PR, its own
     loop-state file. Returns (decision, state).
@@ -685,7 +662,11 @@ def main(argv: list[str]) -> int:
             return 2
 
     # Live: ensure the selected backend is ready once, up front.
-    adapter = get_backend(args.backend)
+    try:
+        adapter = get_backend(args.backend)
+    except RegistryError as exc:
+        print(f"ABORT: backend registry error: {exc}", file=sys.stderr)
+        return 1
     if issues:
         ok, pnote = adapter.prepare()
         if not ok:

--- a/scripts/test_afk_registry.py
+++ b/scripts/test_afk_registry.py
@@ -1,0 +1,101 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from afk_backends.claude_code import ClaudeCodeBackend
+from afk_backends.registry import get_backend, load_registry, provider_for, RegistryError
+from afk_backends.remote import RemoteBackend
+from afk_backends.sandcastle import SandcastleBackend
+
+
+class TestLoadRegistry(unittest.TestCase):
+    def test_loads_default_config(self):
+        reg = load_registry()
+        self.assertIn("claude-code", reg)
+        self.assertIn("local", reg)
+        self.assertIn("remote", reg)
+        self.assertEqual(reg["claude-code"]["provider"], "claude-code-cli")
+        self.assertEqual(reg["local"]["provider"], "codex-cli")
+
+    def test_missing_schema_version_raises(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+            tmp.write("backends:\n  x:\n    adapter: a.b.C\n    provider: p\n")
+            path = tmp.name
+        self.addCleanup(Path(path).unlink)
+        with self.assertRaises(RegistryError):
+            load_registry(Path(path))
+
+    def test_missing_backend_section_raises(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+            tmp.write('schema_version: "1.0"\n')
+            path = tmp.name
+        self.addCleanup(Path(path).unlink)
+        with self.assertRaises(RegistryError):
+            load_registry(Path(path))
+
+    def test_missing_adapter_raises(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+            tmp.write('schema_version: "1.0"\nbackends:\n  x:\n    provider: p\n')
+            path = tmp.name
+        self.addCleanup(Path(path).unlink)
+        with self.assertRaises(RegistryError):
+            load_registry(Path(path))
+
+
+class TestGetBackend(unittest.TestCase):
+    def test_returns_configured_adapters(self):
+        reg = {
+            "claude-code": {"adapter": "afk_backends.claude_code.ClaudeCodeBackend",
+                            "provider": "claude-code-cli", "enabled": True},
+            "local": {"adapter": "afk_backends.sandcastle.SandcastleBackend",
+                      "provider": "codex-cli", "enabled": True},
+            "remote": {"adapter": "afk_backends.remote.RemoteBackend",
+                       "provider": "claude-code-cli", "enabled": False},
+        }
+        self.assertIsInstance(get_backend("claude-code", reg), ClaudeCodeBackend)
+        self.assertIsInstance(get_backend("local", reg), SandcastleBackend)
+
+    def test_disabled_backend_raises(self):
+        reg = {
+            "remote": {"adapter": "afk_backends.remote.RemoteBackend",
+                       "provider": "claude-code-cli", "enabled": False},
+        }
+        with self.assertRaisesRegex(RegistryError, "disabled"):
+            get_backend("remote", reg)
+
+    def test_unknown_backend_raises(self):
+        reg = {"claude-code": {"adapter": "afk_backends.claude_code.ClaudeCodeBackend",
+                               "provider": "claude-code-cli", "enabled": True}}
+        with self.assertRaisesRegex(RegistryError, "unknown backend"):
+            get_backend("not-real", reg)
+
+    def test_bad_adapter_path_raises(self):
+        reg = {"x": {"adapter": "not.a.module.Class", "provider": "p", "enabled": True}}
+        with self.assertRaises(RegistryError):
+            get_backend("x", reg)
+
+    def test_non_afk_backend_raises(self):
+        reg = {"x": {"adapter": "builtins.str", "provider": "p", "enabled": True}}
+        with self.assertRaisesRegex(RegistryError, "does not implement AFKBackend"):
+            get_backend("x", reg)
+
+
+class TestProviderFor(unittest.TestCase):
+    def test_returns_provider_for_backend(self):
+        reg = {
+            "claude-code": {"adapter": "afk_backends.claude_code.ClaudeCodeBackend",
+                            "provider": "claude-code-cli", "enabled": True},
+        }
+        self.assertEqual(provider_for("claude-code", reg), "claude-code-cli")
+
+    def test_unknown_backend_raises(self):
+        with self.assertRaisesRegex(RegistryError, "unknown backend"):
+            provider_for("missing", {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -425,7 +425,7 @@ class TestBudgetGate(unittest.TestCase):
             "claude-code-cli")
 
     def test_unmapped_backend_fails_closed(self):
-        allowed, result = g._budget_reserve({"number": 5, "body": ""}, "remote")
+        allowed, result = g._budget_reserve({"number": 5, "body": ""}, "not-a-backend")
         self.assertFalse(allowed)
         self.assertEqual(result["decision"], "block")
 


### PR DESCRIPTION
Adds a backend registry so the AFK governor loads adapters and their budget providers from configuration instead of hardcoded mappings.

Closes #875.

## Changes

- `config/afk-backends.yaml` — registry mapping `claude-code`, `local`, and `remote` to adapter classes and AIW budget providers. Backends can be enabled/disabled independently.
- `scripts/afk_backends/registry.py` — `load_registry()`, `get_backend()`, and `provider_for()`. Loads the YAML file, validates the schema version, resolves adapter classes dynamically, and checks that they implement `AFKBackend`.
- `scripts/run_afk_cycle.py` — removed the hardcoded `BACKEND_PROVIDER` and `_BACKEND_ADAPTERS` dicts; imports `get_backend` and `provider_for` from the registry. Fails closed on registry errors.
- `scripts/test_run_afk_cycle.py` — updated the unmapped-backend test to use a truly unknown backend name.
- `scripts/test_afk_registry.py` — new tests for registry loading, adapter resolution, disabled backends, and provider lookup.

## Verification

- `python -m unittest discover -s scripts -p "test_*.py"` → 368 pass
- `python scripts/validate_governance.py` → 18 evolution logs valid, 0 invalid
- `python scripts/build_manifest.py` → green
- `pwsh scripts/verify.ps1` → still blocked by missing `tree-sitter` on PATH (pre-existing)

## Backward compatibility

The same `--backend` values work and the same provider mappings are preserved. The only behavioral change is that `--backend remote` now returns a clean registry error (disabled) rather than being treated as an unmapped backend by the budget gate.
