### PR TITLE
fix(afk): attribute local backend to claude-code-cli, not codex-cli (#877)

### DIFF
--- a/config/afk-backends.yaml
+++ b/config/afk-backends.yaml
@@ -16,8 +16,8 @@ backends:
 
   local:
     adapter: "afk_backends.sandcastle.SandcastleBackend"
-    provider: "codex-cli"
-    description: "Podman sandcastle via the sibling ../afk-harness project."
+    provider: "claude-code-cli"
+    description: "Podman sandcastle via the sibling ../afk-harness project. Forwards ANTHROPIC_API_KEY, so it is metered Claude API spend."
     enabled: true
 
   remote:

--- a/docs/solutions/harness/2026-07-29-a-guard-is-only-as-good-as-its-subject.md
+++ b/docs/solutions/harness/2026-07-29-a-guard-is-only-as-good-as-its-subject.md
@@ -24,10 +24,14 @@ The guard is not dead. It is looking in the wrong direction, confidently.
 **1. The budget gate evaluated the right policy against the wrong provider.**
 `run_afk_cycle.py --backend local` runs `claudeCode("claude-opus-4-8")` and
 forwards `ANTHROPIC_API_KEY` into the sandbox — metered API spend. But
-`BACKEND_PROVIDER` maps `local` → `codex-cli`, which the policy classifies
-`tier: local-seat`, `requires_manual_approval: false`. The AIW budget gate exists
+`BACKEND_PROVIDER` mapped `local` → `codex-cli`, which the policy classifies
+`tier: local-seat`, `requires_manual_approval: false`. The AIW budget gate existed
 precisely to stop unapproved metered spend. It ran, it passed, and it was correct
 about `codex-cli` — a provider that was not being used. (#863)
+
+Fixed in #877 by moving the provider mapping to `config/afk-backends.yaml` and
+attributing the `local` backend to `claude-code-cli`, so the gate now applies the
+right provider caps and approval rules.
 
 **2. The agent's oracle checked schemas, not the suite.**
 `prompts/afk-implement.prompt.md` required `validate_governance.py` and nothing

--- a/docs/solutions/harness/2026-07-29-afk-backend-adapter-contract.md
+++ b/docs/solutions/harness/2026-07-29-afk-backend-adapter-contract.md
@@ -81,20 +81,20 @@ A declarative registry file will map backend names to adapter classes, execution
 ```yaml
 backends:
   claude-code:
-    adapter: scripts.afk_backends.claude_code.ClaudeCodeBackend
-    execution_mode: desktop
+    adapter: afk_backends.claude_code.ClaudeCodeBackend
     provider: claude-code-cli
+    enabled: true
   local:
-    adapter: scripts.afk_backends.sandcastle.SandcastleBackend
-    execution_mode: desktop
-    provider: anthropic-api
+    adapter: afk_backends.sandcastle.SandcastleBackend
+    provider: claude-code-cli
+    enabled: true
   remote:
-    adapter: scripts.afk_backends.remote.RemoteBackend
-    execution_mode: cloud
-    provider: cloud-worker
+    adapter: afk_backends.remote.RemoteBackend
+    provider: claude-code-cli
+    enabled: false
 ```
 
-This removes the hardcoded `BACKEND_PROVIDER` dict from `run_afk_cycle.py` and fixes the spend-attribution bug in #863 at the config/policy layer.
+This removes the hardcoded `BACKEND_PROVIDER` dict from `run_afk_cycle.py` and fixes the spend-attribution bug in #863 at the config/policy layer (completed in #877).
 
 ## Consequences
 

--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -22,10 +22,9 @@ Backends (--backend):
                  the CLI falls back to the interactive subscription.
   local        — per-agent ephemeral clone + Podman sandbox. Runs on this box and
                  FORWARDS ANTHROPIC_API_KEY into the sandbox, i.e. it bills
-                 metered API spend. It is currently attributed to `codex-cli`
-                 (local-seat, no approval required) by config/afk-backends.yaml, so
-                 that spend passes the AIW budget gate as if it were free
-                 subscription work — see #863/#877. Opt in explicitly, knowing that.
+                 metered Claude API spend. It is attributed to `claude-code-cli`
+                 by config/afk-backends.yaml so the AIW budget gate applies the
+                 right provider caps and approval rules. Opt in explicitly.
   remote       — Vercel isolated sandboxes (NOT yet implemented; seam reserved)
 
 Usage:

--- a/scripts/test_afk_registry.py
+++ b/scripts/test_afk_registry.py
@@ -19,7 +19,7 @@ class TestLoadRegistry(unittest.TestCase):
         self.assertIn("local", reg)
         self.assertIn("remote", reg)
         self.assertEqual(reg["claude-code"]["provider"], "claude-code-cli")
-        self.assertEqual(reg["local"]["provider"], "codex-cli")
+        self.assertEqual(reg["local"]["provider"], "claude-code-cli")
 
     def test_missing_schema_version_raises(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -419,7 +419,7 @@ class TestBudgetGate(unittest.TestCase):
 
     def test_budget_request_maps_backend_provider(self):
         self.assertEqual(
-            g._budget_request({"number": 5, "body": ""}, "local")["provider"], "codex-cli")
+            g._budget_request({"number": 5, "body": ""}, "local")["provider"], "claude-code-cli")
         self.assertEqual(
             g._budget_request({"number": 5, "body": ""}, "claude-code")["provider"],
             "claude-code-cli")


### PR DESCRIPTION
Fixes the AIW budget gate bypass that misattributed the `--backend local` sandcastle spend to the free `codex-cli` provider.

Closes #877. Supersedes #863.

## The bug

The `local` backend runs Claude Code inside a Podman sandbox and forwards `ANTHROPIC_API_KEY`, so it bills metered Claude API spend. The old hardcoded `BACKEND_PROVIDER` dict mapped `local` → `codex-cli`, which the policy treats as a local-seat provider with no manual approval. The gate ran and passed — against the wrong provider.

## The fix

The backend registry added in #875 makes the provider mapping configurable. This change flips the `local` entry in `config/afk-backends.yaml` from `codex-cli` to `claude-code-cli`, so the AIW budget gate now applies the correct provider caps and approval rules.

## Files changed

- `config/afk-backends.yaml` — `local` provider now `claude-code-cli`; description updated.
- `scripts/run_afk_cycle.py` — docstring updated to reflect the correct attribution.
- `docs/solutions/harness/2026-07-29-afk-backend-adapter-contract.md` — registry example updated.
- `docs/solutions/harness/2026-07-29-a-guard-is-only-as-good-as-its-subject.md` — notes the fix.
- `scripts/test_run_afk_cycle.py` — `test_budget_request_maps_backend_provider` expects `claude-code-cli` for `local`.
- `scripts/test_afk_registry.py` — `test_loads_default_config` expects `claude-code-cli` for `local`.

## Verification

- `python -m unittest discover -s scripts -p "test_*.py"` → 368 pass
- `python scripts/validate_governance.py` → 18 evolution logs valid, 0 invalid
- `python scripts/build_manifest.py` → green
- `pwsh scripts/verify.ps1` → blocked by missing `tree-sitter` on PATH (pre-existing)
