### PR TITLE
feat(afk): add generic shell backend to prove tool-agnostic abstraction (#882)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Demerzel/
 | Personas | 17 | `personas/*.persona.yaml` |
 | Policies | 46 | `policies/*.yaml` |
 | Grammars | 20 | `grammars/*.ebnf` |
-| Schemas | 49 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
+| Schemas | 48 + 9 contracts | `schemas/*.json` + `schemas/contracts/` |
 | Behavioral tests | 115 | `tests/behavioral/*.md` |
 | Skills | 69 | `.claude/skills/*/` |
 | Streeling departments | 23 | `state/streeling/departments/*.department.json` |

--- a/config/afk-backends.yaml
+++ b/config/afk-backends.yaml
@@ -29,3 +29,15 @@ backends:
       # endpoint: "https://example.com/afk-worker"
       # api_key_env: "DEMERZEL_REMOTE_API_KEY"
       # timeout: 300
+
+  shell:
+    adapter: "afk_backends.shell.ShellBackend"
+    provider: "generic-shell"
+    description: "Generic configurable shell command. Proves the AFKBackend abstraction works with any non-Claude tool that reads a JSON issue from stdin and emits a JSON result on stdout. Disabled by default until a command is configured."
+    enabled: false
+    config:
+      # command: ["python", "my_afk_agent.py"]
+      # timeout: 300
+      # needs_local_repo: true
+      # env:
+      #   MY_AGENT_MODE: "afk"

--- a/governance-manifest.json
+++ b/governance-manifest.json
@@ -10,7 +10,7 @@
     "persona": 17,
     "pipeline": 23,
     "policy": 46,
-    "schema": 49,
+    "schema": 48,
     "seldon_schema": 7,
     "skill": 69,
     "streeling_schema": 1,
@@ -502,10 +502,6 @@
       {
         "name": "reconnaissance-profile.schema",
         "path": "schemas/reconnaissance-profile.schema.json"
-      },
-      {
-        "name": "recursive-learning-eval.schema",
-        "path": "schemas/recursive-learning-eval.schema.json"
       },
       {
         "name": "research-anomaly.schema",

--- a/scripts/afk_backends/shell.py
+++ b/scripts/afk_backends/shell.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Generic shell backend for the AFK implement lane.
+
+Runs a configurable external command as the implementation agent. The command
+receives the issue as JSON on stdin and a set of AFK_* environment variables.
+It must print a JSON object with branch, commits, and blocked keys on stdout.
+
+Configuration (from config/afk-backends.yaml under the shell backend entry):
+
+    command: ["python", "my_agent.py"]          # required
+    timeout: 300                                 # default 300
+    needs_local_repo: true                         # default true
+    env:                                            # extra env vars
+      MY_AGENT_MODE: "afk"
+"""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from afk_backends import AFKBackend  # noqa: E402
+
+
+class ShellBackend(AFKBackend):
+    """Desktop backend: delegate to a configurable shell command.
+
+    This proves the AFKBackend abstraction works with any non-Claude tool that
+    can read a JSON issue from stdin and emit a JSON result on stdout.
+    """
+
+    def _command(self) -> list[str] | None:
+        raw = self.config.get("command")
+        if raw is None:
+            return None
+        if isinstance(raw, list):
+            return [str(x) for x in raw]
+        if isinstance(raw, str):
+            return shlex.split(raw)
+        return None
+
+    def _timeout(self) -> int:
+        return int(self.config.get("timeout", 300))
+
+    def _needs_local_repo(self) -> bool:
+        return bool(self.config.get("needs_local_repo", True))
+
+    def _env(self, issue: dict[str, Any], repo_path: str | None) -> dict[str, str]:
+        base = os.environ.copy()
+        extra = self.config.get("env") or {}
+        base.update({str(k): str(v) for k, v in extra.items()})
+        base["AFK_ISSUE_NUMBER"] = str(issue.get("number", ""))
+        base["AFK_ISSUE_TITLE"] = str(issue.get("title", ""))
+        base["AFK_ISSUE_BODY"] = str(issue.get("body", ""))
+        base["AFK_ISSUE_LABELS"] = ",".join(str(l) for l in issue.get("labels", []))
+        if repo_path is not None:
+            base["AFK_REPO_PATH"] = repo_path
+        return base
+
+    def prepare(self) -> tuple[bool, str]:
+        command = self._command()
+        if not command:
+            return False, "shell backend is enabled but no command is configured"
+        tool = command[0]
+        if not shutil.which(tool):
+            return False, f"shell backend command not found on PATH: {tool}"
+        return True, f"shell backend command ready ({tool})"
+
+    def needs_local_repo(self) -> bool:
+        return self._needs_local_repo()
+
+    def invoke(self, issue: dict[str, Any], repo_path: str | None) -> dict:
+        command = self._command()
+        if not command:
+            return {"branch": None, "commits": [],
+                    "blocked": "shell backend has no command configured"}
+
+        try:
+            result = subprocess.run(
+                command,
+                input=json.dumps(issue).encode("utf-8"),
+                env=self._env(issue, repo_path),
+                capture_output=True,
+                timeout=self._timeout(),
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            return {"branch": None, "commits": [],
+                    "blocked": f"shell backend command not found: {exc}"}
+        except subprocess.TimeoutExpired as exc:
+            return {"branch": None, "commits": [],
+                    "blocked": f"shell backend timed out after {exc.timeout} seconds"}
+        except OSError as exc:
+            return {"branch": None, "commits": [],
+                    "blocked": f"shell backend failed to run: {exc}"}
+
+        if result.returncode != 0:
+            stderr = result.stderr.decode("utf-8", errors="replace")[:400]
+            return {"branch": None, "commits": [],
+                    "blocked": f"shell backend exited {result.returncode}: {stderr}"}
+
+        stdout = result.stdout.decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            return {"branch": None, "commits": [],
+                    "blocked": f"shell backend returned invalid JSON: {exc}"}
+
+        for key in ("branch", "commits", "blocked"):
+            if key not in parsed:
+                return {"branch": None, "commits": [],
+                        "blocked": f"shell backend response missing required field {key!r}"}
+        return parsed
+
+    def estimate_cost(self, issue: dict[str, Any]) -> dict:
+        return {"estimated_cost_usd": 1.0, "estimated_runner_minutes": 15}

--- a/scripts/test_afk_registry.py
+++ b/scripts/test_afk_registry.py
@@ -10,6 +10,7 @@ from afk_backends.claude_code import ClaudeCodeBackend
 from afk_backends.registry import get_backend, load_registry, provider_for, RegistryError
 from afk_backends.remote import RemoteBackend
 from afk_backends.sandcastle import SandcastleBackend
+from afk_backends.shell import ShellBackend
 
 
 class TestLoadRegistry(unittest.TestCase):
@@ -18,8 +19,11 @@ class TestLoadRegistry(unittest.TestCase):
         self.assertIn("claude-code", reg)
         self.assertIn("local", reg)
         self.assertIn("remote", reg)
+        self.assertIn("shell", reg)
         self.assertEqual(reg["claude-code"]["provider"], "claude-code-cli")
         self.assertEqual(reg["local"]["provider"], "claude-code-cli")
+        self.assertEqual(reg["shell"]["provider"], "generic-shell")
+        self.assertFalse(reg["shell"]["enabled"])
 
     def test_missing_schema_version_raises(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
@@ -55,9 +59,13 @@ class TestGetBackend(unittest.TestCase):
                       "provider": "codex-cli", "enabled": True},
             "remote": {"adapter": "afk_backends.remote.RemoteBackend",
                        "provider": "claude-code-cli", "enabled": False},
+            "shell": {"adapter": "afk_backends.shell.ShellBackend",
+                      "provider": "generic-shell", "enabled": True,
+                      "config": {"command": ["echo"]}},
         }
         self.assertIsInstance(get_backend("claude-code", reg), ClaudeCodeBackend)
         self.assertIsInstance(get_backend("local", reg), SandcastleBackend)
+        self.assertIsInstance(get_backend("shell", reg), ShellBackend)
 
     def test_disabled_backend_raises(self):
         reg = {

--- a/scripts/test_shell_backend.py
+++ b/scripts/test_shell_backend.py
@@ -1,0 +1,115 @@
+import json
+import os
+import subprocess
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from afk_backends.shell import ShellBackend
+
+
+class TestShellBackend(unittest.TestCase):
+    def _completed(self, stdout: bytes, stderr: bytes = b"", returncode: int = 0):
+        return subprocess.CompletedProcess(args=["agent"], returncode=returncode,
+                                           stdout=stdout, stderr=stderr)
+
+    def test_needs_local_repo_defaults_true(self):
+        self.assertTrue(ShellBackend().needs_local_repo())
+
+    def test_needs_local_repo_can_be_false(self):
+        self.assertFalse(ShellBackend({"needs_local_repo": False}).needs_local_repo())
+
+    def test_prepare_without_command_fails(self):
+        ok, note = ShellBackend().prepare()
+        self.assertFalse(ok)
+        self.assertIn("no command", note.lower())
+
+    def test_prepare_with_missing_executable_fails(self):
+        ok, note = ShellBackend({"command": ["not-a-real-binary-xyz"]}).prepare()
+        self.assertFalse(ok)
+        self.assertIn("not found", note.lower())
+
+    def test_prepare_with_existing_executable_succeeds(self):
+        with mock.patch("shutil.which", return_value="/usr/bin/python"):
+            ok, note = ShellBackend({"command": ["python", "agent.py"]}).prepare()
+        self.assertTrue(ok)
+        self.assertIn("python", note.lower())
+
+    def test_invoke_without_command_is_blocked(self):
+        result = ShellBackend().invoke({"number": 1}, None)
+        self.assertIn("no command", result["blocked"].lower())
+
+    def test_invoke_runs_command_with_issue_json(self):
+        backend = ShellBackend({"command": ["python", "agent.py"]})
+        seen = {}
+        def run(cmd, input=None, env=None, capture_output=None, timeout=None, check=None):
+            seen["cmd"] = cmd
+            seen["input"] = input.decode("utf-8")
+            seen["timeout"] = timeout
+            seen["env_keys"] = set(env.keys()) - set(os.environ.keys())
+            return self._completed(json.dumps({"branch": "agent/issue-1",
+                                               "commits": ["feat: x"],
+                                               "blocked": None}).encode())
+        with mock.patch("subprocess.run", side_effect=run):
+            result = backend.invoke({"number": 1, "title": "x", "body": "y"}, None)
+        self.assertEqual(seen["cmd"], ["python", "agent.py"])
+        payload = json.loads(seen["input"])
+        self.assertEqual(payload["number"], 1)
+        self.assertEqual(seen["timeout"], 300)
+        self.assertIn("AFK_ISSUE_NUMBER", seen["env_keys"])
+        self.assertEqual(result["branch"], "agent/issue-1")
+        self.assertEqual(result["commits"], ["feat: x"])
+        self.assertIsNone(result["blocked"])
+
+    def test_invoke_passes_repo_path_in_env(self):
+        backend = ShellBackend({"command": ["agent"]})
+        seen = {}
+        def run(cmd, input=None, env=None, capture_output=None, timeout=None, check=None):
+            seen["AFK_REPO_PATH"] = env.get("AFK_REPO_PATH")
+            return self._completed(json.dumps({"branch": None, "commits": [], "blocked": "busy"}).encode())
+        with mock.patch("subprocess.run", side_effect=run):
+            backend.invoke({"number": 1}, "/tmp/repo")
+        self.assertEqual(seen["AFK_REPO_PATH"], "/tmp/repo")
+
+    def test_invoke_passes_extra_env(self):
+        backend = ShellBackend({"command": ["agent"], "env": {"MY_MODE": "afk"}})
+        seen = {}
+        def run(cmd, input=None, env=None, capture_output=None, timeout=None, check=None):
+            seen["MY_MODE"] = env.get("MY_MODE")
+            return self._completed(json.dumps({"branch": None, "commits": [], "blocked": "busy"}).encode())
+        with mock.patch("subprocess.run", side_effect=run):
+            backend.invoke({"number": 1}, None)
+        self.assertEqual(seen["MY_MODE"], "afk")
+
+    def test_nonzero_exit_returns_blocked(self):
+        backend = ShellBackend({"command": ["agent"]})
+        with mock.patch("subprocess.run", return_value=self._completed(b"", b"bad args", 2)):
+            result = backend.invoke({"number": 1}, None)
+        self.assertIn("exited 2", result["blocked"])
+        self.assertIn("bad args", result["blocked"])
+
+    def test_timeout_returns_blocked(self):
+        backend = ShellBackend({"command": ["agent"], "timeout": 10})
+        with mock.patch("subprocess.run", side_effect=subprocess.TimeoutExpired(["agent"], 10)):
+            result = backend.invoke({"number": 1}, None)
+        self.assertIn("timed out", result["blocked"].lower())
+
+    def test_invalid_json_returns_blocked(self):
+        backend = ShellBackend({"command": ["agent"]})
+        with mock.patch("subprocess.run", return_value=self._completed(b"not json")):
+            result = backend.invoke({"number": 1}, None)
+        self.assertIn("invalid JSON", result["blocked"])
+
+    def test_missing_result_fields_returns_blocked(self):
+        backend = ShellBackend({"command": ["agent"]})
+        with mock.patch("subprocess.run", return_value=self._completed(json.dumps({"branch": "x"}).encode())):
+            result = backend.invoke({"number": 1}, None)
+        self.assertIn("missing required field", result["blocked"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #882.

Adds a second, non-Claude desktop adapter to prove the AFKBackend abstraction is tool-agnostic.

## Changes

- `scripts/afk_backends/shell.py` — new `ShellBackend` that runs a configurable command:
  - Receives the issue as JSON on stdin.
  - Receives `AFK_ISSUE_NUMBER`, `AFK_ISSUE_TITLE`, `AFK_ISSUE_BODY`, `AFK_ISSUE_LABELS`, and `AFK_REPO_PATH` via environment variables.
  - Configurable `command`, `timeout`, `needs_local_repo`, and extra `env`.
  - Validates the command's stdout JSON contains `branch`, `commits`, and `blocked`.
  - Returns clean `blocked` messages on missing command, missing executable, timeout, nonzero exit, invalid JSON, and malformed responses.
- `config/afk-backends.yaml` — adds a `shell` backend entry with provider `generic-shell`, disabled by default until a command is configured.
- `scripts/test_shell_backend.py` — new test suite covering success, env vars, extra env, missing command, missing executable, nonzero exit, timeout, invalid JSON, and missing response fields.
- `scripts/test_afk_registry.py` — asserts the `shell` backend is present in the default registry and resolves to `ShellBackend`.
- `README.md` — reverts the schema count from `49 + 9 contracts` back to `48 + 9 contracts`. The prior drift was caused by an untracked `schemas/recursive-learning-eval.schema.json` in the working tree; the canonical `schemas/*.json` count is 48.
- `governance-manifest.json` — regenerated by the manifest builder.

## Verification

```bash
python -m unittest discover -s scripts -p "test_*.py"  # 390 pass
python scripts/validate_governance.py                  # 18 evolution logs valid, 0 invalid
python scripts/build_manifest.py                         # green
```
