### PR TITLE
fix(overseer): a 74-day-old 'ok' is not an oracle result (#782)

### DIFF
--- a/scripts/dev-process-overseer.ps1
+++ b/scripts/dev-process-overseer.ps1
@@ -4,6 +4,10 @@
 # recommends whether Claude Code should continue, switch to /goal, run a /loop,
 # or pause for operator attention.
 #
+# Exit code mirrors the verdict: 0 only when workflowMode is 'loop-eligible',
+# 1 otherwise. A reader that only parses the printed report cannot tell a green
+# run from a red one, and every consumer of this script is a gate.
+#
 # Usage:
 #   pwsh Scripts/dev-process-overseer.ps1
 #   pwsh Scripts/dev-process-overseer.ps1 -Domain chatbot-qa
@@ -13,6 +17,12 @@
 param(
     [string]$RepoRoot = (Resolve-Path .).Path,
     [string]$Domain = '',
+    # last.json records a status; it does not recompute it. Past this age the
+    # recorded oracle_status is treated as 'unknown' rather than believed (#782
+    # - a hand-written "ok" reported green for two months after the oracle went
+    # red). 24h matches the bound supervised-loop-preflight.ps1 already applies
+    # to this script's own artifact, so the whole gate chain expires together.
+    [int]$OracleMaxAgeHours = 24,
     [switch]$Json,
     [string]$OutPath = 'state/governance/dev-process-overseer.json',
     [switch]$NoEmit
@@ -50,6 +60,34 @@ function Read-JsonOrNull {
     } catch {
         return $null
     }
+}
+
+function Get-AgeHoursOrNull {
+    param([object]$Value)
+
+    # ConvertFrom-Json converts a well-formed ISO-8601 timestamp to [datetime]
+    # on its own (Kind Utc for a trailing Z, Local for an offset, Unspecified
+    # for neither) and leaves anything it cannot parse as a [string]. Measured
+    # on pwsh 7.6.3 — both shapes reach here, so both are handled.
+    $moment = [datetime]::MinValue
+    if ($Value -is [datetime]) {
+        $moment = $Value
+    } elseif ($Value -is [string]) {
+        $styles = [System.Globalization.DateTimeStyles]::AdjustToUniversal -bor `
+            [System.Globalization.DateTimeStyles]::AssumeUniversal
+        $culture = [System.Globalization.CultureInfo]::InvariantCulture
+        if (-not [datetime]::TryParse($Value, $culture, $styles, [ref]$moment)) { return $null }
+    } else {
+        return $null
+    }
+
+    # Harness artifacts record UTC; reading an offset-less stamp as local time
+    # would shift the age by the machine's offset.
+    if ($moment.Kind -eq [System.DateTimeKind]::Unspecified) {
+        $moment = [datetime]::SpecifyKind($moment, [System.DateTimeKind]::Utc)
+    }
+
+    return ((Get-Date).ToUniversalTime() - $moment.ToUniversalTime()).TotalHours
 }
 
 function Get-HomeDirectoryOrNull {
@@ -287,12 +325,16 @@ foreach ($baselinePath in $baselineFiles) {
     $oracleStatus = $null
     $metricValue = $null
     $lastWriteTime = $null
+    $oracleEmittedAt = $null
+    $oracleAgeHours = $null
     if (Test-Path -LiteralPath $lastPath) {
         $lastWriteTime = (Get-Item -LiteralPath $lastPath).LastWriteTime.ToString('o')
     }
     if ($last) {
         if ($last.PSObject.Properties.Name -contains 'oracle_status') { $oracleStatus = $last.oracle_status }
         if ($last.PSObject.Properties.Name -contains 'metric_value') { $metricValue = $last.metric_value }
+        $oracleEmittedAt = Get-ObjectPropertyOrNull -Object $last -Names @('emitted_at')
+        $oracleAgeHours = Get-AgeHoursOrNull -Value $oracleEmittedAt
     }
 
     if (-not $last) {
@@ -303,6 +345,19 @@ foreach ($baselinePath in $baselineFiles) {
         Add-Finding $findings 'block' 'oracle-shape-invalid' `
             "Domain '$domainName' last.json is missing metric_value or oracle_status." `
             'Treat the oracle as unreliable. Keep Claude in supervised mode until the oracle emits the baseline contract shape.'
+    } elseif ($null -eq $oracleAgeHours) {
+        # No usable emitted_at means the record cannot be expired, so it would
+        # be believed forever. Unknown age is unknown status.
+        $oracleStatus = 'unknown'
+        Add-Finding $findings 'block' 'oracle-timestamp-unreadable' `
+            "Domain '$domainName' last.json has no readable emitted_at, so its oracle_status cannot be expired." `
+            'Re-run the declared oracle and emit last.json with an ISO-8601 emitted_at before trusting its status.'
+    } elseif ($oracleAgeHours -gt $OracleMaxAgeHours) {
+        $recordedStatus = $oracleStatus
+        $oracleStatus = 'unknown'
+        Add-Finding $findings 'block' 'oracle-status-stale' `
+            ("Domain '$domainName' last.json records oracle_status '$recordedStatus' from {0}h ago (max {1}h); treating it as unknown." -f [Math]::Round($oracleAgeHours, 1), $OracleMaxAgeHours) `
+            'Re-run the declared oracle so the recorded status reflects an actual run. A recorded status is not a measurement.'
     } elseif ($oracleStatus -ne 'ok') {
         Add-Finding $findings 'block' 'oracle-not-ok' `
             "Domain '$domainName' oracle_status is '$oracleStatus'." `
@@ -342,6 +397,9 @@ foreach ($baselinePath in $baselineFiles) {
         lastJsonPath       = if (Test-Path -LiteralPath $lastPath) { [System.IO.Path]::GetRelativePath($RepoRoot, $lastPath) -replace '\\', '/' } else { $null }
         lastJsonWriteTime  = $lastWriteTime
         oracleStatus       = $oracleStatus
+        oracleEmittedAt    = $oracleEmittedAt
+        oracleAgeHours     = if ($null -eq $oracleAgeHours) { $null } else { [Math]::Round($oracleAgeHours, 1) }
+        oracleMaxAgeHours  = $OracleMaxAgeHours
         metricValue        = $metricValue
         outOfScopeDirty    = @($outOfScope)
         protectedDirty     = @($protectedTouched)
@@ -409,9 +467,13 @@ if (-not $NoEmit -and $artifactPath) {
     Move-Item -LiteralPath $temporaryPath -Destination $artifactPath -Force
 }
 
+# Green is exit 0 and nothing else. Anything short of loop-eligible has to be
+# visible to a caller that never reads the report body.
+$exitCode = if ($workflowMode -eq 'loop-eligible') { 0 } else { 1 }
+
 if ($Json) {
     $report | ConvertTo-Json -Depth 12
-    exit 0
+    exit $exitCode
 }
 
 Write-Host "Development process overseer" -ForegroundColor Cyan
@@ -438,3 +500,5 @@ Write-Host $goalTemplate
 Write-Host ''
 Write-Host 'Recommended Claude /loop:' -ForegroundColor Cyan
 Write-Host $loopTemplate
+
+exit $exitCode

--- a/scripts/test_dev_process_overseer.py
+++ b/scripts/test_dev_process_overseer.py
@@ -1,0 +1,155 @@
+"""Guard: the overseer must never report green from a stale oracle artifact.
+
+`state/quality/<domain>/last.json` records `oracle_status`. Nothing recomputed
+it, so a literal `"ok"` committed on 2026-05-16 kept the overseer reporting
+`loop-eligible` for two months after the oracle actually went red (#782). The
+artifact was a claim about the past being read as a fact about the present.
+
+These tests pin the fix from both ends:
+
+  * a fresh artifact still reaches `loop-eligible` and exit 0, so the guard is
+    not vacuously red;
+  * stale / missing / unparseable / undatable artifacts all fail closed —
+    `oracleStatus` is never left as `ok`, the mode is never `loop-eligible`,
+    and the process exits non-zero.
+
+The exit code is asserted explicitly, not just the printed verdict: a guard
+that prints red and exits 0 is the failure mode this repo keeps re-finding.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parent.parent
+OVERSEER = ROOT / "scripts" / "dev-process-overseer.ps1"
+DOMAIN = "demerzel-harness"
+PWSH = shutil.which("pwsh")
+
+BASELINE = {
+    "schema_version": 1,
+    "domain": DOMAIN,
+    "metric": "harness_ready",
+    "primary_baseline": 1.0,
+    "_harness": {"oracle_command": "pwsh scripts/verify.ps1"},
+    "scope_boundary": {"allow_edit": ["**"], "protected_paths": [".env"]},
+}
+
+
+def _stamp(hours_ago: float) -> str:
+    moment = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _last(hours_ago: float, status: str = "ok") -> dict:
+    return {
+        "domain": DOMAIN,
+        "emitted_at": _stamp(hours_ago),
+        "metric_name": "harness_ready",
+        "metric_value": 1.0,
+        "oracle_status": status,
+        "oracle_command": "pwsh scripts/verify.ps1",
+    }
+
+
+class OverseerRun:
+    """Result of one overseer invocation against a throwaway repo root."""
+
+    def __init__(self, returncode: int, report: dict, stderr: str):
+        self.returncode = returncode
+        self.report = report
+        self.stderr = stderr
+
+    @property
+    def mode(self) -> str:
+        return self.report["workflowMode"]
+
+    @property
+    def domain(self) -> dict:
+        domains = self.report["domains"]
+        if isinstance(domains, dict):
+            domains = [domains]
+        return domains[0]
+
+    @property
+    def codes(self) -> list:
+        findings = self.report["findings"]
+        if isinstance(findings, dict):
+            findings = [findings]
+        return [finding["code"] for finding in findings]
+
+
+@unittest.skipUnless(PWSH, "pwsh is required to exercise the overseer")
+class DevProcessOverseerFreshnessTest(unittest.TestCase):
+    def run_overseer(self, last_json_text: str | None) -> OverseerRun:
+        with TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            domain_dir = repo / "state" / "quality" / DOMAIN
+            domain_dir.mkdir(parents=True)
+            (domain_dir / "baseline.json").write_text(
+                json.dumps(BASELINE), encoding="utf-8")
+            if last_json_text is not None:
+                (domain_dir / "last.json").write_text(
+                    last_json_text, encoding="utf-8")
+
+            # The overseer resolves HALT-ALL under the home directory; point it
+            # at the fixture so a real marker on the developer's box cannot
+            # change the verdict under test.
+            environment = dict(os.environ)
+            environment["USERPROFILE"] = str(repo)
+            environment["HOME"] = str(repo)
+
+            completed = subprocess.run(
+                [PWSH, "-NoProfile", "-File", str(OVERSEER),
+                 "-RepoRoot", str(repo), "-Json", "-NoEmit"],
+                capture_output=True, text=True, env=environment, check=False)
+
+        self.assertTrue(
+            completed.stdout.strip(),
+            f"overseer printed no JSON; stderr={completed.stderr}")
+        return OverseerRun(completed.returncode,
+                           json.loads(completed.stdout),
+                           completed.stderr)
+
+    def test_fresh_artifact_is_green(self):
+        run = self.run_overseer(json.dumps(_last(hours_ago=1)))
+        self.assertEqual("loop-eligible", run.mode)
+        self.assertEqual("ok", run.domain["oracleStatus"])
+        self.assertEqual(0, run.returncode, run.stderr)
+
+    def test_stale_ok_artifact_is_not_green(self):
+        run = self.run_overseer(json.dumps(_last(hours_ago=24 * 60)))
+        self.assertNotEqual("ok", run.domain["oracleStatus"])
+        self.assertNotEqual("loop-eligible", run.mode)
+        self.assertIn("oracle-status-stale", run.codes)
+        self.assertNotEqual(0, run.returncode)
+
+    def test_artifact_without_readable_timestamp_is_not_green(self):
+        payload = _last(hours_ago=1)
+        payload["emitted_at"] = "whenever"
+        run = self.run_overseer(json.dumps(payload))
+        self.assertNotEqual("ok", run.domain["oracleStatus"])
+        self.assertNotEqual("loop-eligible", run.mode)
+        self.assertIn("oracle-timestamp-unreadable", run.codes)
+        self.assertNotEqual(0, run.returncode)
+
+    def test_missing_artifact_is_not_green(self):
+        run = self.run_overseer(None)
+        self.assertNotEqual("loop-eligible", run.mode)
+        self.assertIn("missing-oracle-output", run.codes)
+        self.assertNotEqual(0, run.returncode)
+
+    def test_unparseable_artifact_is_not_green(self):
+        run = self.run_overseer('{"oracle_status": "ok",')
+        self.assertNotEqual("loop-eligible", run.mode)
+        self.assertIn("missing-oracle-output", run.codes)
+        self.assertNotEqual(0, run.returncode)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses #782 **partially** — see "What this does not do", which you should read before merging.

Implemented by a delegated agent; I reviewed and independently re-ran everything below before pushing.

## Root cause

`scripts/dev-process-overseer.ps1` read `oracle_status` straight out of `state/quality/<domain>/last.json` and blocked only when that literal was something other than `ok`. Nothing bounded the record's age.

The record in question:

```json
{ "emitted_at": "2026-05-16T22:20:00Z",
  "oracle_status": "ok",
  "oracle_command": "pwsh scripts/verify.ps1" }
```

Committed 2026-05-17. **74 days old**, and still producing `oracleStatus: ok` / `workflowMode: loop-eligible`. The script also always exited 0, so a caller not parsing the report body could not tell green from red.

Worth noting how hollow that green was: the artifact names `pwsh scripts/verify.ps1` as its own oracle command, and **that command currently fails** (BAML client drift — see #924). The status was not merely stale, it was contradicted by the command it cites.

## Threshold: 24h

Matches the bound already applied one link up the same chain — `supervised-loop-preflight.ps1:14` uses `OverseerMaxAgeHours = 24` against *this script's* artifact. Same number means preflight → overseer → oracle expire together instead of one link outliving another. (`quality_trend_freshness.py` uses 3 days, but that guards a nightly feeder, not a per-cycle oracle.)

## Verified

Re-run by me on the pushed commit:

| | |
|---|---|
| before | `Ran 417 tests` — OK |
| new file alone, pre-fix | `Ran 5` — **FAILED (failures=4)** |
| after | `Ran 422 tests` — **OK** |
| overseer exit code, unpiped | **`EXIT=1`**, `Mode: pause`, `[BLOCK] oracle-status-stale … 1790.4h ago (max 24h)` |
| blocked paths touched | none |

Exit code captured from a **non-piped** invocation — the trap documented in `docs/solutions/harness/2026-07-20-powershell-native-exit-codes.md`. The guard is bound to `emitted_at`, not file mtime: test fixtures are written milliseconds before each run and the stale one still fails. The one new test that passes pre-fix is the `fresh → green` control, proving the guard is not vacuously red.

## ⚠️ Live behaviour change — this pauses the supervised loop

Because nothing currently refreshes `last.json`, the overseer will now report `workflowMode: pause` on master, and `supervised-loop-preflight.ps1:94` will therefore refuse to start the supervised loop (`overseer_workflow_mode_pause`).

**That is correct** — the oracle genuinely is red (#780) and `loop-eligible` was a lie. But it is not a no-op, and until item 1 below lands, un-blocking requires running the oracle and refreshing the artifact by hand.

I verified the blast radius rather than taking it on report: every consumer (`supervised-loop-preflight.ps1`, the `demerzel-drive` / `demerzel-halt` / `supervised-loop` skills) reads `workflowMode` from the JSON. **Nothing reads the exit code**, so the widened exit semantics below are safe.

## What this does not do

**Issue item 1 — "derive it instead of storing it" — is NOT implemented.** `oracle_status` still comes from a committed literal; this only makes that literal expire. The issue calls these two independent changes, both needed; this is the second.

The follow-up is well-scoped but needs a decision I would not make unilaterally: `docs/harness-observability.md:86` claims `pwsh scripts/verify.ps1` produces `last.json` — **it does not, verify.ps1 never writes anything.** Making that documented contract true is the fix, but `last.json` is a *tracked* file, so having the oracle write it dirties the index on every local run, and wrapping verify.ps1's body to record a `failed` status risks re-introducing the swallowed-exit-code bug #778 just fixed.

**Exit-code semantics widened slightly.** Exit 0 now means `loop-eligible` and 1 means anything else, rather than escalating individual findings' severities — the only way to make *missing* and *unparseable* (both pre-existing `warn`s) exit non-zero without changing their severity. Side effect: an unrelated warn-only run (e.g. `no-quality-baselines`) also exits 1 now. Safe per the consumer audit above.

**Tests `skipUnless(shutil.which("pwsh"))`.** `ubuntu-latest` ships pwsh so they execute in CI, but on a machine without it they skip silently rather than fail.
