### PR TITLE
fix(ci): stop the wiki sync dying on SIGPIPE (#917)

### DIFF
--- a/.github/workflows/demerzel-wiki-cross-repo.yml
+++ b/.github/workflows/demerzel-wiki-cross-repo.yml
@@ -92,8 +92,19 @@ jobs:
           if [ -f repo/CLAUDE.md ]; then
             echo "## Development Guide" >> wiki/Home.md
             echo "" >> wiki/Home.md
-            # Extract content before governance markers
-            sed -n '1,/<!-- BEGIN DEMERZEL GOVERNANCE -->/p' repo/CLAUDE.md | head -50 >> wiki/Home.md
+            # Extract content before the governance marker, capped at 50 lines.
+            #
+            # Deliberately NOT `sed ... | head -50`. This step runs under
+            # `bash -e -o pipefail`: once head has its 50 lines it closes the pipe, sed
+            # dies on EPIPE ("couldn't flush stdout: Broken pipe", exit 4), and pipefail
+            # fails the whole step. The wiki output was always correct — only the exit
+            # code was wrong. It passed while CLAUDE.md was under 50 lines before the
+            # marker and started failing when it grew past it, so nothing looked like a
+            # change had broken it. (#917)
+            #
+            # One sed process, reading a FILE, so there is no pipe to break: print lines
+            # 1..50, stopping early at the marker.
+            sed -n '1,50{p;/<!-- BEGIN DEMERZEL GOVERNANCE -->/q;};50q' repo/CLAUDE.md >> wiki/Home.md
             echo "" >> wiki/Home.md
             echo "[Full CLAUDE.md](${REPO_URL}/blob/master/CLAUDE.md)" >> wiki/Home.md
           fi
@@ -144,8 +155,8 @@ jobs:
             ! -path './obj*' \
             ! -path './target*' \
             ! -path './.vs*' \
-            | sort | head -40 \
-            | sed 's|^\./||')
+            | sort \
+            | sed -n '1,40{s|^\./||;p}')
           \`\`\`
 
           ---

--- a/.github/workflows/demerzel-wiki-cross-repo.yml
+++ b/.github/workflows/demerzel-wiki-cross-repo.yml
@@ -104,6 +104,14 @@ jobs:
             #
             # One sed process, reading a FILE, so there is no pipe to break: print lines
             # 1..50, stopping early at the marker.
+            #
+            # NOT byte-equivalent to the old form in one case, and the new behaviour is the
+            # correct one. In `sed -n 'addr1,/regex/p'` the end regex is never tested
+            # against addr1's own line, so if the marker were on LINE 1 the old range ran
+            # to EOF and `head -50` published 50 lines of governance content — precisely
+            # what this step exists to exclude. The new form quits on line 1. Every other
+            # marker position (1<n<=50, >50, absent, empty file) is byte-identical;
+            # verified across all of them.
             sed -n '1,50{p;/<!-- BEGIN DEMERZEL GOVERNANCE -->/q;};50q' repo/CLAUDE.md >> wiki/Home.md
             echo "" >> wiki/Home.md
             echo "[Full CLAUDE.md](${REPO_URL}/blob/master/CLAUDE.md)" >> wiki/Home.md


### PR DESCRIPTION
Closes #917.

`Demerzel Cross-Repo Wiki Sync` has failed on **every run since 2026-07-29**. Two pipelines, one bug.

## The bug

A producer piped into `head`, under `bash -e -o pipefail`. `head` exits the moment it has its quota and closes the pipe; the producer's next write gets EPIPE and exits non-zero; `pipefail` promotes that to a step failure.

```
sed: couldn't flush stdout: Broken pipe
##[error]Process completed with exit code 4
```

**The wiki content was always correct.** Only the exit code was wrong, which is why nothing looked broken.

## Root cause is sharper than "the file got long"

The governance marker is **absent from all three sibling `CLAUDE.md` files** — checked directly:

| repo | size | marker |
|---|---|---|
| ix | 12,054 B | **absent** |
| tars | 6,700 B | **absent** |
| ga | 15,965 B | **absent** |

So `sed -n '1,/marker/p'` never stops early — it streams the *entire* file into a pipe that closes after 50 lines. At 6–16KB that's a race against how fast `head` exits; past the 64KB pipe buffer it's certain. **The fix removes the race rather than making it less likely.**

## Reproduced, not assumed

```
OLD  sed -n '1,/marker/p' big.md | head -50   ->  exit 141
NEW  sed -n '1,50{p;/marker/q;};50q' big.md   ->  exit 0
output: byte-identical, 50 lines
```

My first repro attempt with a 122-line file **passed on both forms** — small enough that sed's write completes into the pipe buffer before head exits. That near-miss is what led to the size/marker analysis above, so it is worth recording: a naive repro of this bug looks like "not a bug".

## The fixes

**Line 96** — one `sed` process reading a **file**, so there is no pipe to break. `q` is safe here for exactly that reason.

**Line 147** — `| sort | head -40 | sed` becomes `| sort | sed -n '1,40{s|^\./||;p}'`.

Worth being explicit, because it is the intuitive wrong answer: **moving `head` to the end would not have fixed it.** Whoever is upstream still gets EPIPE when `head` exits, regardless of position. Draining stdin is the fix, which is why this `sed` deliberately has **no** `q`.

## Separately worth knowing

Because the marker is absent everywhere, the *"extract content before governance markers"* step has **never** truncated at a marker — it takes the first 50 lines regardless. Not changed here; that is a content question for whoever owns the marker convention, and fixing it silently would change what the wiki publishes.

## Blocked path

`.github/workflows/**` is a blocked path under `docs/review-independence.md`, so `risk-report` will flag this and it needs your merge — I will not self-apply the attestation label.