### PR TITLE
docs(afk): update doctrine and policy for tool-agnostic desktop/cloud AFK (#884)

### DIFF
--- a/docs/workflows/aiw-operating-doctrine.md
+++ b/docs/workflows/aiw-operating-doctrine.md
@@ -301,9 +301,10 @@ job_spec (explore/shape)
 The AIW router chooses how an already-shaped issue becomes an agent execution episode and should own:
 
 1. **Provider selection**
-   - choose from Claude Code, Codex, Jules, Gemini, Ollama, NotebookLM, Augment/Antigravity, etc.;
+   - choose a backend from the `config/afk-backends.yaml` registry (Claude Code, local sandcastle, remote cloud worker, generic shell, etc.);
    - prefer local/free providers first when adequate;
-   - escalate only when evidence justifies it.
+   - escalate only when evidence justifies it;
+   - new backends can be added without changing the governor because the AFK harness uses the `AFKBackend` adapter contract.
 2. **Budget control**
    - read budget caps from the job spec;
    - estimate context/token cost before invocation;
@@ -388,6 +389,23 @@ adapter:
     - cancel
     - estimate_cost
 ```
+
+### AFK backend registry
+
+The AFK implement governor is tool-agnostic: it loads backends from `config/afk-backends.yaml` and drives them through the `AFKBackend` contract in `scripts/afk_backends/`. A new backend is added by creating an adapter module and a registry entry; the governor does not change.
+
+Registry entries declare the adapter class, the AIW budget provider used for cost gating, an `enabled` flag, and an optional `config` block. The provider must match the actual API or compute that will be billed (for example, the local Podman sandcastle forwards `ANTHROPIC_API_KEY` and is therefore attributed to `claude-code-cli`, not a free local provider).
+
+Current shipped backends:
+
+| Name | Adapter | Provider | Execution environment |
+|------|---------|----------|----------------------|
+| `claude-code` | `afk_backends.claude_code.ClaudeCodeBackend` | `claude-code-cli` | Local Claude Code desktop subscription |
+| `local` | `afk_backends.sandcastle.SandcastleBackend` | `claude-code-cli` | Podman sandcastle in sibling `../afk-harness` |
+| `remote` | `afk_backends.remote.RemoteBackend` | `claude-code-cli` | HTTP cloud worker (Vercel, Codespaces, etc.) |
+| `shell` | `afk_backends.shell.ShellBackend` | `generic-shell` | Configurable local command; proves non-Claude abstraction |
+
+The harness fails closed on unknown backends, disabled backends, and backends whose configuration is missing or invalid. This keeps the AFK surface bounded, observable, and reviewable regardless of which AI tool is behind the adapter.
 
 ## Follow-up Implementation
 

--- a/policies/autonomous-loop-policy.yaml
+++ b/policies/autonomous-loop-policy.yaml
@@ -239,6 +239,60 @@ domain_work_authorization:
       Governance work bypass does not extend to domain work disguised as governance.
       Drift checks (see review_criteria.drift_check) apply.
 
+### AFK Backend Governance
+
+afk_backend_governance:
+  description: >
+    Governance rules for the AFK implement lane's backend adapter system. The
+    governor must be tool-agnostic: it selects a backend from the registry and
+    drives it through the AFKBackend contract, regardless of whether the underlying
+    tool is a local desktop agent, a container, or a remote cloud worker.
+  references:
+    - config/afk-backends.yaml
+    - scripts/afk_backends/__init__.py
+    - scripts/afk_backends/registry.py
+    - scripts/aiw_budget_gate.py
+    - docs/workflows/aiw-operating-doctrine.md
+
+  registry_rules:
+    - >
+      Every backend entry must declare an adapter Python class, a budget provider,
+      an enabled flag, and an optional config block. Unknown or disabled backends
+      must fail closed.
+    - >
+      New backends may be added by creating an adapter module and a registry entry.
+      The governor must not require code changes to recognize a new backend.
+    - >
+      Backend configuration that is required for operation (e.g., a remote endpoint or
+      shell command) must be explicitly set before the backend is enabled. Disabled
+      backends must return a clean blocked result rather than crash.
+
+  provider_attribution_rules:
+    - >
+      The budget provider assigned to a backend must match the actual API or compute
+      that will be billed. A backend that forwards a metered API key is attributed
+      to that metered provider, not to a free local provider.
+    - >
+      Changing a backend's provider attribution requires updating the registry entry
+      and the AIW budget policy if the provider is not already allowlisted.
+    - >
+      Provider attribution changes are treated as high-risk because they affect cost
+      gating and may bypass budget controls.
+
+  adapter_contract_rules:
+    - >
+      Every adapter must implement prepare(), needs_local_repo(), invoke(), and
+      estimate_cost(). cancel() is optional and defaults to a no-op.
+    - >
+      prepare() verifies prerequisites before the cycle starts. A failed prepare is a
+      hard abort for the cycle.
+    - >
+      invoke() must return a result dict with branch, commits, and blocked keys. It
+      must not mutate the issue dict.
+    - >
+      Adapters must return structured blocked reasons for configuration errors,
+      network failures, invalid worker output, and missing response fields.
+
 ### Self-Merge Authority
 
 self_merge_authority:


### PR DESCRIPTION
Closes #884.

Updates governance documentation and policy to describe the tool-agnostic AFK backend adapter system.

## Changes

- `docs/workflows/aiw-operating-doctrine.md`
  - Updated the router **Provider selection** responsibility to reference the `config/afk-backends.yaml` registry and the `AFKBackend` contract, noting that new backends can be added without changing the governor.
  - Added an **AFK backend registry** subsection with a table of the current shipped backends (`claude-code`, `local`, `remote`, `shell`), their adapters, budget providers, and execution environments.
  - Documented that the harness fails closed on unknown, disabled, or misconfigured backends.

- `policies/autonomous-loop-policy.yaml`
  - Added a new `afk_backend_governance` section with:
    - Registry rules (adapter class, provider, enabled flag, config block, fail-closed behavior).
    - Provider attribution rules (provider must match actual billed API, e.g., local sandcastle -> `claude-code-cli`; attribution changes are high-risk).
    - Adapter contract rules (`prepare`, `needs_local_repo`, `invoke`, `estimate_cost`, `cancel`; hard abort on failed prepare; immutable issue dict; structured blocked reasons).

## Verification

```bash
python -m unittest discover -s scripts -p "test_*.py"  # 390 pass
python scripts/validate_governance.py                  # 18 evolution logs valid, 0 invalid
python scripts/build_manifest.py                         # green
```
