### PR TITLE
fix(freshness): a newborn low-cadence loop is not a dead one (#850)

### DIFF
--- a/scripts/ecosystem_freshness.py
+++ b/scripts/ecosystem_freshness.py
@@ -17,7 +17,8 @@ declares, per loop, exactly one of:
 
 Findings and exit codes (a producer with a real problem must fail CI):
 
-  0  every active loop is healthy; disabled entries are bounded and verified.
+  0  every active loop is healthy, newborn (added too recently to have been
+     able to produce evidence yet), or bounded-disabled and verified.
   1  at least one: stale, silent_green, unregistered, malformed_proof,
      expired_disable, failed_run, activation_mismatch.
   2  configuration or evidence-adapter failure (registry unreadable / invalid /
@@ -72,7 +73,7 @@ _EXIT1_KINDS = (
     "failed_run",
     "activation_mismatch",
 )
-# Everything else (healthy, disabled) is exit 0.
+# Everything else (healthy, newborn, disabled) is exit 0.
 
 
 class ConfigError(Exception):
@@ -229,6 +230,46 @@ def workflow_crons(workflows_dir: Path, workflow: str) -> list[str] | None:
         for entry in sched
         if isinstance(entry, dict) and isinstance(entry.get("cron"), str)
     )
+
+
+def workflow_added_at(
+    workflow: str,
+    workflows_dir: Path,
+    repo_root: Path,
+    default_branch: str,
+    git_runner,
+) -> datetime | None:
+    """When the workflow file was last ADDED to the default branch, or None.
+
+    Returns None whenever birth cannot be *proven* — git unavailable, the
+    workflows dir sits outside the repo, or the file has never been committed
+    to the default branch. Callers must not suppress anything on None: an
+    unprovable birth date is not evidence of youth.
+
+    The newest add-commit wins, not the oldest. A workflow that was deleted and
+    re-added (or renamed — git records a rename as an add at the new path, and
+    GitHub Actions likewise starts its run history over) is a new producer with
+    a new run history, so its clock restarts at the latest addition.
+    """
+    try:
+        rel = os.path.relpath(workflows_dir / workflow, repo_root)
+    except ValueError:  # different drives on Windows
+        return None
+    rel = rel.replace(os.sep, "/")
+    if rel.startswith("../"):
+        return None
+    try:
+        out = git_runner(
+            ["log", "--diff-filter=A", "--format=%cI", default_branch, "--", rel],
+            repo_root,
+        )
+    except AdapterError:
+        return None
+    for line in out.splitlines():
+        line = line.strip()
+        if line:
+            return _parse_iso(line)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -397,6 +438,7 @@ def _evaluate_loop(
     loop: dict,
     now: datetime,
     repo_root: Path,
+    workflows_dir: Path,
     default_branch: str,
     git_runner,
     actions_runner,
@@ -468,11 +510,13 @@ def _evaluate_loop(
     proof = loop["proof"]
     adapter = proof.get("adapter")
     if adapter == "state_glob":
-        return _eval_state_glob(proof, now, repo_root)
-    if adapter == "git_log":
-        return _eval_git_log(proof, now, repo_root, default_branch, git_runner)
-    if adapter == "workflow_run":
-        return _eval_workflow_run(
+        kind, detail = _eval_state_glob(proof, now, repo_root)
+    elif adapter == "git_log":
+        kind, detail = _eval_git_log(
+            proof, now, repo_root, default_branch, git_runner
+        )
+    elif adapter == "workflow_run":
+        kind, detail = _eval_workflow_run(
             proof,
             wf,
             now,
@@ -481,7 +525,44 @@ def _evaluate_loop(
             token,
             actions_runner,
         )
-    raise ConfigError(f"{wf}: unknown proof adapter {adapter!r}")
+    else:
+        raise ConfigError(f"{wf}: unknown proof adapter {adapter!r}")
+
+    if kind != "silent_green":
+        return kind, detail
+
+    # Newborn grace (#850). "No evidence ever" is ambiguous: a daily loop with
+    # nothing after three days is dead, but a monthly loop added eleven days
+    # ago has simply not reached its first scheduled opportunity. Alarming on
+    # the newborn is a false positive, and a guard that cries wolf is one
+    # people stop reading — which is exactly how a real dead loop hides.
+    #
+    # The grace window is the loop's OWN max_stale_days, measured from the
+    # default-branch add-commit. Reasons for that exact boundary:
+    #   * It is already cadence-scaled (35d monthly, 1d for a */15 loop), so no
+    #     cron arithmetic and no second dial to keep in sync with the first.
+    #   * It is the tolerance the loop's author already declared as "longer
+    #     than this without output means dead". A newborn cannot be judged by a
+    #     softer standard than a running loop without inventing a weaker one.
+    #   * It is therefore not over-broad: a missed FIRST run surfaces exactly as
+    #     late as a missed subsequent run already does, no later.
+    # Silence past that window is proof of death and still turns the board red.
+    grace_days = float(proof["max_stale_days"])
+    added = workflow_added_at(
+        wf, workflows_dir, repo_root, default_branch, git_runner
+    )
+    if added is None:
+        return kind, detail
+    age = _age_days(added, now)
+    if age > grace_days:
+        return kind, detail
+    return (
+        "newborn",
+        f"added to `{default_branch}` {age:.1f}d ago and has not yet had a "
+        f"full {grace_days:g}d window to produce evidence — "
+        f"withheld until then, after which silence is red. Original finding: "
+        f"{detail}",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -558,6 +639,7 @@ def evaluate(
                 loop,
                 now,
                 repo_root,
+                workflows_dir,
                 default_branch,
                 git_runner,
                 actions_runner,

--- a/scripts/test_ecosystem_freshness.py
+++ b/scripts/test_ecosystem_freshness.py
@@ -352,6 +352,107 @@ class EcosystemFreshnessTest(unittest.TestCase):
         })
         self.assertEqual(self._one(stale, "producer.yml")["kind"], "stale")
 
+    # ── newborn vs genuinely-silent (issue #850) ──────────────────────────
+
+    def _birth_git(self, added_at, seen=None):
+        """git_runner stub answering the `--diff-filter=A` birth query."""
+        def runner(args, cwd):
+            if seen is not None:
+                seen["args"] = args
+            return "" if added_at is None else _iso(added_at) + "\n"
+        return runner
+
+    def test_newborn_low_cadence_loop_stays_quiet(self):
+        # substrate-audit.yml: monthly cron, 35d threshold, added 7 days ago.
+        # Its first scheduled opportunity has not arrived, so "no run" is not
+        # evidence of death and must not turn the board red.
+        seen = {}
+        findings = self._evaluate(
+            self._workflow_run_registry("substrate-audit.yml", 35),
+            actions_runner=lambda *args: None,
+            git_runner=self._birth_git(NOW - timedelta(days=7), seen),
+        )
+        finding = self._one(findings, "substrate-audit.yml")
+        self.assertEqual(finding["kind"], "newborn")
+        self.assertEqual(ef.exit_code(findings), 0)
+        self.assertEqual(ef.stable_alert(findings), [])
+        # Birth is read from the DEFAULT branch's add-commit, not the worktree.
+        self.assertIn("--diff-filter=A", seen["args"])
+        self.assertIn("master", seen["args"])
+        self.assertIn(".github/workflows/substrate-audit.yml", seen["args"])
+
+    def test_overdue_silent_loop_still_fires_after_grace(self):
+        # Same loop, one second past its own staleness window with still no
+        # run: the grace has run out and silence is now proof of death.
+        findings = self._evaluate(
+            self._workflow_run_registry("substrate-audit.yml", 35),
+            actions_runner=lambda *args: None,
+            git_runner=self._birth_git(NOW - timedelta(days=35, seconds=1)),
+        )
+        self.assertEqual(self._one(findings, "substrate-audit.yml")["kind"],
+                         "silent_green")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_newborn_grace_scales_to_the_declared_cadence(self):
+        # A 1-day-threshold loop silent for 2 days is dead, not newborn — the
+        # grace is the loop's own cadence-scaled window, not a fixed one.
+        findings = self._evaluate(
+            self._workflow_run_registry("ga-chatbot-discussions.yml", 1),
+            actions_runner=lambda *args: None,
+            git_runner=self._birth_git(NOW - timedelta(days=2)),
+        )
+        self.assertEqual(self._one(findings, "ga-chatbot-discussions.yml")["kind"],
+                         "silent_green")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_unprovable_birth_does_not_suppress(self):
+        # Never added on the default branch -> birth unknown. An unprovable
+        # birth date is not evidence of youth; the finding must survive.
+        findings = self._evaluate(
+            self._workflow_run_registry("producer.yml", 35),
+            actions_runner=lambda *args: None,
+            git_runner=self._birth_git(None),
+        )
+        self.assertEqual(self._one(findings, "producer.yml")["kind"],
+                         "silent_green")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_broken_git_does_not_suppress(self):
+        def boom(args, cwd):
+            raise ef.AdapterError("git exploded")
+
+        findings = self._evaluate(
+            self._workflow_run_registry("producer.yml", 35),
+            actions_runner=lambda *args: None,
+            git_runner=boom,
+        )
+        self.assertEqual(self._one(findings, "producer.yml")["kind"],
+                         "silent_green")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_newborn_grace_applies_to_state_glob_evidence(self):
+        # Same defect for a committed-state producer: a brand-new loop has not
+        # had a window in which to write its first state file.
+        registry = {
+            "version": 1,
+            "loops": [{
+                "workflow": "newborn-producer.yml",
+                "status": "active",
+                "proof": {
+                    "adapter": "state_glob",
+                    "glob": "state/newborn/*.jsonl",
+                    "timestamp_field": "timestamp",
+                    "max_stale_days": 7,
+                },
+            }],
+        }
+        findings = self._evaluate(
+            registry, git_runner=self._birth_git(NOW - timedelta(days=2))
+        )
+        self.assertEqual(self._one(findings, "newborn-producer.yml")["kind"],
+                         "newborn")
+        self.assertEqual(ef.exit_code(findings), 0)
+
     def test_workflow_run_adapter_failure_is_exit_2(self):
         def boom(*args):
             raise ef.AdapterError("Actions API unavailable")


### PR DESCRIPTION
Closes #850.

Implemented by a delegated agent; I reviewed and independently re-ran everything below before pushing.

## Root cause

`_eval_workflow_run` returned `silent_green` whenever the Actions API reported no completed scheduled run, with no reference to how long the workflow had existed. Same blind spot in `_eval_state_glob` and `_eval_git_log`. Nothing in `_evaluate_loop` weighed age, so **a monthly loop added 7 days ago and a daily loop dead for a month produced the same verdict.**

`substrate-audit.yml` was added on 2026-07-23, cron `0 6 1 * *`, first opportunity 2026-08-01 — genuinely newborn, reported as silently dead.

## The rule, and why no new dial

A `silent_green` becomes a neutral `newborn` finding (exit 0, excluded from the committable alert) while the workflow's age since its default-branch add is `<= max_stale_days` — **the loop's own existing threshold**, strict `>` to fire.

No new registry field, no cron parsing. The reasoning the agent gave, which I think is the right one:

> the window is not a new leniency, it is the existing one applied from birth instead of from the last run

It is already cadence-scaled per loop (35d for monthly `substrate-audit`, 1d for the `*/15` loops), and it is the number the loop's author already declared as *"longer than this without output means dead."* A missed **first** run therefore surfaces exactly as late as a missed **subsequent** run already does — no later. It also sidesteps `schemas/loop-health.schema.json` being `additionalProperties: false` and a blocked path.

Two judgement calls worth noting:

- **Birth = the *newest* `--diff-filter=A` commit**, not the oldest. A rename or delete/re-add restarts GitHub's run history too, so the clock should restart with it.
- **Unprovable birth suppresses nothing.** If git fails or the file was never on the default branch, the original finding survives. An unprovable birth date is not evidence of youth — this fails loud, not silent.

## Verified

| | |
|---|---|
| before | `Ran 417 tests` — OK |
| the two "stay quiet" tests, pre-fix | **FAILED (failures=2)** |
| after | `Ran 423 tests` — **OK** |
| blocked paths touched | **none** — fix is entirely in `scripts/` |

Both directions are tested, which was the requirement: `test_newborn_low_cadence_loop_stays_quiet` (35d loop, 7d old, no run → `newborn`, exit 0) and `test_overdue_silent_loop_still_fires_after_grace` (same loop at **35d + 1 second** → `silent_green`, exit 1). Plus non-suppression tests for unprovable birth and broken git, which passed before *and* after — they pin behaviour that must not regress.

Live run against the real Actions API: `substrate-audit.yml` → `newborn: added to master 6.6d ago … full 35d window`, contributing 0. Mutated to `--now 2026-09-01` on the same live data → `silent_green`, exit 1.

## Known limitation, stated by the agent rather than buried

With a 35d grace, a genuinely missed **first** run on 2026-08-01 would not turn red until 2026-08-27 — a real 26-day blind spot specific to first runs. The defence is that this is the same lateness the registry already accepts for an established loop. A cron-aware rule (*"one full period after the first scheduled opportunity"*) would tighten it to a few days; the agent chose not to build cron arithmetic for one workflow. **If 26 days is unacceptable, that's the follow-up** — flagging it rather than letting it be discovered later.

## Out of scope

#844 (freshness cannot see event-triggered loops) is untouched — only the verdict for already-registered loops changed; `scheduled_workflows()` enumeration is unchanged.

`state/loop-health/.freshness-alert.json` still lists the substrate-audit false positive. The workflow's `persist` job owns that file and rewrites it on the next run; hand-editing committed alert state would be forging evidence.
