### PR TITLE
fix(jules): write the delegation marker after Jules accepts, not before (#925)

### DIFF
--- a/.github/workflows/jules-auto-delegate.yml
+++ b/.github/workflows/jules-auto-delegate.yml
@@ -17,7 +17,9 @@ name: Auto-delegate ready-for-agent issues to Jules
 #
 # Eligibility:
 # - open issue must have BOTH `ready-for-agent` and `worker:jules`.
-# - the workflow writes a `<!-- jules-delegated -->` marker before invoking Jules.
+# - the workflow writes a `<!-- jules-delegated -->` marker only AFTER Jules has
+#   accepted the delegation. It used to write it before invoking Jules, which turned
+#   a failed delegation into a permanent record of a successful one (#925).
 # - repeated scheduled runs skip issues already carrying that marker.
 #
 # Safety:
@@ -210,7 +212,13 @@ jobs:
           fi
           echo "::notice::AIW budget gate allowed jules delegation for issue #$issue"
 
-          gh issue comment "$issue" --repo "$REPO" --body "🤖 Delegating this \`ready-for-agent\` + \`worker:jules\` issue to Jules via governed AFK workflow. $marker\n\nJules should open a PR targeting \`master\`. Human/Demerzel review is still required before merge."
+          # NOTE: no delegation marker here. This comment announces the ATTEMPT; the
+          # marker that makes an issue permanently ineligible is written only after
+          # `Delegate to Jules` actually succeeds. See the step at the end of this job
+          # and #925 — six issues were marked delegated on 2026-06-30 and Jules never
+          # opened a single PR, because the receipt was written before the thing it
+          # attests to had happened.
+          gh issue comment "$issue" --repo "$REPO" --body "🤖 Attempting delegation of this \`ready-for-agent\` + \`worker:jules\` issue to Jules via the governed AFK workflow. Jules should open a PR targeting \`master\`; human/Demerzel review is still required before merge. If no confirmation comment follows this one, the delegation did **not** succeed and the issue stays eligible for retry."
 
           echo "issue=$issue" >> "$GITHUB_OUTPUT"
           echo "proceed=true" >> "$GITHUB_OUTPUT"
@@ -250,9 +258,43 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Delegate to Jules
+        id: jules
         if: steps.gate.outputs.proceed == 'true'
         uses: google-labs-code/jules-action@v1.0.0
         with:
           prompt: ${{ steps.prompt.outputs.text }}
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           starting_branch: master
+
+      # The delegation marker is written HERE, and only here — after the action above
+      # actually succeeded. It is what makes an issue permanently ineligible for the
+      # scheduled listener (see has_delegation_marker), so writing it earlier turns a
+      # failed delegation into a permanent record of a successful one. That is exactly
+      # what happened to #596, #594, #543, #527, #517 and #471: marked 2026-06-30,
+      # zero PRs a month later, and skipped by every scheduled run since. (#925)
+      #
+      # A step with no `if:` does not run when an earlier step in the job failed, so
+      # this is naturally gated on the delegation having worked.
+      - name: Record confirmed delegation
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ steps.gate.outputs.issue }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh issue comment "$ISSUE" --repo "$REPO" --body "✅ Jules accepted the delegation ([run]($RUN_URL)). This marker makes the issue ineligible for further automatic delegation; re-delegate via \`workflow_dispatch\` with \`force: true\` if needed. <!-- jules-delegated -->"
+
+      # Fail loud and stay eligible. Without this the only signal that a delegation
+      # failed is a red run nobody is watching, on an issue that looks delegated.
+      - name: Report failed delegation
+        if: failure() && steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ steps.gate.outputs.issue }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh issue comment "$ISSUE" --repo "$REPO" --body "❌ Delegation to Jules **failed** ([run]($RUN_URL)). No delegation marker was written, so this issue stays eligible and the scheduled listener will retry it. If this repeats, check \`JULES_API_KEY\` and the \`google-labs-code/jules-action\` step log."

