### PR TITLE
docs(policy): allow config-derived provider attribution for AFK backends (#915)

### DIFF
--- a/policies/autonomous-loop-policy.yaml
+++ b/policies/autonomous-loop-policy.yaml
@@ -256,9 +256,13 @@ afk_backend_governance:
 
   registry_rules:
     - >
-      Every backend entry must declare an adapter Python class, a budget provider,
-      an enabled flag, and an optional config block. Unknown or disabled backends
-      must fail closed.
+      Every backend entry must declare an adapter Python class, an enabled flag, a
+      budget provider, and an optional config block. The budget provider is declared
+      either on the entry itself, or - for a backend whose billing depends on operator
+      configuration rather than on the adapter - in its config block, by marking the
+      entry provider_from_config and setting config.provider. An entry may not do both.
+      A provider_from_config backend cannot be enabled without a configured provider.
+      Unknown or disabled backends must fail closed.
     - >
       New backends may be added by creating an adapter module and a registry entry.
       The governor must not require code changes to recognize a new backend.
@@ -278,6 +282,13 @@ afk_backend_governance:
     - >
       Provider attribution changes are treated as high-risk because they affect cost
       gating and may bypass budget controls.
+    - >
+      Where a backend's billing is a property of the endpoint an operator configures
+      rather than of the adapter, the attribution must be derived from that configuration
+      and must not be defaulted. A hardcoded guess in the registry is how a metered
+      endpoint comes to be gated as a free local seat. Resolution of an unset provider
+      must raise, so the budget preflight fails closed, rather than falling back to any
+      default.
 
   adapter_contract_rules:
     - >


### PR DESCRIPTION
Follow-up to #927 (merged), which flagged this as the one thing it could not do.

## Why

#927 removed the hardcoded `provider: "claude-code-cli"` from the `remote` backend and made attribution derive from `config.provider`, on the reasoning that what a lane bills is a property of the endpoint an operator configures, not of the adapter — so any hardcoded id is a guess, and the guess that shipped was the free one.

But `policies/autonomous-loop-policy.yaml` still said:

> Every backend entry must declare an adapter Python class, **a budget provider**, an enabled flag, and an optional config block.

So the shipped code and the written rule disagreed. `policies/**` is a blocked path, so the agent correctly stopped rather than editing it, and I raised it on the PR instead of quietly proceeding.

## What changed

**`registry_rules` rule 1** now says the budget provider is declared *either* on the entry, *or* — for an entry marked `provider_from_config` — in its config block; that an entry may not do both; and that such a backend **cannot be enabled without a configured provider**.

The requirement that a provider exist is unchanged. It moved from convention to load-time enforcement, which is **stricter** than before, not looser: previously a wrong-but-present literal satisfied the rule, and now an absent one blocks the lane from being enabled at all.

**One new `provider_attribution_rules` clause** carries the part that is actually governance rather than mechanics:

> Where a backend's billing is a property of the endpoint an operator configures rather than of the adapter, the attribution must be derived from that configuration and must not be defaulted. A hardcoded guess in the registry is how a metered endpoint comes to be gated as a free local seat. Resolution of an unset provider must raise, so the budget preflight fails closed, rather than falling back to any default.

That last sentence is the one worth having in policy: it is the difference between #915 and #863 recurring, and it binds the behaviour (`provider_for` raises → `_budget_reserve` blocks) rather than the spelling.

## Verified

| | |
|---|---|
| frontmatter parses | identical to master |
| whole-file YAML | fails identically **before and after** — this file is markdown with YAML frontmatter, so that is pre-existing, not a regression I introduced |
| `validate_governance.py` | `PASSED: all checks green.` |
| suite | `Ran 460 tests` — OK |
| shipped config conforms | `remote`: `provider_from_config: true`, `enabled: false`, no `config.provider` — permitted, since the rule bars *enabling* without one |

I checked master's parse behaviour explicitly rather than assuming, because "my edit broke the YAML" and "this file was never whole-file YAML" look the same from a single failing parse.

## Blocked path

Touches `policies/**`, so `risk-report` fails closed and this needs explicit human review per `docs/review-independence.md`. No `agent-blackbox-reviewed` label applied.

This is a policy amendment, so it deserves a closer read than a code change: the substantive question is whether *"attribution must be derived and must not be defaulted"* is the rule you want, or whether you would rather forbid endpoint-configurable backends from being enabled at all until they appear in `aiw-budget-policy.json` by name.
