### PR TITLE
fix(governance): declare all registry providers, unwedge metered release, correct three docs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,21 +48,25 @@ humanity) overrides everything. Constitutions are **append-only**.
 - **LOLLI / Resilience score (R)** — `R = injections_caught / injections_total`; the
   chaos-engineering metric for how well governance detects injected poison (dead
   bindings, orphaned branches, BS descriptions, unconsumed artifacts).
-- **BAML (Boundary AI Markup Language)** — the DSL (`baml_src/`) that declares prompts as
-  strongly-typed functions, enforcing LLM output schemas *in flight* rather than validating
-  them at rest (ADR-0005). One `.baml` source generates three clients: Python/Pydantic at
-  the repo root (`baml_client/`, so `from baml_client import b` resolves) plus TypeScript
-  and Rust under `clients/`, one per consumer language. Each generator needs a distinct
-  `output_dir` — BAML writes `<output_dir>/baml_client`, so two generators sharing a
-  directory silently clobber each other. The Rust output is a module tree, not a crate.
-- **validate_dsp_loop** — the self-correcting parameter gate (`scripts/validate_dsp_loop.py`):
-  binary-searches a DSP distortion parameter until a hexavalent swarm consensus clears the
-  bounds in [`logic/dsp-safety-bounds.yaml`](logic/dsp-safety-bounds.yaml). Two interchangeable
-  graders — deterministic threshold comparisons (default) and the typed BAML
-  `EvaluateSignalSwarm` function (`--use-baml`) — read the *same* bounds file, so the code
-  gate and the model gate cannot drift apart. Emits an audited record per run to
-  `state/dsp-validation/`; a validated parameter is a **proposal**, and enacting it as a
-  control input (`--use-cached-bounds`) is an explicit authorization, per Article 9.
+- **BAML (Boundary AI Markup Language)** — **PROPOSED, NOT IN TREE.** A DSL that would
+  declare prompts as strongly-typed functions, enforcing LLM output schemas *in flight*
+  rather than validating them at rest. The committed decision is to **defer**: see
+  [`docs/research/2026-07-28-baml-adoption-assessment.md`](docs/research/2026-07-28-baml-adoption-assessment.md)
+  ("do not put BAML on a production path or make it a cross-repo contract yet") and #890.
+  No `baml_src/`, `baml_client/`, or `clients/` exists in this repository, and there is no
+  committed ADR-0005. Do not write code against those paths. If adoption proceeds, note
+  that each generator needs a distinct `output_dir` — BAML writes `<output_dir>/baml_client`,
+  so two generators sharing a directory silently clobber each other.
+- **validate_dsp_loop** — **PROPOSED, NOT IN TREE.** A self-correcting parameter gate that
+  would binary-search a DSP distortion parameter until a hexavalent swarm consensus clears
+  declared safety bounds, keeping a deterministic grader and a model grader on the *same*
+  bounds file so the code gate and the model gate cannot drift apart. Neither
+  `scripts/validate_dsp_loop.py`, `logic/dsp-safety-bounds.yaml`, nor `state/dsp-validation/`
+  is in the repository. A local prototype exists outside version control and **fails open**
+  — with a warm cache it exits 0 printing "CONSTITUTIONAL RULES SATISFIED" on a compilation
+  error — so it must not be treated as a gate until that is fixed and it is committed.
+  The design intent stands: a validated parameter is a **proposal**, and enacting it as a
+  control input is an explicit authorization, per Article 9.
 
 ## Architecture seams (designed 2026-06-20 via `/improve-codebase-architecture`; built 2026-06-21, PR #357)
 

--- a/config/afk-backends.yaml
+++ b/config/afk-backends.yaml
@@ -27,8 +27,14 @@ backends:
 
   remote:
     adapter: "afk_backends.remote.RemoteBackend"
+    # PROVISIONAL attribution, and knowingly imprecise: what this backend bills
+    # depends entirely on the endpoint an operator configures, so no single
+    # provider is correct for it in the abstract. A remote HTTP worker is NOT a
+    # local Claude Code subscription seat. Re-attribute this to the provider the
+    # configured endpoint actually bills BEFORE setting enabled: true, or the
+    # gate will wave through metered spend exactly as in #863.
     provider: "claude-code-cli"
