### PR TITLE
fix(afk): stop attributing the remote backend to a free local seat (#915)

### DIFF
--- a/config/afk-backends.yaml
+++ b/config/afk-backends.yaml
@@ -27,16 +27,22 @@ backends:
 
   remote:
     adapter: "afk_backends.remote.RemoteBackend"
-    # PROVISIONAL attribution, and knowingly imprecise: what this backend bills
-    # depends entirely on the endpoint an operator configures, so no single
-    # provider is correct for it in the abstract. A remote HTTP worker is NOT a
-    # local Claude Code subscription seat. Re-attribute this to the provider the
-    # configured endpoint actually bills BEFORE setting enabled: true, or the
-    # gate will wave through metered spend exactly as in #863.
-    provider: "claude-code-cli"
-    description: "HTTP cloud worker (Vercel, Codespaces, or any AFK-compatible endpoint). Disabled by default until an endpoint is configured. Provider attribution is provisional and must be set to whatever the endpoint bills before enabling."
+    # NO static provider here, deliberately. What this backend bills depends
+    # entirely on the endpoint an operator configures, so no single provider is
+    # correct for it in the abstract, and the previous placeholder
+    # (claude-code-cli, a free local-seat subscription) let a metered HTTP worker
+    # clear the gate as if it cost nothing -- #915, the same shape as #863. The
+    # attribution is derived from config.provider below, and the registry
+    # REFUSES TO LOAD this entry with enabled: true while that is unset, so
+    # enabling the lane without stating what it bills is a load error rather
+    # than a comment nobody reads.
+    provider_from_config: true
+    description: "HTTP cloud worker (Vercel, Codespaces, or any AFK-compatible endpoint). Disabled by default until an endpoint is configured. Its budget provider is whatever the configured endpoint bills, declared in config.provider — the adapter has no inherent cost attribution."
     enabled: false
     config:
+      # provider: "anthropic-api"    # REQUIRED before enabling: the allowlisted
+      #                              # AIW provider (state/driver/aiw-budget-policy.json)
+      #                              # that the endpoint below ACTUALLY bills.
       # endpoint: "https://example.com/afk-worker"
       # api_key_env: "DEMERZEL_REMOTE_API_KEY"
       # timeout: 300

--- a/docs/workflows/aiw-operating-doctrine.md
+++ b/docs/workflows/aiw-operating-doctrine.md
@@ -396,13 +396,15 @@ The AFK implement governor is tool-agnostic: it loads backends from `config/afk-
 
 Registry entries declare the adapter class, the AIW budget provider used for cost gating, an `enabled` flag, and an optional `config` block. The provider must match the actual API or compute that will be billed. The local Podman sandcastle forwards `ANTHROPIC_API_KEY` and runs `claudeCode(opus)`, so it is attributed to `anthropic-api` (`metered-cloud`, `requires_manual_approval: true`) — **not** to `claude-code-cli`, which is a `local-seat` subscription provider that requires no approval. #863 was mis-fixed twice by naming a free `local-seat` id here (`codex-cli`, then `claude-code-cli`); both were well-formed and allowlisted, so nothing caught either. When a backend forwards a metered key, name the metered provider.
 
+Some backends have no inherent attribution: what a `remote` HTTP worker bills is a property of the endpoint an operator configures, not of the adapter, so any static id is a guess — and the guess that shipped (`claude-code-cli`) was a free `local-seat` one, #863's shape again (#915). Such an entry sets `provider_from_config: true` and omits the top-level `provider`; the attribution is read from `config.provider`, and the registry **refuses to load the entry with `enabled: true` while that is unset**. Enabling the lane without stating what it bills is a load error, and an unattributed backend that somehow reaches the budget gate fails closed rather than reserving under a default.
+
 Current shipped backends:
 
 | Name | Adapter | Provider | Execution environment |
 |------|---------|----------|----------------------|
 | `claude-code` | `afk_backends.claude_code.ClaudeCodeBackend` | `claude-code-cli` | Local Claude Code desktop subscription |
 | `local` | `afk_backends.sandcastle.SandcastleBackend` | `anthropic-api` | Podman sandcastle in sibling `../afk-harness`; forwards `ANTHROPIC_API_KEY`, so metered and approval-gated |
-| `remote` | `afk_backends.remote.RemoteBackend` | `claude-code-cli` | HTTP cloud worker (Vercel, Codespaces, etc.) |
+| `remote` | `afk_backends.remote.RemoteBackend` | from `config.provider` (`provider_from_config: true`) | HTTP cloud worker (Vercel, Codespaces, etc.) |
 | `shell` | `afk_backends.shell.ShellBackend` | `generic-shell` | Configurable local command; proves non-Claude abstraction |
 
 The harness fails closed on unknown backends, disabled backends, and backends whose configuration is missing or invalid. This keeps the AFK surface bounded, observable, and reviewable regardless of which AI tool is behind the adapter.

--- a/scripts/afk_backends/registry.py
+++ b/scripts/afk_backends/registry.py
@@ -45,15 +45,48 @@ def load_registry(path: Path | None = None) -> dict[str, dict[str, Any]]:
     for name, cfg in backends.items():
         if not isinstance(cfg, dict):
             raise RegistryError(f"{p}: backend {name!r} must be a mapping")
-        for key in ("adapter", "provider"):
-            if not isinstance(cfg.get(key), str) or not cfg[key].strip():
-                raise RegistryError(f"{p}: backend {name!r} missing required {key}")
+        if not isinstance(cfg.get("adapter"), str) or not cfg["adapter"].strip():
+            raise RegistryError(f"{p}: backend {name!r} missing required adapter")
+
+        from_config = cfg.get("provider_from_config", False)
+        if not isinstance(from_config, bool):
+            raise RegistryError(
+                f"{p}: backend {name!r} provider_from_config must be a boolean")
+        if from_config:
+            if "provider" in cfg:
+                raise RegistryError(
+                    f"{p}: backend {name!r} sets both provider and "
+                    f"provider_from_config; the attribution has one source")
+        elif not isinstance(cfg.get("provider"), str) or not cfg["provider"].strip():
+            raise RegistryError(f"{p}: backend {name!r} missing required provider")
+
         if "enabled" not in cfg:
             cfg["enabled"] = False
         elif not isinstance(cfg["enabled"], bool):
             raise RegistryError(f"{p}: backend {name!r} enabled must be a boolean")
 
+        # A backend whose spend attribution depends on operator configuration
+        # cannot be enabled without stating what it bills. Hardcoding a guess in
+        # the registry is how a metered endpoint ends up gated as a free
+        # local-seat subscription (#915, same shape as #863).
+        if from_config and cfg["enabled"] and _config_provider(cfg) is None:
+            raise RegistryError(
+                f"{p}: backend {name!r} is enabled but its config block declares "
+                f"no provider; set config.provider to the allowlisted AIW provider "
+                f"this backend actually bills")
+
     return backends
+
+
+def _config_provider(cfg: dict[str, Any]) -> str | None:
+    """Return the provider declared inside a backend's own config block, if any."""
+    conf = cfg.get("config")
+    if not isinstance(conf, dict):
+        return None
+    value = conf.get("provider")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
 
 
 def _resolve_class(dotted_path: str) -> type[AFKBackend]:
@@ -90,9 +123,24 @@ def get_backend(name: str, registry: dict[str, dict[str, Any]] | None = None) ->
 
 
 def provider_for(name: str, registry: dict[str, dict[str, Any]] | None = None) -> str:
-    """Return the AIW budget provider id for the named backend."""
+    """Return the AIW budget provider id for the named backend.
+
+    For a backend marked ``provider_from_config``, the attribution is a property
+    of the endpoint an operator configured, not of the adapter, so it is read
+    from ``config.provider``. An unset one raises rather than falling back to a
+    default: the caller (``_budget_reserve``) fails closed on the raise, whereas
+    a fallback would bill metered spend under whatever the default happened to
+    be (#915).
+    """
     reg = load_registry() if registry is None else registry
     cfg = reg.get(name)
     if cfg is None:
         raise RegistryError(f"unknown backend {name!r}")
+    if cfg.get("provider_from_config"):
+        provider = _config_provider(cfg)
+        if provider is None:
+            raise RegistryError(
+                f"backend {name!r} takes its budget provider from its config "
+                f"block and none is set; there is no safe default to assume")
+        return provider
     return cfg["provider"]

--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -33,7 +33,13 @@ Backends (--backend):
                  plumbed -- a metered job needs a trusted receipt that
                  _budget_release never passes, so every approved run leaves an open
                  reservation (#896). Treat `local` as operator-driven.
-  remote       — Vercel isolated sandboxes (NOT yet implemented; seam reserved)
+  remote       — HTTP cloud worker at an operator-configured endpoint (#879).
+                 Disabled by default, and it has NO inherent cost attribution:
+                 what it bills is a property of the endpoint, so
+                 config/afk-backends.yaml marks it provider_from_config and the
+                 provider is read from that entry's config.provider. The registry
+                 refuses to load it with enabled: true while that is unset, and an
+                 unattributed backend fails closed at the gate (#915).
 
 Usage:
   python scripts/run_afk_cycle.py --dry-run            # classify + plan, no side effects

--- a/scripts/test_afk_registry.py
+++ b/scripts/test_afk_registry.py
@@ -50,6 +50,88 @@ class TestLoadRegistry(unittest.TestCase):
             load_registry(Path(path))
 
 
+class TestConfigDerivedProvider(unittest.TestCase):
+    """#915: a backend whose spend attribution is a property of the endpoint an
+    operator configures (``remote``) has no correct provider in the abstract.
+    Naming one anyway is how a metered HTTP worker got gated as a free
+    local-seat Claude Code subscription. The attribution is read from the
+    backend's own config block instead, and it is mandatory to enable the lane."""
+
+    def _write(self, body: str) -> Path:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False,
+                                         encoding="utf-8") as tmp:
+            tmp.write(body)
+            path = Path(tmp.name)
+        self.addCleanup(path.unlink)
+        return path
+
+    def test_config_declared_provider_is_what_reaches_the_gate(self):
+        path = self._write(
+            'schema_version: "1.0"\n'
+            "backends:\n"
+            "  remote:\n"
+            "    adapter: afk_backends.remote.RemoteBackend\n"
+            "    provider_from_config: true\n"
+            "    enabled: true\n"
+            "    config:\n"
+            "      provider: anthropic-api\n"
+            "      endpoint: https://example.com/afk-worker\n")
+        reg = load_registry(path)
+        self.assertEqual("anthropic-api", provider_for("remote", reg))
+
+    def test_enabling_without_a_declared_provider_is_a_load_error(self):
+        """The control the #914 comment was not: an operator who flips
+        ``enabled: true`` without saying what the endpoint bills gets a refusal
+        at load time, before any reservation is attempted."""
+        path = self._write(
+            'schema_version: "1.0"\n'
+            "backends:\n"
+            "  remote:\n"
+            "    adapter: afk_backends.remote.RemoteBackend\n"
+            "    provider_from_config: true\n"
+            "    enabled: true\n"
+            "    config:\n"
+            "      endpoint: https://example.com/afk-worker\n")
+        with self.assertRaises(RegistryError) as ctx:
+            load_registry(path)
+        self.assertIn("config.provider", str(ctx.exception))
+
+    def test_disabled_without_a_provider_loads_but_never_resolves(self):
+        """The shipped state: the entry is loadable while the lane is off, but
+        nothing can derive a provider for it — so if anything did reach the
+        budget gate, the gate fails closed instead of billing under a guess."""
+        path = self._write(
+            'schema_version: "1.0"\n'
+            "backends:\n"
+            "  remote:\n"
+            "    adapter: afk_backends.remote.RemoteBackend\n"
+            "    provider_from_config: true\n"
+            "    enabled: false\n")
+        reg = load_registry(path)
+        with self.assertRaises(RegistryError):
+            provider_for("remote", reg)
+
+    def test_two_sources_of_truth_are_rejected(self):
+        path = self._write(
+            'schema_version: "1.0"\n'
+            "backends:\n"
+            "  remote:\n"
+            "    adapter: afk_backends.remote.RemoteBackend\n"
+            "    provider: claude-code-cli\n"
+            "    provider_from_config: true\n"
+            "    enabled: false\n")
+        with self.assertRaises(RegistryError):
+            load_registry(path)
+
+    def test_shipped_remote_entry_declares_no_static_provider(self):
+        """Bound to the real config, not a fixture: the defect was a literal
+        value in config/afk-backends.yaml, so a fixture would reproduce it
+        rather than catch it."""
+        remote = load_registry()["remote"]
+        self.assertTrue(remote.get("provider_from_config"))
+        self.assertNotIn("provider", remote)
+
+
 class TestGetBackend(unittest.TestCase):
     def test_returns_configured_adapters(self):
         reg = {

--- a/scripts/test_run_afk_cycle.py
+++ b/scripts/test_run_afk_cycle.py
@@ -478,11 +478,28 @@ class TestBudgetGate(unittest.TestCase):
         self.assertEqual(result["decision"], "allow")
         self.assertEqual(result["tier"], "local-seat")
 
+    def test_remote_backend_cannot_reserve_as_a_free_subscription_lane(self):
+        """#915 regression, stated as the outcome rather than the mechanism.
+        `remote` POSTs to an operator-configured endpoint with an optional bearer
+        token, so it can bill a metered API -- but it was attributed to
+        claude-code-cli (local-seat, requires_manual_approval: false) and
+        reserved as if it were free.
+
+        Asserts the DECISION, not the provider id: any attribution that clears
+        this lane with no approval artifact is #863 again, whatever it is named.
+        The safe outcomes are a block (unattributed, or metered-and-unapproved);
+        an allow is not one of them."""
+        with tempfile.TemporaryDirectory() as d, \
+             mock.patch.object(g.budget, "CYCLE_LEDGER_PATH", Path(d) / "cycle.json"):
+            allowed, result = g._budget_reserve({"number": 5, "body": ""}, "remote")
+        self.assertFalse(allowed, f"remote reserved with no approval: {result}")
+        self.assertEqual("block", result["decision"])
+
     def test_every_registry_provider_is_declared_in_policy(self):
         """config/afk-backends.yaml has no schema, so an unvalidated YAML edit
         is all that stands between a correct and an incorrect attribution. Bind
         it to the policy allowlist at least."""
-        from afk_backends.registry import load_registry
+        from afk_backends.registry import RegistryError, load_registry, provider_for
         declared = {p["id"] for p in
                     g.budget.load_policy(g.budget.POLICY_PATH)["providers"]}
         # Every backend, enabled or not. Scoping this to enabled-only left
@@ -491,10 +508,26 @@ class TestBudgetGate(unittest.TestCase):
         # closed, but the misconfiguration only surfaced when someone flipped
         # `enabled` and got a mystery block. Both are now declared, so the check
         # can be unconditional -- which is what makes it catch the NEXT one.
-        for backend, cfg in load_registry().items():
-            self.assertIn(cfg["provider"], declared,
+        #
+        # Checks the EFFECTIVE provider (what provider_for hands the gate), not
+        # the raw `provider` key: since #915 an attribution may be derived from
+        # the backend's config block, and the key the gate never reads is not
+        # the one worth pinning.
+        registry = load_registry()
+        for backend, cfg in registry.items():
+            try:
+                provider = provider_for(backend, registry)
+            except RegistryError:
+                # Only legitimate for a config-derived attribution left unset --
+                # and load_registry refuses that combination with enabled: true,
+                # so the lane cannot run. Nothing to check against the allowlist.
+                self.assertFalse(cfg["enabled"],
+                                 f"backend {backend!r} is enabled but resolves to "
+                                 f"no provider at all")
+                continue
+            self.assertIn(provider, declared,
                           f"backend {backend!r} names undeclared provider "
-                          f"{cfg['provider']!r}")
+                          f"{provider!r}")
 
     def test_process_issue_forwards_its_own_backend_to_the_gate(self):
         """Pinning the registry is not enough: if _process_issue reserves under


### PR DESCRIPTION
Closes #915.

Implemented by a delegated agent; I reviewed and independently re-ran everything below before pushing.

## The fix is not the one the issue implies

The issue reads as "wrong provider id, swap it". The agent argued that swapping it just moves the guess:

> what the lane bills is a property of the endpoint, not the adapter, so any hardcoded id is a guess and the guess that shipped was the free one

`config/afk-backends.yaml` declared `provider: "claude-code-cli"` for the `remote` backend. That id is `tier: local-seat`, `cost_model: subscription-or-local`, `requires_manual_approval: false`. `provider_for()` returned it verbatim into `_budget_request` → `budget.reserve`, so a `RemoteBackend` POSTing to any operator-configured endpoint with an optional bearer token would reserve metered spend through the **free** lane.

So instead of a new literal: the `remote` entry now carries **no top-level `provider`**. It sets `provider_from_config: true`, and `provider_for()` **raises rather than defaults** when `config.provider` is unset. `_budget_reserve` already fails closed on any exception, so an unattributed backend blocks instead of billing under a placeholder. `load_registry()` additionally refuses to load such an entry with `enabled: true` and no configured provider.

The wrong value no longer exists to leak.

## Two details worth calling out

- The existing #914 guard `test_every_registry_provider_is_declared_in_policy` was strengthened to check the **effective** provider via `provider_for()` rather than the raw `cfg["provider"]` key — which would have `KeyError`'d under the new shape. Strictly stronger than before.
- The new test asserts the **decision**, not the provider string — explicitly because pinning the string is what let #863 survive two swaps between equally-free ids.

The forged-receipt tripwire (`test_metered_release_is_abandoned_not_forged`) was not touched.

## Verified

Re-run by me on the pushed commit, not taken on report:

| | |
|---|---|
| before | `Ran 417 tests` — OK |
| new tests against unfixed source | `Ran 423` — **FAILED (failures=4, errors=2)**, all six new |
| after | `Ran 423 tests` — **OK** |
| `validate_governance.py` | `PASSED: all checks green.` |
| blocked paths touched | none |

## ⚠️ Needs a policy amendment before this is complete

`policies/autonomous-loop-policy.yaml:259` says every backend entry must declare *"an adapter Python class, a budget provider, an enabled flag, and an optional config block."* This change makes the **top-level** `provider` key optional for config-derived entries, so the literal wording no longer describes the file.

The intent is preserved and tightened — a budget provider is still mandatory to *enable* a lane, now enforced at load time rather than by a comment — and rule 3 of that same block already says *"configuration that is required for operation … must be explicitly set before the backend is enabled"*, which is exactly what this implements. But `policies/**` is a blocked path and the agent correctly did not edit it. **A human needs to amend rule 1 to allow `provider_from_config`.**

Also not done: `config/afk-backends.yaml` still has no JSON schema (that would land in `schemas/**`, also blocked). The loader plus two guard tests are the only validation.
