### PR TITLE
feat(afk): implement cloud-worker backend adapter (#879)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Demerzel/
 | Personas | 17 | `personas/*.persona.yaml` |
 | Policies | 46 | `policies/*.yaml` |
 | Grammars | 20 | `grammars/*.ebnf` |
-| Schemas | 48 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
+| Schemas | 49 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
 | Behavioral tests | 115 | `tests/behavioral/*.md` |
 | Skills | 69 | `.claude/skills/*/` |
 | Streeling departments | 23 | `state/streeling/departments/*.department.json` |

--- a/config/afk-backends.yaml
+++ b/config/afk-backends.yaml
@@ -23,5 +23,9 @@ backends:
   remote:
     adapter: "afk_backends.remote.RemoteBackend"
     provider: "claude-code-cli"
-    description: "Cloud-worker backend (Vercel isolated sandboxes). Not yet implemented."
+    description: "HTTP cloud worker (Vercel, Codespaces, or any AFK-compatible endpoint). Disabled by default until an endpoint is configured."
     enabled: false
+    config:
+      # endpoint: "https://example.com/afk-worker"
+      # api_key_env: "DEMERZEL_REMOTE_API_KEY"
+      # timeout: 300

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -10,7 +10,7 @@
     "persona": 17,
     "pipeline": 23,
     "policy": 46,
-    "schema": 48,
+    "schema": 49,
     "seldon_schema": 7,
     "skill": 69,
     "streeling_schema": 1,
@@ -502,6 +502,10 @@
       {
         "name": "reconnaissance-profile.schema",
         "path": "schemas/reconnaissance-profile.schema.json"
+      },
+      {
+        "name": "recursive-learning-eval.schema",
+        "path": "schemas/recursive-learning-eval.schema.json"
       },
       {
         "name": "research-anomaly.schema",

--- a/scripts/afk_backends/__init__.py
+++ b/scripts/afk_backends/__init__.py
@@ -33,6 +33,15 @@ class AFKBackend(ABC):
     and treats them as interchangeable workers.
     """
 
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """Optional config from the registry entry.
+
+        Backends that do not need configuration can ignore this. Cloud or
+        pluggable backends should read their endpoint, credentials, etc. from
+        the registry-supplied config dict.
+        """
+        self.config = config or {}
+
     @abstractmethod
     def prepare(self) -> tuple[bool, str]:
         """Check that the backend is ready to run.

--- a/scripts/afk_backends/registry.py
+++ b/scripts/afk_backends/registry.py
@@ -86,7 +86,7 @@ def get_backend(name: str, registry: dict[str, dict[str, Any]] | None = None) ->
     if not cfg.get("enabled", False):
         raise RegistryError(f"backend {name!r} is disabled in the registry")
     cls = _resolve_class(cfg["adapter"])
-    return cls()
+    return cls(cfg.get("config"))
 
 
 def provider_for(name: str, registry: dict[str, dict[str, Any]] | None = None) -> str:

--- a/scripts/afk_backends/remote.py
+++ b/scripts/afk_backends/remote.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """Cloud worker backend for the AFK implement lane.
 
-Backend seam for Vercel isolated sandboxes or any generic HTTP worker. Not yet
-implemented; this module exists to keep the governor's backend abstraction
-complete while the remote worker contract is being built (see #879).
+Delegates to a configurable HTTP worker endpoint (Vercel isolated sandboxes,
+GitHub Codespaces, or any service that implements the AFK result contract). The
+endpoint must accept a POST with the issue JSON and return
+`{"branch": ..., "commits": [...], "blocked": ...}`.
 """
 from __future__ import annotations
 
+import json
+import os
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -18,23 +23,86 @@ from afk_backends import AFKBackend  # noqa: E402
 
 
 class RemoteBackend(AFKBackend):
-    """Cloud backend: delegate to a remote worker endpoint.
+    """Cloud backend: delegate to a remote worker endpoint over HTTP.
 
-    Currently returns a clean blocked result so the backend can be registered and
-    selected without crashing the governor. A real implementation will be added
-    in #879.
+    Configuration (from config/afk-backends.yaml under the remote backend entry):
+
+        endpoint:      URL to POST to (required when enabled)
+        api_key_env:   name of an env var holding an Authorization bearer token
+        timeout:       request timeout in seconds (default 300)
     """
 
+    def _endpoint(self) -> str | None:
+        return self.config.get("endpoint")
+
+    def _api_key(self) -> str | None:
+        env_name = self.config.get("api_key_env")
+        if env_name:
+            return os.environ.get(env_name)
+        return None
+
+    def _timeout(self) -> int:
+        return int(self.config.get("timeout", 300))
+
     def prepare(self) -> tuple[bool, str]:
-        return True, "remote backend registered but not configured (no-op)"
+        endpoint = self._endpoint()
+        if not endpoint:
+            return False, "remote backend is enabled but no endpoint is configured"
+        try:
+            req = urllib.request.Request(endpoint, method="HEAD")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                _ = resp.read()
+        except urllib.error.HTTPError as exc:
+            # A 404/405 from a HEAD request is common; the endpoint may only
+            # support POST. Treat HTTP-level reachability as success.
+            if exc.code >= 500:
+                return False, f"remote endpoint unavailable: HTTP {exc.code}"
+        except (OSError, urllib.error.URLError) as exc:
+            return False, f"remote endpoint unreachable: {exc}"
+        return True, f"remote endpoint reachable ({endpoint})"
 
     def needs_local_repo(self) -> bool:
         return False
 
     def invoke(self, issue: dict[str, Any], repo_path: str | None) -> dict:
-        return {"branch": None, "commits": [],
-                "blocked": "remote backend (Vercel isolated sandboxes) not implemented yet — "
-                           "use --backend claude-code or local"}
+        endpoint = self._endpoint()
+        if not endpoint:
+            return {"branch": None, "commits": [],
+                    "blocked": "remote backend has no endpoint configured"}
+
+        payload = json.dumps({"issue": issue, "repo_path": repo_path}).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        api_key = self._api_key()
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout()) as resp:
+                body = resp.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8")[:400]
+            return {"branch": None, "commits": [],
+                    "blocked": f"remote worker returned HTTP {exc.code}: {body}"}
+        except (OSError, urllib.error.URLError) as exc:
+            return {"branch": None, "commits": [],
+                    "blocked": f"remote worker request failed: {exc}"}
+
+        try:
+            result = json.loads(body)
+        except json.JSONDecodeError as exc:
+            return {"branch": None, "commits": [],
+                    "blocked": f"remote worker returned invalid JSON: {exc}"}
+
+        for key in ("branch", "commits", "blocked"):
+            if key not in result:
+                return {"branch": None, "commits": [],
+                        "blocked": f"remote worker response missing required field {key!r}"}
+        return result
 
     def estimate_cost(self, issue: dict[str, Any]) -> dict:
         return {"estimated_cost_usd": 2.0, "estimated_runner_minutes": 30}

--- a/scripts/test_remote_backend.py
+++ b/scripts/test_remote_backend.py
@@ -1,0 +1,111 @@
+import json
+import os
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from afk_backends.remote import RemoteBackend
+
+
+class TestRemoteBackend(unittest.TestCase):
+    def test_needs_no_local_repo(self):
+        self.assertFalse(RemoteBackend().needs_local_repo())
+
+    def test_without_endpoint_is_blocked(self):
+        result = RemoteBackend().invoke({"number": 1, "title": "x", "body": "y"}, None)
+        self.assertIsNone(result["branch"])
+        self.assertEqual(result["commits"], [])
+        self.assertIn("no endpoint", result["blocked"].lower())
+
+    def test_prepare_without_endpoint_fails(self):
+        ok, note = RemoteBackend().prepare()
+        self.assertFalse(ok)
+        self.assertIn("no endpoint", note.lower())
+
+    def _make_response(self, body: bytes, code: int = 200):
+        class FakeResponse:
+            def __init__(self, body, code):
+                self._body = body
+                self.code = code
+            def read(self):
+                return self._body
+            def __enter__(self):
+                return self
+            def __exit__(self, *exc):
+                return False
+        return FakeResponse(body, code)
+
+    def test_invoke_posts_issue_and_repo_path(self):
+        backend = RemoteBackend({"endpoint": "https://worker.example/afk"})
+        seen = {}
+        def urlopen(req, timeout=None):
+            seen["url"] = req.full_url
+            seen["body"] = req.data
+            seen["headers"] = dict(req.headers)
+            return self._make_response(json.dumps({"branch": "agent/issue-1",
+                                                   "commits": ["feat: x"],
+                                                   "blocked": None}).encode())
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen):
+            result = backend.invoke({"number": 1, "title": "x", "body": "y"}, None)
+        self.assertEqual(seen["url"], "https://worker.example/afk")
+        payload = json.loads(seen["body"])
+        self.assertEqual(payload["issue"]["number"], 1)
+        self.assertIsNone(payload["repo_path"])
+        self.assertEqual(result["branch"], "agent/issue-1")
+        self.assertEqual(result["commits"], ["feat: x"])
+        self.assertIsNone(result["blocked"])
+
+    def test_invoke_sends_api_key(self):
+        backend = RemoteBackend({"endpoint": "https://worker.example/afk",
+                                 "api_key_env": "TEST_REMOTE_KEY"})
+        seen = {}
+        def urlopen(req, timeout=None):
+            seen["auth"] = req.get_header("Authorization")
+            return self._make_response(json.dumps({"branch": None,
+                                                   "commits": [],
+                                                   "blocked": "busy"}).encode())
+        with mock.patch("urllib.request.urlopen", side_effect=urlopen), \
+             mock.patch.dict(os.environ, {"TEST_REMOTE_KEY": "secret-token"}):
+            backend.invoke({"number": 1}, None)
+        self.assertEqual(seen["auth"], "Bearer secret-token")
+
+    def test_http_error_returns_blocked(self):
+        backend = RemoteBackend({"endpoint": "https://worker.example/afk"})
+        err = HTTPError("https://worker.example/afk", 503, "Service Unavailable", None, None)
+        err.read = lambda: b"overloaded"
+        with mock.patch("urllib.request.urlopen", side_effect=err):
+            result = backend.invoke({"number": 1}, None)
+        self.assertIsNone(result["branch"])
+        self.assertEqual(result["commits"], [])
+        self.assertIn("503", result["blocked"])
+
+    def test_network_error_returns_blocked(self):
+        backend = RemoteBackend({"endpoint": "https://worker.example/afk"})
+        with mock.patch("urllib.request.urlopen", side_effect=URLError("no route")):
+            result = backend.invoke({"number": 1}, None)
+        self.assertIsNone(result["branch"])
+        self.assertEqual(result["commits"], [])
+        self.assertIn("request failed", result["blocked"].lower())
+
+    def test_invalid_json_returns_blocked(self):
+        backend = RemoteBackend({"endpoint": "https://worker.example/afk"})
+        with mock.patch("urllib.request.urlopen",
+                        return_value=self._make_response(b"not json")):
+            result = backend.invoke({"number": 1}, None)
+        self.assertIn("invalid JSON", result["blocked"])
+
+    def test_missing_result_fields_returns_blocked(self):
+        backend = RemoteBackend({"endpoint": "https://worker.example/afk"})
+        with mock.patch("urllib.request.urlopen",
+                        return_value=self._make_response(json.dumps({"branch": "x"}).encode())):
+            result = backend.invoke({"number": 1}, None)
+        self.assertIn("missing required field", result["blocked"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -99,7 +99,7 @@ class TestParallelDispatch(unittest.TestCase):
 
 
 class TestBackend(unittest.TestCase):
-    def test_remote_backend_is_blocked_stub(self):
+    def test_remote_backend_without_config_is_blocked(self):
         hr = RemoteBackend().invoke({"number": 1, "title": "x", "body": "y"}, None)
         self.assertIsNone(hr["branch"])
         self.assertIn("remote", hr["blocked"].lower())


### PR DESCRIPTION
Closes #879.

Implements the `--backend remote` seam as a real HTTP adapter, completing the AFK backend-adapter abstraction for desktop, container, and cloud tools.

## Changes

- `scripts/afk_backends/__init__.py` — `AFKBackend.__init__` now accepts an optional `config` dict so the registry can pass per-backend configuration.
- `scripts/afk_backends/registry.py` — `get_backend()` instantiates adapters with `cfg.get("config")`.
- `scripts/afk_backends/remote.py` — replaces the no-op stub with a full HTTP implementation:
  - POSTs `{"issue": ..., "repo_path": ...}` as JSON to a configured `endpoint`.
  - Optionally sends `Authorization: Bearer <token>` from the environment variable named in `api_key_env`.
  - Default 5-minute timeout, configurable via `timeout`.
  - Validates the worker response contains `branch`, `commits`, and `blocked`.
  - Returns clean `blocked` messages on missing endpoint, network errors, HTTP errors, invalid JSON, and malformed responses.
- `config/afk-backends.yaml` — adds a `config` block for the `remote` backend with `endpoint`, `api_key_env`, and `timeout` fields (commented out until an operator enables it).
- `scripts/test_remote_backend.py` — new test suite covering success, payload shape, auth header, HTTP error, network error, invalid JSON, and missing response fields using `unittest.mock`.
- `scripts/test_run_afk_cycle.py` — renames the remote no-op test to reflect the new behavior.
- `README.md` — synchronizes the schema count from `48 + 9 contracts` to `49 + 9 contracts` so `python scripts/build_manifest.py` passes.
- `governance-manifest.json` — regenerated by the manifest builder.

## Verification

```bash
python -m unittest discover -s scripts -p "test_*.py"  # 390 pass
python scripts/validate_governance.py                  # 18 evolution logs valid, 0 invalid
python scripts/build_manifest.py                         # green
```
