### PR TITLE
state(afk): record tool-agnostic AFK docs/policy update (#884)

### DIFF
--- a/state/beliefs/2026-07-29-afk-backend-adapter.belief.json
+++ b/state/beliefs/2026-07-29-afk-backend-adapter.belief.json
@@ -39,9 +39,15 @@
         "claim": "Implemented ShellBackend as a second, non-Claude desktop adapter in scripts/afk_backends/shell.py. It runs a configurable command, passes the issue as JSON on stdin and AFK_* environment variables, and parses the JSON result. Added a registry entry with provider generic-shell and tests in scripts/test_shell_backend.py. Also corrected the README schema count back to 48 + 9 contracts after discovering the prior drift was caused by an untracked schema file. Closes #882.",
         "timestamp": "2026-07-29T12:50:00Z",
         "reliability": 0.98
+      },
+      {
+        "source": "feat/tool-agnostic-afk-docs-884 (#906)",
+        "claim": "Updated governance docs and policy for tool-agnostic AFK. Added an AFK backend registry section to docs/workflows/aiw-operating-doctrine.md describing the AFKBackend contract, registry, current backends, and provider attribution. Added an afk_backend_governance section to policies/autonomous-loop-policy.yaml with registry rules, provider attribution rules, and adapter contract rules. Closes #884.",
+        "timestamp": "2026-07-29T12:55:00Z",
+        "reliability": 0.98
       }
     ]
   },
-  "last_updated": "2026-07-29T12:50:00Z",
+  "last_updated": "2026-07-29T12:55:00Z",
   "evaluated_by": "demerzel"
 }

--- a/state/evolution/2026-07-29-afk-backend-adapter.evolution.json
+++ b/state/evolution/2026-07-29-afk-backend-adapter.evolution.json
@@ -41,6 +41,11 @@
       "type": "amended",
       "context": "Implemented a second desktop adapter (ShellBackend) to prove the AFKBackend abstraction works with a non-Claude tool. Created scripts/afk_backends/shell.py with a configurable command, timeout, optional local-repo flag, and extra env vars. The command receives the issue as JSON on stdin and AFK_ISSUE_NUMBER, AFK_ISSUE_TITLE, AFK_ISSUE_BODY, AFK_ISSUE_LABELS, and AFK_REPO_PATH via the environment. It parses the command's stdout JSON and validates branch/commits/blocked. Added a shell entry to config/afk-backends.yaml with provider generic-shell, disabled by default. Added scripts/test_shell_backend.py with subprocess.run mocks covering success, env vars, missing command, missing executable, nonzero exit, timeout, invalid JSON, and missing response fields. Updated scripts/test_afk_registry.py to assert the shell backend is present. Reverted the README schema count from 49 to 48 after the prior drift was traced to an untracked schema file in the working tree. 390 unit tests pass. Issue #882, PR #902.",
       "timestamp": "2026-07-29T12:50:00Z"
+    },
+    {
+      "type": "amended",
+      "context": "Updated governance docs and policy for tool-agnostic AFK. In docs/workflows/aiw-operating-doctrine.md, updated the router provider-selection bullet to reference the config/afk-backends.yaml registry and the AFKBackend adapter contract, and added a new 'AFK backend registry' subsection with a table of the current backends (claude-code, local, remote, shell), their providers, and execution environments. In policies/autonomous-loop-policy.yaml, added an afk_backend_governance section with registry rules, provider attribution rules (including the local sandcastle -> claude-code-cli requirement), and adapter contract rules. All governance validation passes. Issue #884, PR #906.",
+      "timestamp": "2026-07-29T12:55:00Z"
     }
   ],
   "assessment": {


### PR DESCRIPTION
Mandatory state maintenance: records the tool-agnostic AFK docs/policy update in the AFK backend-adapter belief and evolution logs.\n\n- state/beliefs/2026-07-29-afk-backend-adapter.belief.json — adds evidence for PR #906.\n- state/evolution/2026-07-29-afk-backend-adapter.evolution.json — adds an mended event for #884.\n\nVerification: python scripts/validate_governance.py → 18 evolution logs valid, 0 invalid.