### PR TITLE
state(afk): record backend registry in belief and evolution (#875)

### DIFF
--- a/state/beliefs/2026-07-29-afk-backend-adapter.belief.json
+++ b/state/beliefs/2026-07-29-afk-backend-adapter.belief.json
@@ -15,6 +15,12 @@
         "claim": "Extracted the existing claude-code, local (sandcastle), and remote invocation paths from scripts/run_afk_cycle.py into scripts/afk_backends/claude_code.py, sandcastle.py, and remote.py. The governor now selects backends via get_backend() and delegates prepare()/invoke() to the adapter. All 357 unit tests pass.",
         "timestamp": "2026-07-29T00:00:00Z",
         "reliability": 0.98
+      },
+      {
+        "source": "feat/afk-backend-registry-875 (#893)",
+        "claim": "Added a YAML registry at config/afk-backends.yaml and a loader in scripts/afk_backends/registry.py. The governor no longer hardcodes adapter-to-provider mappings; it loads them from configuration, enabling new backends and provider attributions to be added without code changes. 368 unit tests pass.",
+        "timestamp": "2026-07-29T00:00:00Z",
+        "reliability": 0.98
       }
     ]
   },

--- a/state/evolution/2026-07-29-afk-backend-adapter.evolution.json
+++ b/state/evolution/2026-07-29-afk-backend-adapter.evolution.json
@@ -21,6 +21,11 @@
       "type": "amended",
       "context": "Extracted the existing backend invocation paths from scripts/run_afk_cycle.py into dedicated adapter modules: ClaudeCodeBackend (scripts/afk_backends/claude_code.py), SandcastleBackend (scripts/afk_backends/sandcastle.py), and RemoteBackend (scripts/afk_backends/remote.py). The governor now selects a backend via get_backend(name) and delegates prepare() once per cycle and invoke() per issue. Removed the monolithic _invoke_harness, _invoke_harness_claude_code, _invoke_harness_remote, and _ensure_podman functions from the governor. Updated tests to mock adapter classes instead of internal helpers. Issue #873, PR #888.",
       "timestamp": "2026-07-29T00:00:00Z"
+    },
+    {
+      "type": "amended",
+      "context": "Added a backend registry so adapter and provider mappings are loaded from configuration rather than hardcoded. Created config/afk-backends.yaml with entries for claude-code, local, and remote backends, each specifying adapter class, budget provider, description, and enabled flag. Added scripts/afk_backends/registry.py with load_registry(), get_backend(), and provider_for() to resolve adapters dynamically and fail closed on registry errors. Removed the hardcoded BACKEND_PROVIDER and _BACKEND_ADAPTERS dicts from scripts/run_afk_cycle.py. Added scripts/test_afk_registry.py. Issue #875, PR #893.",
+      "timestamp": "2026-07-29T00:00:00Z"
     }
   ],
   "assessment": {


### PR DESCRIPTION
Mandatory state maintenance for the backend registry loader (PR #893).\n\n- state/beliefs/2026-07-29-afk-backend-adapter.belief.json updated with registry evidence.\n- state/evolution/2026-07-29-afk-backend-adapter.evolution.json updated with registry amendment event.\n\nValidated with python scripts/validate_governance.py → 18 evolution logs valid, 0 invalid.