--- a/scripts/test_jules_delegation_ordering.py
+++ b/scripts/test_jules_delegation_ordering.py
@@ -1,0 +1,109 @@
+"""The Jules delegation marker must be written AFTER Jules accepts, never before.
+
+Why this test exists (#925). `jules-auto-delegate.yml` writes a
+`<!-- jules-delegated -->` comment, and `has_delegation_marker` treats any issue
+carrying it as permanently ineligible for automatic delegation. The marker used to be
+written in the preflight step, before `google-labs-code/jules-action` ran at all — so a
+delegation that failed, no-opped, or was silently dropped by Jules still left behind a
+receipt saying it had succeeded.
+
+That is not hypothetical. Six issues (#596, #594, #543, #527, #517, #471) were marked
+delegated on 2026-06-30 and Jules never opened a single pull request. Every scheduled run
+for the following month skipped them, and the workflow reported success throughout,
+because "nothing left to delegate" and "delegation is broken" produce identical output.
+
+The ordering is the whole defect, so the ordering is what this pins. A comment saying
+"write the marker after" is what the workflow already had, in its header, describing the
+opposite of what the code did.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml is installed in CI
+    yaml = None
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "jules-auto-delegate.yml"
+MARKER = "<!-- jules-delegated -->"
+JULES_ACTION = "google-labs-code/jules-action"
+
+
+def _steps() -> list[dict]:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return data["jobs"]["delegate"]["steps"]
+
+
+def _writes_marker(step: dict) -> bool:
+    """True when the step POSTS a comment carrying the marker.
+
+    Deliberately not "the marker literal appears in this step". The preflight step
+    legitimately contains `marker='<!-- jules-delegated -->'` as the needle for its
+    eligibility grep, and the first version of this test flagged that assignment as a
+    write — a guard bound to the wrong subject, which is the exact family of bug it was
+    written to catch. Reading a marker and writing one are opposite operations that share
+    a string.
+
+    A write is a `gh issue comment` invocation whose body carries the marker, either as
+    the literal or via the `$marker` variable the workflow expands into it.
+    """
+    for line in str(step.get("run", "")).splitlines():
+        if "gh issue comment" not in line:
+            continue
+        if MARKER in line or "$marker" in line:
+            return True
+    return False
+
+
+@unittest.skipIf(yaml is None, "pyyaml not installed")
+class TestDelegationMarkerOrdering(unittest.TestCase):
+    def test_workflow_is_parseable_and_invokes_jules(self):
+        """Guard the guard: if the action is renamed, the ordering test below is vacuous."""
+        steps = _steps()
+        indexes = [i for i, s in enumerate(steps)
+                   if JULES_ACTION in str(s.get("uses", ""))]
+        self.assertEqual(
+            1, len(indexes),
+            f"expected exactly one {JULES_ACTION} step; found {len(indexes)}. "
+            "If the action moved or was renamed, update this test — do not delete it.")
+
+    def test_marker_is_never_written_before_jules_runs(self):
+        steps = _steps()
+        jules_at = next(i for i, s in enumerate(steps)
+                        if JULES_ACTION in str(s.get("uses", "")))
+
+        writers = [i for i, s in enumerate(steps) if _writes_marker(s)]
+        self.assertTrue(
+            writers,
+            f"no step writes {MARKER}; the scheduled listener would re-delegate the "
+            "same issue forever. Did the marker literal change?")
+
+        early = [i for i in writers if i < jules_at]
+        self.assertEqual(
+            [], early,
+            f"step(s) {early} write the delegation marker before "
+            f"{JULES_ACTION} runs at step {jules_at}. A receipt written before the "
+            "thing it attests to converts a failed delegation into a permanent record "
+            "of a successful one, and the issue is then skipped forever (#925). "
+            "Write the marker only after the delegation is confirmed.")
+
+    def test_a_failed_delegation_reports_and_leaves_the_issue_eligible(self):
+        """Failing silently is what made this invisible for a month."""
+        steps = _steps()
+        failure_steps = [s for s in steps if "failure()" in str(s.get("if", ""))]
+        self.assertTrue(
+            failure_steps,
+            "no step runs on failure(); a failed delegation would leave no trace on the "
+            "issue, and the only signal would be a red run nobody is watching.")
+        for step in failure_steps:
+            self.assertFalse(
+                _writes_marker(step),
+                "the failure path must NOT write the delegation marker — the issue has "
+                "to stay eligible for retry.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #925.

## The defect

`jules-auto-delegate.yml` wrote `<!-- jules-delegated -->` in the **preflight** step, before `google-labs-code/jules-action` ran at all. `has_delegation_marker` treats any issue carrying that marker as permanently ineligible for automatic delegation — so a delegation that failed, no-opped, or was silently dropped by Jules still left behind a receipt saying it had succeeded.

The evidence that this is not hypothetical:

```
issues marked <!-- jules-delegated --> on 2026-06-30:
  #596 #594 #543 #527 #517 #471

PRs authored by Jules, ever:  0
PRs since 2026-06-29:         125, all by spareilleux
jules-auto-delegate runs:     87 success · 12 cancelled · 1 failure
```

87 green runs and a month elapsed, because **"nothing left to delegate" and "delegation is broken" produce identical output.** The workflow's own header documented the ordering as intentional, which is what made it read as a design choice rather than a bug.

## The fix

| step | before | after |
|---|---|---|
| preflight comment | carried the marker | announces the **attempt**, no marker |
| `Delegate to Jules` | — | unchanged, now has `id: jules` |
| `Record confirmed delegation` | — | **new** — writes the marker, runs only if the action succeeded |
| `Report failed delegation` | — | **new** — `if: failure()`, comments, writes **no** marker |

A step with no `if:` is skipped once an earlier step in the job has failed, so the confirmation is naturally gated on the delegation having worked — no extra condition needed.

The failure step matters as much as the ordering. Without it the only signal is a red run nobody is watching, on an issue that looks delegated. Now the issue says so and stays eligible for the scheduled listener to retry.

The header comment that described the old ordering is corrected.

## The regression guard

`scripts/test_jules_delegation_ordering.py` parses the workflow and pins the invariant. Proven red against master and green here:

```
against master's ordering:  Ran 3 tests — FAILED (failures=2)
  "step(s) [3] write the delegation marker before
   google-labs-code/jules-action runs at step 5"
against this branch:        Ran 3 tests — OK
full suite:                 Ran 463 tests — OK   (was 460)
validate_governance.py:     PASSED: all checks green.
```

It also includes a guard-the-guard test asserting exactly one `jules-action` step exists — if the action is renamed, the ordering test would otherwise pass vacuously.

## One thing worth reading, about the test

Its first version flagged the **preflight** step, because that step legitimately contains `marker='<!-- jules-delegated -->'` as the needle for its eligibility grep. My check looked for the literal anywhere in a step, so it could not tell reading a marker from writing one — two opposite operations that share a string.

That is a guard bound to the wrong subject, inside the guard written to catch precisely that. `_writes_marker` now requires a `gh issue comment` invocation carrying the marker. Recording it here because it caught me in the same turn I was writing about it, which is the argument for `docs/solutions/harness/2026-07-29-a-guard-is-only-as-good-as-its-subject.md` being a live hazard rather than a historical note.

## What this does not do

**It does not unstick the six already-marked issues.** They stay ineligible until someone either deletes their marker comments or re-delegates with `workflow_dispatch` + `force: true`.

I did not do that, deliberately: re-delegating into a path whose failure mode is still unknown would either fail six more times or spend metered budget six times to find out. The ordering fix means the *next* attempt reports honestly — that is the thing worth having before retrying. #925's suggested fix 4 (investigate whether Jules ever received those prompts) should come first; the June run logs have since been purged, so it likely needs one controlled live attempt.

Note also that the AIW budget gate now blocks Jules at `provider_requires_manual_approval` **before** the marker step, so it independently prevents a marker being written for a non-delegation. #789 was labelled on 2026-07-30 and blocked cleanly. This PR fixes the path that runs *after* an approval artifact is committed.

## Blocked path

Touches `.github/workflows/**`, so `risk-report` fails closed and this needs explicit human review per `docs/review-independence.md`. No `agent-blackbox-reviewed` label applied.