-    description: "HTTP cloud worker (Vercel, Codespaces, or any AFK-compatible endpoint). Disabled by default until an endpoint is configured."
+    description: "HTTP cloud worker (Vercel, Codespaces, or any AFK-compatible endpoint). Disabled by default until an endpoint is configured. Provider attribution is provisional and must be set to whatever the endpoint bills before enabling."
     enabled: false
     config:
       # endpoint: "https://example.com/afk-worker"

--- a/schemas/aiw-budget-policy.schema.json
+++ b/schemas/aiw-budget-policy.schema.json
@@ -4,7 +4,7 @@
   "definitions": {
     "providerId": {
       "type": "string",
-      "enum": ["claude-code-cli", "codex-cli", "antigravity", "augment-code", "anthropic-api", "gemini-cli", "jules", "notebooklm"],
+      "enum": ["claude-code-cli", "codex-cli", "antigravity", "augment-code", "generic-shell", "anthropic-api", "gemini-cli", "jules", "junie-cli", "notebooklm"],
       "description": "Closed allowlist. Adding a provider must be a deliberate schema change."
     }
   },
@@ -130,6 +130,19 @@
             }
           },
           {
+            "description": "junie-cli bills real money: JetBrains Junie consumes a JetBrains AI quota (its registry entry references JUNIE_API_KEY), so it is metered cloud spend, not a local seat. Pinned by id for the same reason as the others -- #863 was mis-fixed twice by naming a free local-seat provider for a metered backend, and both wrong values were well-formed and allowlisted.",
+            "if": {"properties": {"id": {"const": "junie-cli"}}, "required": ["id"]},
+            "then": {
+              "properties": {
+                "tier": {"const": "metered-cloud"},
+                "cost_model": {"const": "provider-billing"},
+                "requires_manual_approval": {"const": true},
+                "trusted_receipt_issuer": {"const": "api.jetbrains.com"}
+              },
+              "required": ["trusted_receipt_issuer"]
+            }
+          },
+          {
             "description": "anthropic-api bills real money: it is the Anthropic Messages API consuming ANTHROPIC_API_KEY, NOT a Claude subscription seat. Pinned by id because #863 was exactly this confusion, twice. First the AFK `local` backend was attributed to codex-cli; then #877 'fixed' it by swapping to claude-code-cli -- a DIFFERENT local-seat, no-approval provider -- so the observable behaviour never changed. Both wrong values were well-formed and allowlisted, which is why nothing caught either. Pinning by id means a later diff cannot re-open the hole by editing tier alone. Do NOT reuse this id for claude-code-cli, which strips the key and rides the subscription.",
             "if": {"properties": {"id": {"const": "anthropic-api"}}, "required": ["id"]},
             "then": {
@@ -146,7 +159,7 @@
             "description": "Local-seat providers have no metered spend; grouping their ids keeps one shared constraint from drifting as the allowlist evolves.",
             "if": {
               "properties": {
-                "id": {"enum": ["claude-code-cli", "codex-cli", "antigravity", "augment-code"]}
+                "id": {"enum": ["claude-code-cli", "codex-cli", "antigravity", "augment-code", "generic-shell"]}
               },
               "required": ["id"]
             },

--- a/scripts/aiw_budget_gate.py
+++ b/scripts/aiw_budget_gate.py
@@ -375,6 +375,64 @@ def release(cycle_path: Path, job_id: str, actual_cost_usd: float,
         lock_path.unlink(missing_ok=True)
 
 
+def abandon(cycle_path: Path, job_id: str, reason: str) -> dict[str, Any]:
+    """Give up reconciling a reservation WITHOUT claiming its spend was verified.
+
+    A metered job cannot be released without a trusted provider receipt (see
+    ``release``), and the AFK governor has none to offer. Before this existed, a
+    metered episode left its reservation open forever: ``active_packets`` never
+    fell, and after ``cycle.max_parallel_packets`` such episodes the gate blocked
+    EVERY provider — including the free subscription lane that had nothing to do
+    with it (#896).
+
+    Fabricating a receipt would restore liveness by destroying the control the
+    receipt exists to provide: ``trusted_receipt_issuer`` is the only thing
+    separating "the provider states this cost $X" from "we state it did". A
+    self-issued receipt would satisfy ``_validate_receipt`` — it checks structure,
+    not authenticity — and reconcile metered spend at whatever the caller passed,
+    forever, self-certified.
+
+    So this frees the slot and charges the RESERVED ESTIMATE to actual spend
+    instead. Pessimistic on purpose: we cannot prove the money was not spent, so
+    the cycle cost cap keeps counting it rather than crediting the cycle back to
+    zero. Unverified is not the same as free.
+
+    The abandonment is recorded permanently under ``unreconciled`` so an operator
+    can see exactly which spend was never receipt-verified.
+    """
+    if not job_id:
+        raise ValueError("job_id is required to abandon")
+    lock_path = _lock(cycle_path)
+    try:
+        cycle = _read_cycle(cycle_path)
+        reservation = cycle["reservations"].get(job_id)
+        if reservation is None:
+            raise ValueError(f"no reservation for job: {job_id}")
+        estimate = _required_number(reservation, "estimated_cost_usd")
+
+        cycle["reservations"].pop(job_id)
+        cycle["reserved_cost_usd"] -= estimate
+        cycle["active_packets"] -= 1
+        cycle["actual_cost_usd"] = cycle.get("actual_cost_usd", 0) + estimate
+        entry = {
+            "job_id": job_id,
+            "provider": reservation.get("provider"),
+            "request_sha256": reservation.get("request_sha256"),
+            "charged_estimate_usd": estimate,
+            "receipt_verified": False,
+            "reason": str(reason)[:200],
+        }
+        cycle.setdefault("unreconciled", []).append(entry)
+        cycle_path.parent.mkdir(parents=True, exist_ok=True)
+        cycle_path.write_text(json.dumps(cycle, indent=2, sort_keys=True,
+                                        allow_nan=False) + "\n", encoding="utf-8")
+        return {"decision": "abandoned", "job_id": job_id,
+                "charged_estimate_usd": estimate,
+                "receipt_verified": False, "reason": entry["reason"]}
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+
 def _bind_canonical(name: str, supplied: Path, canonical: Path) -> Path:
     """Pin a runtime path to this repository, never the caller's directory.
 

--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -152,19 +152,41 @@ def _budget_release(issue: dict, actual_cost_usd: float = 0.0) -> None:
     try:
         budget.release(budget.CYCLE_LEDGER_PATH, job_id, actual_cost_usd,
                        policy=budget.load_policy(budget.POLICY_PATH))
+        return
     except Exception as exc:
-        # The breadth here is deliberate — release failure must never break the
-        # loop. But a swallowed release leaves the reservation open, so the
-        # ledger over-reports committed spend and max_parallel_packets fills with
-        # reservations that never clear. Write the swallow down so that state is
-        # detectable afterwards instead of silent (#794).
-        try:
-            noted = budget.note_release_failure(budget.CYCLE_LEDGER_PATH, job_id, str(exc))
-        except Exception:  # noqa: BLE001 — recording a failure must never become one
-            noted = False
-        print(f"budget release skipped for #{issue.get('number')}: {exc}"
-              f"{'' if noted else ' (and the ledger note could not be written)'}",
-              file=sys.stderr)
+        release_error = exc
+
+    # A metered reservation (e.g. `local` -> anthropic-api) cannot be released
+    # here: release() demands a trusted provider receipt and the governor has
+    # none to offer. Leaving it open was the #896 wedge — active_packets never
+    # fell, and four such episodes blocked every lane including the healthy
+    # subscription one. Abandon it instead: the slot is freed and the reserved
+    # ESTIMATE is charged to actual spend, but nothing is claimed as verified.
+    # Deliberately NOT synthesising a receipt — _validate_receipt checks
+    # structure, not authenticity, so a self-issued one would pass and turn the
+    # metered-spend control into a no-op.
+    try:
+        abandoned = budget.abandon(budget.CYCLE_LEDGER_PATH, job_id, str(release_error))
+        print(f"budget reservation abandoned for #{issue.get('number')}: charged "
+              f"${abandoned['charged_estimate_usd']:.2f} as UNVERIFIED spend "
+              f"({release_error})", file=sys.stderr)
+        return
+    except Exception:  # noqa: BLE001 — fall through to the audit note below
+        pass
+
+    # Neither release nor abandon worked (e.g. the reservation was never written,
+    # or the ledger is unreadable). Release failure must never break the loop, but
+    # a swallowed one leaves the reservation open, so the ledger over-reports
+    # committed spend and max_parallel_packets fills with reservations that never
+    # clear. Write the swallow down so that state is detectable (#794).
+    try:
+        noted = budget.note_release_failure(
+            budget.CYCLE_LEDGER_PATH, job_id, str(release_error))
+    except Exception:  # noqa: BLE001 — recording a failure must never become one
+        noted = False
+    print(f"budget release skipped for #{issue.get('number')}: {release_error}"
+          f"{'' if noted else ' (and the ledger note could not be written)'}",
+          file=sys.stderr)
 
 
 def halt_active() -> tuple[bool, str]:

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -122,6 +122,25 @@ def _council(verdict="APPROVE", conf=0.75, n_reviews=2, aligned=True):
     return {"verdict": verdict, "post_council_confidence": conf, "reviews": reviews}
 
 
+def _approval(request, policy):
+    """A structurally valid human-approval artifact for a metered reserve.
+
+    Built in the test rather than by product code on purpose: the governor must
+    never mint its own approval, exactly as it must never mint its own receipt.
+    """
+    return {
+        "schema_version": "1.0",
+        "kind": "human-approval",
+        "decision": "approve",
+        "job_id": request["job_id"],
+        "provider": request["provider"],
+        "request_sha256": g.budget._request_sha256(request),
+        "approval_id": "test-approval-001",
+        "approver": "test-operator",
+        "approved_at": "2026-07-29T00:00:00Z",
+    }
+
+
 class TestAuthorizationTrace(unittest.TestCase):
     def test_closes(self):
         self.assertEqual(g.parse_authorization_trace("Implements #381 via AFK.\nCloses #381"),
@@ -466,13 +485,13 @@ class TestBudgetGate(unittest.TestCase):
         from afk_backends.registry import load_registry
         declared = {p["id"] for p in
                     g.budget.load_policy(g.budget.POLICY_PATH)["providers"]}
+        # Every backend, enabled or not. Scoping this to enabled-only left
+        # `generic-shell` (#882) and `junie-cli` (#911) naming providers no policy
+        # declared: safe, because _provider() raises and _budget_reserve fails
+        # closed, but the misconfiguration only surfaced when someone flipped
+        # `enabled` and got a mystery block. Both are now declared, so the check
+        # can be unconditional -- which is what makes it catch the NEXT one.
         for backend, cfg in load_registry().items():
-            if not cfg.get("enabled"):
-                # A disabled backend cannot spend. `shell` (#882) currently names
-                # `generic-shell`, which no policy declares -- _provider() raises
-                # and _budget_reserve fails closed, so it is safe but unrunnable.
-                # Filed rather than fixed here: choosing its tier is #882's call.
-                continue
             self.assertIn(cfg["provider"], declared,
                           f"backend {backend!r} names undeclared provider "
                           f"{cfg['provider']!r}")
@@ -493,6 +512,54 @@ class TestBudgetGate(unittest.TestCase):
                 g._process_issue(issue, seq=1, today="2026-07-19", backend=backend,
                                  adapter=mock.Mock())
             res.assert_called_once_with(issue, backend)
+
+    def test_metered_release_is_abandoned_not_forged(self):
+        """#896: a metered reservation cannot be released (no receipt), so it used
+        to stay open forever and wedge the cycle. It is now ABANDONED: the slot is
+        freed and the reserved estimate is charged as unverified spend.
+
+        The point of the test is what must NOT happen: no receipt is synthesised.
+        `_validate_receipt` checks structure, not authenticity, so a self-issued
+        receipt would pass and reconcile metered spend at whatever we claimed --
+        turning the control into a no-op. Assert the ledger records the charge as
+        unverified rather than as a clean release."""
+        policy = g.budget.load_policy(g.budget.POLICY_PATH)
+        with tempfile.TemporaryDirectory() as d:
+            led = Path(d) / "cycle.json"
+            req = g._budget_request({"number": 5, "body": ""}, "local")
+            req["estimated_cost_usd"] = 1.25
+            g.budget.reserve(policy, req, led, approval=_approval(req, policy))
+
+            with mock.patch.object(g.budget, "CYCLE_LEDGER_PATH", led):
+                g._budget_release({"number": 5}, actual_cost_usd=0.0)
+
+            cycle = json.loads(led.read_text(encoding="utf-8"))
+        self.assertEqual({}, cycle["reservations"])          # slot freed
+        self.assertEqual(0, cycle["active_packets"])
+        self.assertAlmostEqual(1.25, cycle["actual_cost_usd"])  # charged, not $0
+        entry = cycle["unreconciled"][0]
+        self.assertFalse(entry["receipt_verified"])
+        self.assertEqual("anthropic-api", entry["provider"])
+
+    def test_abandon_does_not_wedge_the_gate_after_repeated_metered_runs(self):
+        """The actual #896 acceptance test. Four unreconciled metered episodes
+        exhausted cycle.max_parallel_packets and blocked EVERY provider,
+        including the free subscription lane. After abandon, the default lane
+        still reserves."""
+        policy = g.budget.load_policy(g.budget.POLICY_PATH)
+        cap = int(policy["cycle"]["max_parallel_packets"])
+        with tempfile.TemporaryDirectory() as d:
+            led = Path(d) / "cycle.json"
+            for n in range(cap + 1):
+                req = g._budget_request({"number": 100 + n, "body": ""}, "local")
+                g.budget.reserve(policy, req, led, approval=_approval(req, policy))
+                with mock.patch.object(g.budget, "CYCLE_LEDGER_PATH", led):
+                    g._budget_release({"number": 100 + n})
+            after = g.budget.reserve(
+                policy, g._budget_request({"number": 999, "body": ""}, "claude-code"), led)
+        self.assertEqual("allow", after["decision"],
+                         f"subscription lane blocked after {cap + 1} metered runs: "
+                         f"{after['reasons']}")
 
     def test_unmapped_backend_fails_closed(self):
         allowed, result = g._budget_reserve({"number": 5, "body": ""}, "not-a-backend")

--- a/state/driver/aiw-budget-policy.json
+++ b/state/driver/aiw-budget-policy.json
@@ -38,6 +38,12 @@
       "requires_manual_approval": false
     },
     {
+      "id": "generic-shell",
+      "tier": "local-seat",
+      "cost_model": "subscription-or-local",
+      "requires_manual_approval": false
+    },
+    {
       "id": "anthropic-api",
       "tier": "metered-cloud",
       "cost_model": "provider-billing",
@@ -59,6 +65,13 @@
       "trusted_receipt_issuer": "jules.googleapis.com"
     },
     {
+      "id": "junie-cli",
+      "tier": "metered-cloud",
+      "cost_model": "provider-billing",
+      "requires_manual_approval": true,
+      "trusted_receipt_issuer": "api.jetbrains.com"
+    },
+    {
       "id": "notebooklm",
       "tier": "metered-cloud",
       "cost_model": "provider-billing",
@@ -71,9 +84,11 @@
     "codex-cli",
     "antigravity",
     "augment-code",
+    "generic-shell",
     "anthropic-api",
     "gemini-cli",
     "jules",
+    "junie-cli",
     "notebooklm"
   ]
 }

--- a/state/learning/README.md
+++ b/state/learning/README.md
@@ -1,33 +1,55 @@
-# Learning Journal
+# state/learning/
 
-Epistemic learning records produced by the `demerzel:meta-brainstorm` skill.
+**Status: no files have ever been produced here.** This directory is declared by two
+different specifications, neither of which has a working producer. Both are recorded
+below so the next reader does not mistake either for something that runs.
 
-Each entry captures a multi-LLM brainstorm session triggered when Demerzel's internal
-epistemic processes stall (low-confidence beliefs, PDCA stalls, conscience discomfort,
-or explicit user requests).
+## 1. Recursive-learning eval artifacts (declared by policy)
 
-## File Naming
+`policies/recursive-learning-eval-policy.yaml` §state declares this directory as the
+home of:
 
-```
-YYYY-MM-DD-<short-slug>.learning.json
-```
+| file | purpose |
+|---|---|
+| `meta-metrics.json` | the five meta-metrics (learning acceleration, teaching improvement, knowledge retention, transfer efficiency, meta false-positive rate) |
+| `eval-input-{yyyy-mm}.json` | monthly self-evaluation input |
+| `eval-grades-{yyyy-mm}.json` | graded results |
+| `eval-diagnosis-{yyyy-mm}.json` | diagnosed anti-patterns |
+| `eval-proposals-{yyyy-mm}.json` | improvement proposals (each requires `article_4_check`) |
+| `eval-report-{yyyy-mm}.json` | monthly report |
+| `meta-eval-{yyyy-q}.json` | quarterly depth-2 meta-evaluation |
 
-## Schema
+**None of these exist and nothing computes them.** No script references
+`meta-metrics`, and no workflow schedules the monthly `self_evaluation_cycle`. The
+`article_4_check` boundary IS now enforceable — `schemas/recursive-learning-eval.schema.json`
+constrains proposals and `scripts/test_recursive_learning_eval_schema.py` tests it — but
+enforcement only bites once something emits a proposal. The policy says this plainly:
+*"Until an executor exists the policy constrains nothing at runtime."*
 
-See `.agent/skills/demerzel-meta-brainstorm/SKILL.md` (Step 4) for the full JSON schema.
+Note that `tests/behavioral/recursive-learning-eval-cases.md` asserts results are
+*"stored in state/learning/meta-metrics.json"*. Behavioral tests are prose counted by
+`governance-manifest.json`, not executed, so that case passes by existing. Do not read
+its presence as evidence the computation works.
 
-## Grounding
+## 2. Learning journal (declared by a skill that is not in tree)
 
-All entries reference articles from the Epistemic Constitution
-(`governance/demerzel/constitutions/epistemic.constitution.md`):
+The prior contents of this file described epistemic learning records named
+`YYYY-MM-DD-<short-slug>.learning.json`, produced by a `demerzel:meta-brainstorm` skill
+and grounded in the Epistemic Constitution's E-0..E-9 articles.
 
-- **E-0** Epistemic Braiding (strand identification)
-- **E-1** Contradictory Ground (halting condition)
-- **E-2** Teaching-as-Validation (pre-commit explanation gate)
-- **E-3** Epistemic Viscosity (belief resistance detection)
-- **E-4** Incompetence Portfolio (known limitations)
-- **E-5** Deliberate Amnesia (re-derivation tests)
-- **E-6** Governance Uncertainty Principle (introspection perturbation)
-- **E-7** Epistemic Tensor (State_MetaState classification)
-- **E-8** Epistemic Epigenetics (strategy methylation)
-- **E-9** Federated Epistemology (peer review via multi-LLM)
+Two corrections to that description:
+
+- The skill was cited as `.agent/skills/demerzel-meta-brainstorm/SKILL.md`. **No such
+  file exists anywhere in this repository**, so the schema it pointed to is unavailable.
+- The constitution was cited as `governance/demerzel/constitutions/epistemic.constitution.md`.
+  That is a path from a different repository layout. The real location is
+  [`constitutions/epistemic.constitution.md`](../../constitutions/epistemic.constitution.md),
+  which does define E-0 through E-9.
+
+## If you are about to build something here
+
+Pick **one** of the two specifications and delete the other from its source, rather than
+leaving a directory with two owners and no output. The smallest honest first step is a
+single producer for `knowledge_retention` — it is the only metric whose inputs already
+exist, since beliefs in `state/beliefs/` carry hexavalent truth values and timestamps.
+Per the LOLLI rule, do not add more declared artifacts here until one is actually emitted.


### PR DESCRIPTION
Sweep of the governance issues found today. Four independent fixes; each verified by mutation rather than by reading the diff.

## 1. #896 — approved `local` runs leaked their reservation

`release()` demands a trusted provider receipt for a metered job (`aiw_budget_gate.py:347-350`) and the governor has none to offer, so a metered episode left its reservation open forever. `active_packets` never fell, and after `cycle.max_parallel_packets` such episodes the gate blocked **every** provider — including the free subscription lane that had nothing to do with it.

Adds `aiw_budget_gate.abandon()`: frees the slot, charges the **reserved estimate** to actual spend, and records the job under `unreconciled` with `receipt_verified: false`.

**It deliberately does not synthesise a receipt.** `_validate_receipt` checks structure, not authenticity — every field it requires is derivable from the reservation the governor just created — so a self-issued receipt would pass and reconcile metered spend at whatever we claimed, forever, self-certified. That restores liveness by destroying the control the receipt exists to provide. Charging the estimate is pessimistic on purpose: **unverified is not the same as free.**

## 2. Undeclared providers

`generic-shell` (#882) and `junie-cli` (#911) named providers no policy declared. Both failed closed, so they were safe but unrunnable — and the misconfiguration would only have surfaced as a mystery block the first time someone set `enabled: true`.

| provider | tier | approval | rationale |
|---|---|---|---|
| `generic-shell` | `local-seat` | no | runs a local command, no metered API |
| `junie-cli` | `metered-cloud` | **yes** | JetBrains AI bills a quota; its own registry config references `JUNIE_API_KEY` |

`junie-cli` is pinned by id in the schema for the same reason `anthropic-api` is: the tier-keyed guards constrain shape *given* a tier, and tier is editable in the same diff that would downgrade it.

The registry↔policy test is now **unconditional**. Scoping it to `enabled` entries is exactly what let both of these through; checking every entry is what catches the next one.

## 3. `remote` — attribution marked provisional, not fixed

What `remote` bills depends entirely on the endpoint an operator configures, so `claude-code-cli` is a false statement — a remote HTTP worker is not a local subscription seat. But choosing its tier is #879's call, not this PR's. It is `enabled: false`, so the risk is latent; the config now says so explicitly and warns to re-attribute before enabling. Filed separately.

## 4. Three documents describing things that do not exist

**`CONTEXT.md`** — the file `CLAUDE.md` names as *the authority* — described **seven** paths, none of which are in the repository: `baml_src/`, `baml_client/`, `clients/`, `scripts/validate_dsp_loop.py`, `logic/dsp-safety-bounds.yaml`, `state/dsp-validation/`, and ADR-0005 — including a markdown link to the missing bounds file. Both glossary entries now say **PROPOSED, NOT IN TREE** and point at the committed decision to defer BAML (`docs/research/2026-07-28-baml-adoption-assessment.md`, #890). It also records that the local `validate_dsp_loop` prototype **fails open**: with a warm cache it exits **0** printing `CONSTITUTIONAL RULES SATISFIED` on a compilation error. I ran it.

**`state/learning/README.md`** cited a skill that exists nowhere (`.agent/skills/demerzel-meta-brainstorm/SKILL.md`) and the epistemic constitution at a path from a different repo's layout. Rewritten to reconcile the two competing specifications for that directory, state that **neither has ever produced a file**, and note that its behavioral test asserts a result *"stored in state/learning/meta-metrics.json"* — a file that has never existed. Behavioral tests are prose counted by `governance-manifest.json`, not executed, so it passes by existing.

## Verification

| mutation | result |
|---|---|
| disable `abandon` (restore the #896 leak) | **2 failures** |
| `abandon` charges `$0` instead of the estimate | **1 failure** |
| unmutated | 417 pass |

```
claude-code  claude-code-cli  local-seat     allow  []
local        anthropic-api    metered-cloud  block  ['provider_requires_manual_approval']
remote       claude-code-cli  local-seat     allow  []
shell        generic-shell    local-seat     allow  []
junie        junie-cli        metered-cloud  block  ['provider_requires_manual_approval']
```

`validate_governance` PASS · `belief_lint` 0 FAIL.

## Review

Touches `schemas/` — **blocked path**. `risk-report` will fail closed. Not applying `agent-blackbox-reviewed`; that is yours.

Note that the blocked-path gate currently has no teeth regardless — `master` has no required status checks, which is #902. I attempted a ruleset for that today and it is **left disabled**; see the issue for why.