### PR TITLE
fix(freshness): enumerate event-triggered loops, bound to event supply (part of #844)

### DIFF
--- a/.github/workflows/ecosystem-freshness.yml
+++ b/.github/workflows/ecosystem-freshness.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/scripts/ecosystem_freshness.py
+++ b/scripts/ecosystem_freshness.py
@@ -75,14 +75,18 @@ ALLOWED_MONITORS = {
 # loop is not expressible there today, and a hardcoded list cannot be extended by
 # a producer editing its own workflow file.
 #
-# `event` is the `on:` key that dispatches the loop; membership is verified
-# against the live workflow YAML. `max_stale_days` is BOTH the response
-# tolerance and the width of the event-supply window (see _eval_event_producer).
-# Only 'pull_request' is supported — the one event this repo actually has a
-# producer for. Adding a second event means teaching the supply adapter how to
-# date it, which is deliberately not speculated on here.
+# `event` and `activities` describe the exact `on:` dispatch surface; both are
+# verified against live workflow YAML. `max_stale_days` is the response
+# tolerance for an observed but uncorrelated obligation (see _eval_event_producer).
+# The secured workflow from #935 uses `pull_request_target`; the legacy branch
+# uses `pull_request`. Exactly one must be active, and both share the same PR/head
+# supply adapter.
 EVENT_PRODUCERS: dict[str, dict] = {
-    "cross-model-review.yml": {"event": "pull_request", "max_stale_days": 3},
+    "cross-model-review.yml": {
+        "events": ["pull_request", "pull_request_target"],
+        "activities": ["opened", "synchronize"],
+        "max_stale_days": 3,
+    },
 }
 
 for _stream in (sys.stdout, sys.stderr):  # Windows consoles default to cp1252.
@@ -212,23 +216,17 @@ def default_event_supply_runner(
     event: str,
     repository: str,
     token: str,
-) -> tuple[str | None, dict | None]:
-    """Return (newest triggering event ISO timestamp, latest completed run).
+    activities: tuple[str, ...] = ("opened", "synchronize"),
+) -> list[tuple[dict, dict | None]]:
+    """Return PR/head dispatch obligations and their exact-head candidate runs.
 
-    Two reads, one seam, so tests inject a single stub:
-
-      * event supply — the newest pull request CREATED on the repo. `created_at`
-        is used, not `updated_at`: the `opened` activity type dispatches
-        unconditionally, so a PR created inside the window is *proof* that a run
-        was due. `updated_at` also bumps on comments and label edits, which are
-        not triggers, and would demand runs that were never owed (a guard that
-        cries wolf is worse than none). The cost is that a window containing
-        only `synchronize` pushes reads as quiet — under-claiming, not
-        over-claiming.
-      * latest completed run of `workflow` for that event, on ANY branch. There
-        is deliberately no branch filter: a `pull_request` run is attributed to
-        the PR's head branch, so filtering on the default branch would find
-        nothing and every healthy loop would read as dead.
+    Every open pull request is evaluated, so one healthy PR cannot mask another.
+    `updated_at` is deliberately not evidence: comments, labels, merges, and
+    other non-dispatch activity all change it. The observable obligation is each
+    PR's current head SHA. A matching Actions run supplies the dispatch time; if
+    no run exists, the head commit date is the conservative head-correlated
+    lower bound. Both configured activities remain explicit because current API
+    state cannot soundly distinguish an opening head from a synchronized head.
     """
     if not repository or "/" not in repository:
         raise AdapterError(
@@ -236,40 +234,155 @@ def default_event_supply_runner(
         )
     if not token:
         raise AdapterError("event-supply proof requires the existing GITHUB_TOKEN")
-    if event != "pull_request":
+    if event not in {"pull_request", "pull_request_target"}:
         raise AdapterError(f"no event-supply adapter for event {event!r}")
+    if not activities or any(activity not in {"opened", "synchronize"}
+                             for activity in activities):
+        raise AdapterError(
+            f"unsupported pull_request activities for event supply: {activities!r}"
+        )
 
     repo_path = quote(repository, safe="/")
-    pulls = _github_get(
-        f"https://api.github.com/repos/{repo_path}/pulls?"
-        + urlencode({
-            "state": "all",
-            "sort": "created",
-            "direction": "desc",
-            "per_page": 1,
-        }),
-        token,
-        f"{event} supply on {repository}",
-    )
-    if not isinstance(pulls, list):
-        raise AdapterError(f"GitHub API returned malformed pull data for {repository}")
-    newest_event = None
-    if pulls and isinstance(pulls[0], dict):
-        newest_event = pulls[0].get("created_at")
-
-    payload = _github_get(
-        f"https://api.github.com/repos/{repo_path}/actions/workflows/"
-        f"{quote(workflow, safe='')}/runs?"
-        + urlencode({"event": event, "status": "completed", "per_page": 1}),
-        token,
-        f"{workflow} runs",
-    )
-    runs = payload.get("workflow_runs") if isinstance(payload, dict) else None
-    if not isinstance(runs, list):
-        raise AdapterError(
-            f"GitHub Actions API returned malformed run data for {workflow}"
+    pulls: list = []
+    page = 1
+    while True:
+        pull_page = _github_get(
+            f"https://api.github.com/repos/{repo_path}/pulls?"
+            + urlencode({
+                "state": "open",
+                "sort": "updated",
+                "direction": "desc",
+                "per_page": 100,
+                "page": page,
+            }),
+            token,
+            f"{event} supply on {repository} page {page}",
         )
-    return newest_event, (runs[0] if runs else None)
+        if not isinstance(pull_page, list):
+            raise AdapterError(
+                f"GitHub API returned malformed pull data for {repository}"
+            )
+        pulls.extend(pull_page)
+        if len(pull_page) < 100:
+            break
+        page += 1
+    if not pulls:
+        return []
+
+    supplies: list[tuple[dict, dict | None]] = []
+    target_runs: list | None = None
+    if event == "pull_request_target":
+        target_payload = _github_get(
+            f"https://api.github.com/repos/{repo_path}/actions/workflows/"
+            f"{quote(workflow, safe='')}/runs?"
+            + urlencode({"event": event, "per_page": 100}),
+            token,
+            f"{workflow} secured pull-request runs",
+        )
+        target_runs = (target_payload.get("workflow_runs")
+                       if isinstance(target_payload, dict) else None)
+        if not isinstance(target_runs, list):
+            raise AdapterError(
+                f"GitHub Actions API returned malformed run data for {workflow}"
+            )
+
+    for index, pull in enumerate(pulls):
+        if not isinstance(pull, dict):
+            raise AdapterError(
+                f"GitHub API returned malformed pull at index {index} for {repository}"
+            )
+        pull_number = pull.get("number")
+        created_at = _parse_iso(pull.get("created_at"))
+        head = pull.get("head")
+        head_sha = head.get("sha") if isinstance(head, dict) else None
+        if (not isinstance(pull_number, int) or isinstance(pull_number, bool)
+                or created_at is None
+                or not isinstance(head_sha, str) or not head_sha.strip()):
+            raise AdapterError(
+                f"GitHub API returned malformed pull at index {index} for "
+                f"{repository}: integer number, created_at, and head.sha are required"
+            )
+
+        if target_runs is None:
+            payload = _github_get(
+                f"https://api.github.com/repos/{repo_path}/actions/workflows/"
+                f"{quote(workflow, safe='')}/runs?"
+                + urlencode({
+                    "event": event,
+                    "head_sha": head_sha,
+                    "per_page": 1,
+                }),
+                token,
+                f"{workflow} runs for {head_sha}",
+            )
+            runs = payload.get("workflow_runs") if isinstance(payload, dict) else None
+            if not isinstance(runs, list):
+                raise AdapterError(
+                    f"GitHub Actions API returned malformed run data for {workflow}"
+                )
+            run = runs[0] if runs else None
+        else:
+            run = next((candidate for candidate in target_runs
+                        if isinstance(candidate, dict)
+                        and isinstance(candidate.get("pull_requests"), list)
+                        and any(
+                            isinstance(identity, dict)
+                            and identity.get("number") == pull_number
+                            and isinstance(identity.get("head"), dict)
+                            and identity["head"].get("sha") == head_sha
+                            for identity in candidate["pull_requests"]
+                        )), None)
+
+        if run is None:
+            commit = _github_get(
+                f"https://api.github.com/repos/{repo_path}/commits/"
+                f"{quote(head_sha, safe='')}",
+                token,
+                f"head commit {head_sha}",
+            )
+            commit_data = commit.get("commit") if isinstance(commit, dict) else None
+            committer = (commit_data.get("committer")
+                         if isinstance(commit_data, dict) else None)
+            commit_at_raw = (committer.get("date")
+                             if isinstance(committer, dict) else None)
+            commit_at = _parse_iso(commit_at_raw)
+            if commit_at is None:
+                raise AdapterError(
+                    f"GitHub API returned malformed head commit time for {head_sha}"
+                )
+            occurred_at = max(created_at, commit_at)
+        else:
+            if not isinstance(run, dict):
+                raise AdapterError(
+                    f"GitHub Actions API returned malformed first run for {workflow}"
+                )
+            occurred_at_raw = run.get("created_at") or run.get("run_started_at")
+            occurred_at = _parse_iso(occurred_at_raw)
+            if occurred_at is None:
+                raise AdapterError(
+                    f"GitHub Actions API returned malformed run time for {workflow}"
+                )
+            if run.get("pull_requests") == []:
+                associated_pulls = _github_get(
+                    f"https://api.github.com/repos/{repo_path}/commits/"
+                    f"{quote(head_sha, safe='')}/pulls",
+                    token,
+                    f"pull requests associated with {head_sha}",
+                )
+                if not isinstance(associated_pulls, list):
+                    raise AdapterError(
+                        f"GitHub API returned malformed commit pull data for {head_sha}"
+                    )
+                run = dict(run)
+                run["associated_pull_requests"] = associated_pulls
+
+        supplies.append(({
+            "activities": list(activities),
+            "occurred_at": occurred_at.isoformat(),
+            "pull_number": pull_number,
+            "head_sha": head_sha,
+        }, run))
+    return supplies
 
 
 # ---------------------------------------------------------------------------
@@ -371,6 +484,29 @@ def workflow_events(workflows_dir: Path, workflow: str) -> set[str] | None:
     if isinstance(on, str):
         return {on}
     return set()
+
+
+def workflow_event_activities(
+    workflows_dir: Path,
+    workflow: str,
+    event: str,
+) -> set[str] | None:
+    """Explicit activity types configured for a mapped workflow event."""
+    path = workflows_dir / workflow
+    if not path.exists():
+        return None
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"{workflow}: workflow YAML is invalid: {exc}") from exc
+    on = _on_block(doc)
+    config = on.get(event) if isinstance(on, dict) else None
+    if not isinstance(config, dict):
+        return set()
+    activities = config.get("types")
+    if not isinstance(activities, list):
+        return set()
+    return {str(activity) for activity in activities}
 
 
 def workflow_added_at(
@@ -592,20 +728,13 @@ def _eval_event_producer(
         a `pull_request` loop is expected to have run only when a pull request
         actually happened.
 
-    So `max_stale_days` does double duty as the width of the supply window and
-    the response tolerance:
-
-      * newest triggering event older than the window  -> QUIET. Nothing was
-        owed, so the guard says nothing. This is the "quiet but healthy" arm; a
-        repo with no PRs this week must not turn the board red.
-      * event inside the window, no completed run ever -> silent_green (red),
-        subject to the same newborn grace as #850.
-      * event inside the window, newest completed run older than the window
-        -> stale (red). This is the #844 shape: events kept arriving, the loop
-        stopped answering, and nothing enumerated it.
-      * newest completed run did not conclude 'success' -> failed_run (red),
-        matching _eval_workflow_run. For a PR loop this self-clears on the next
-        PR, so a one-off flake fades while a persistently broken loop stays red.
+    Each sampled pull request contributes its current PR/head identity, so one
+    answered PR cannot mask another unanswered one. Opening and synchronize stay
+    explicit as a candidate activity set: generic `updated_at` is not dispatch
+    evidence. A run answers only when both its PR number and head SHA match; a
+    newer global run for another PR is irrelevant. Queued, in-progress, absent,
+    or mismatched runs remain pending within `max_stale_days` and turn red only
+    after that response allowance. A correlated completed failure is red at once.
 
     LIMIT, stated plainly: this proves the loop was DISPATCHED and did not fail,
     not that its output was VALID. The specific #844 incident (runs green,
@@ -613,97 +742,221 @@ def _eval_event_producer(
     exists because #840 made that failure loud. Asserting the artifact itself
     needs per-workflow proof declarations in the registry — see the report.
     """
-    event = spec["event"]
     max_days = float(spec["max_stale_days"])
 
     actual_events = workflow_events(workflows_dir, workflow)
     if actual_events is None:
         return ("activation_mismatch",
                 "declared event-triggered producer workflow is missing")
-    if event not in actual_events:
+    declared_events = set(spec.get("events") or [])
+    supported_events = {"pull_request", "pull_request_target"}
+    if (not declared_events or not declared_events <= supported_events):
+        raise ConfigError(
+            f"{workflow}: event producer has invalid pull-request event candidates"
+        )
+    active_events = declared_events & actual_events
+    if len(active_events) != 1:
         return ("activation_mismatch",
-                f"declared as an `{event}` producer but the workflow's `on:` "
-                f"triggers are {sorted(actual_events)}")
+                f"expected exactly one of {sorted(declared_events)} but the "
+                f"workflow's `on:` triggers are {sorted(actual_events)}")
+    event = next(iter(active_events))
 
-    newest_event_iso, run = event_supply_runner(workflow, event, repository, token)
-    newest_event = _parse_iso(newest_event_iso)
-    if newest_event is None:
+    configured_activities = workflow_event_activities(
+        workflows_dir, workflow, event
+    )
+    declared_activities = set(spec.get("activities") or [])
+    if not declared_activities:
+        raise ConfigError(
+            f"{workflow}: event producer must declare pull_request activities"
+        )
+    if configured_activities != declared_activities:
+        return (
+            "activation_mismatch",
+            f"declared `{event}` activities {sorted(declared_activities)} do not "
+            f"match workflow activities {sorted(configured_activities or [])}",
+        )
+
+    supplies = event_supply_runner(
+        workflow,
+        event,
+        repository,
+        token,
+        tuple(sorted(declared_activities)),
+    )
+    if not isinstance(supplies, list):
+        raise AdapterError(
+            f"event-supply adapter returned invalid obligation collection for {workflow}"
+        )
+    if not supplies:
         return ("healthy",
                 f"quiet: no `{event}` event has ever occurred, so no run was owed "
                 "(event-triggered loops are judged by event supply, not by a clock)")
-    event_age = _age_days(newest_event, now)
 
-    if run is None:
-        kind, detail = ("silent_green",
-                        f"a `{event}` event arrived {event_age:.1f}d ago but the "
-                        "workflow has no completed run at all")
-        return _apply_newborn_grace(
-            kind, detail, workflow, max_days, now, repo_root, workflows_dir,
-            default_branch, git_runner,
+    results: list[tuple[str, str]] = []
+    for item in supplies:
+        if not isinstance(item, (list, tuple)) or len(item) != 2:
+            results.append((
+                "malformed_proof",
+                f"`{event}` supply contains a malformed obligation/run pair",
+            ))
+            continue
+        obligation, run = item
+        if not isinstance(obligation, dict):
+            results.append((
+                "malformed_proof",
+                f"`{event}` supply contains a non-object obligation",
+            ))
+            continue
+
+        activities = obligation.get("activities")
+        pull_number = obligation.get("pull_number")
+        head_sha = obligation.get("head_sha")
+        occurred_at = _parse_iso(obligation.get("occurred_at"))
+        if (not isinstance(activities, list)
+                or not activities
+                or any(not isinstance(activity, str) for activity in activities)
+                or set(activities) != declared_activities
+                or not isinstance(pull_number, int) or isinstance(pull_number, bool)
+                or not isinstance(head_sha, str) or not head_sha
+                or occurred_at is None):
+            results.append((
+                "malformed_proof",
+                f"latest `{event}` obligation has invalid activities, pull "
+                "identity, head SHA, or timestamp",
+            ))
+            continue
+
+        event_age = _age_days(occurred_at, now)
+        activity_label = "/".join(sorted(declared_activities))
+        obligation_label = (
+            f"PR #{pull_number} `{activity_label}` at {head_sha[:12]}"
         )
-    if not isinstance(run, dict):
-        raise AdapterError(f"event-supply adapter returned invalid run data for {workflow}")
+        if run is None:
+            if event_age <= max_days:
+                results.append((
+                    "pending",
+                    f"{obligation_label} has no run yet but is only "
+                    f"{event_age:.1f}d old (allowance {max_days:g}d)",
+                ))
+                continue
+            kind, detail = _apply_newborn_grace(
+                "silent_green",
+                f"{obligation_label} has no run after {event_age:.1f}d "
+                f"(allowance {max_days:g}d)",
+                workflow, max_days, now, repo_root, workflows_dir,
+                default_branch, git_runner,
+            )
+            results.append((kind, detail))
+            continue
+        if not isinstance(run, dict):
+            results.append((
+                "malformed_proof",
+                f"{obligation_label} candidate run is not an object",
+            ))
+            continue
 
-    conclusion = run.get("conclusion")
-    url = run.get("html_url") or "(no run URL)"
-    if conclusion != "success":
-        return ("failed_run",
-                f"newest completed `{event}` run concluded {conclusion!r}: {url}")
+        run_head_sha = run.get("head_sha")
+        run_pulls = run.get("pull_requests")
+        associated_pulls = run.get("associated_pull_requests", [])
+        identity_pulls = (
+            [*run_pulls, *associated_pulls]
+            if isinstance(run_pulls, list) and isinstance(associated_pulls, list)
+            else None
+        )
+        valid_identities = (
+            identity_pulls is not None
+            and all(
+                isinstance(run_pull, dict)
+                and isinstance(run_pull.get("number"), int)
+                and not isinstance(run_pull.get("number"), bool)
+                and (
+                    "head" not in run_pull
+                    or (
+                        isinstance(run_pull.get("head"), dict)
+                        and isinstance(run_pull["head"].get("sha"), str)
+                        and bool(run_pull["head"]["sha"])
+                    )
+                )
+                for run_pull in identity_pulls
+            )
+        )
+        if (not isinstance(run_head_sha, str) or not run_head_sha
+                or identity_pulls is None or not valid_identities):
+            results.append((
+                "malformed_proof",
+                f"{obligation_label} candidate run has malformed PR/head identity",
+            ))
+            continue
 
-    newest_run = _parse_iso(run.get("run_started_at") or run.get("created_at"))
-    if newest_run is None:
-        return ("malformed_proof",
-                f"newest completed `{event}` run has no parseable start timestamp")
-    run_age = _age_days(newest_run, now)
+        correlated = any(
+            run_pull["number"] == pull_number
+            and (
+                run_head_sha == head_sha
+                or (
+                    isinstance(run_pull.get("head"), dict)
+                    and run_pull["head"].get("sha") == head_sha
+                )
+            )
+            for run_pull in identity_pulls
+        )
+        status = run.get("status")
+        if status not in {"queued", "in_progress", "completed"}:
+            results.append((
+                "malformed_proof",
+                f"{obligation_label} candidate run has invalid status {status!r}",
+            ))
+            continue
+        url = run.get("html_url") or "(no run URL)"
 
-    # Compare the run to the EVENT it should have answered — not both to the clock.
-    #
-    # The first version of this adapter tested `event_age <= max_days AND run_age >
-    # max_days`, i.e. both against `now`. That makes the detection window exactly as wide
-    # as the gap between the dead loop's last run and the unanswered event, and then it
-    # closes: once the event ages past max_days the quiet arm returns healthy and a dead
-    # loop reads green FOREVER. Worked example — loop answers PR A at 09:00 and dies, PR B
-    # opens at 15:00, repo goes quiet: `stale` is true only between run_age=3d and
-    # event_age=3d, a six-hour window, and this guard runs once a day
-    # (ecosystem-freshness.yml, cron `15 13 * * *`). Evidence of death decayed at exactly
-    # the rate the obligation did. Caught in adversarial review before merge.
-    #
-    # Ordering has no window. An event newer than the newest run is unanswered, and stays
-    # unanswered until a run actually answers it, so the finding is STICKY: missing one
-    # daily sweep costs nothing. max_days stops being a detection threshold and becomes a
-    # pure response allowance — how long the loop may take to answer — which is what the
-    # registry field should have meant here all along. It also removes an unstated
-    # coupling: detection no longer requires max_days to exceed this guard's own cadence.
-    if newest_run >= newest_event:
-        return ("healthy",
-                f"answering `{event}` supply: newest successful run ({run_age:.1f}d ago) "
-                f"postdates the newest event ({event_age:.1f}d ago): {url}")
+        if not correlated:
+            kind = "pending" if event_age <= max_days else "stale"
+            results.append((
+                kind,
+                f"{obligation_label} has no correlated run after {event_age:.1f}d "
+                f"(allowance {max_days:g}d); candidate belongs to another PR/head: "
+                f"{url}",
+            ))
+            continue
+        if status in {"queued", "in_progress"}:
+            kind = "pending" if event_age <= max_days else "stale"
+            results.append((
+                kind,
+                f"{obligation_label} run is {status} after {event_age:.1f}d "
+                f"(allowance {max_days:g}d): {url}",
+            ))
+            continue
 
-    # The newest event is UNANSWERED. Two independent ways that becomes overdue, and the
-    # loop is dead if either holds — neither alone is sufficient:
-    #
-    #   unanswered_for : how long this event has gone unanswered (now - event). Grows
-    #                    without bound, so it catches a loop that died just before a final
-    #                    event and then went quiet — the case a lag-only test misses,
-    #                    because there the lag is fixed and small.
-    #   lag            : how far the run already trailed the event when it arrived
-    #                    (event - run). Catches a loop that has been behind for a long
-    #                    time even though its newest event is recent — the case an
-    #                    age-only test misses for up to the full allowance.
-    #
-    # Both are monotonic while the loop stays dead, so the finding is STICKY once it
-    # fires: unlike the previous `event_age <= max AND run_age > max` form, there is no
-    # window to miss and no path back to green except an actual answering run.
-    unanswered_for = event_age
-    lag = _age_days(newest_run, newest_event)
-    if unanswered_for > max_days or lag > max_days:
-        return ("stale",
-                f"a `{event}` event arrived {event_age:.1f}d ago and is still "
-                f"unanswered: the newest completed run started {run_age:.1f}d ago, "
-                f"{lag:.1f}d BEFORE that event (allowance {max_days:g}d): {url}")
-    return ("healthy",
-            f"a `{event}` event arrived {event_age:.1f}d ago and is not answered yet, "
-            f"still within the {max_days:g}d response allowance: {url}")
+        run_started = _parse_iso(run.get("run_started_at") or run.get("created_at"))
+        if run_started is None:
+            results.append((
+                "malformed_proof",
+                f"{obligation_label} completed run has no parseable timestamp",
+            ))
+            continue
+        conclusion = run.get("conclusion")
+        if conclusion != "success":
+            results.append((
+                "failed_run",
+                f"{obligation_label} run concluded {conclusion!r}: {url}",
+            ))
+            continue
+        results.append((
+            "healthy",
+            f"{obligation_label} has a correlated successful run "
+            f"({_age_days(run_started, now):.1f}d ago): {url}",
+        ))
+
+    priority = {
+        "malformed_proof": 4,
+        "failed_run": 3,
+        "stale": 3,
+        "silent_green": 3,
+        "pending": 1,
+        "newborn": 0,
+        "healthy": 0,
+    }
+    kind, detail = max(results, key=lambda result: priority.get(result[0], 5))
+    return kind, f"evaluated {len(results)} PR obligation(s): {detail}"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ecosystem_freshness.py
+++ b/scripts/ecosystem_freshness.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Universal ecosystem-freshness monitor — one guard for every scheduled loop.
+"""Universal ecosystem-freshness monitor — one guard for every producer loop.
 
 `state/quality-trend/` died silently for 64 days because a "no news" feeder is
 indistinguishable from a dead one (green != alive). scripts/quality_trend.py got
@@ -14,6 +14,13 @@ declares, per loop, exactly one of:
                        branch git history, or the latest completed scheduled
                        GitHub Actions run and its conclusion).
   * disabled         — intentionally paused for a bounded window (`until`).
+
+Event-triggered producers (#844) have no cron and so cannot be expressed in that
+registry at all — an `active` entry requires at least one cron expression, and
+the schema is closed to new fields. They are declared in EVENT_PRODUCERS below
+and judged against their EVENT SUPPLY rather than a clock: a `pull_request` loop
+is only expected to have run when a pull request actually happened. See
+_eval_event_producer for the semantics and their stated limit.
 
 Findings and exit codes (a producer with a real problem must fail CI):
 
@@ -56,6 +63,26 @@ DEFAULT_BRANCH = "master"
 ALLOWED_MONITORS = {
     "ecosystem-freshness.yml",
     "demerzel-quality-trend-freshness.yml",
+}
+
+# Event-triggered producers (#844). `cross-model-review.yml` is `on:
+# pull_request`; it has no cron, so scheduled_workflows() never enumerates it
+# and nothing noticed when it stopped producing for a week.
+#
+# These live in code rather than in .github/loop-health.yml for the same reason
+# ALLOWED_MONITORS does: the registry schema is closed (an `active` loop REQUIRES
+# >= 1 cron expression, and additionalProperties is false), so an event-triggered
+# loop is not expressible there today, and a hardcoded list cannot be extended by
+# a producer editing its own workflow file.
+#
+# `event` is the `on:` key that dispatches the loop; membership is verified
+# against the live workflow YAML. `max_stale_days` is BOTH the response
+# tolerance and the width of the event-supply window (see _eval_event_producer).
+# Only 'pull_request' is supported — the one event this repo actually has a
+# producer for. Adding a second event means teaching the supply adapter how to
+# date it, which is deliberately not speculated on here.
+EVENT_PRODUCERS: dict[str, dict] = {
+    "cross-model-review.yml": {"event": "pull_request", "max_stale_days": 3},
 }
 
 for _stream in (sys.stdout, sys.stderr):  # Windows consoles default to cp1252.
@@ -159,6 +186,92 @@ def default_actions_runner(
     return runs[0] if runs else None
 
 
+def _github_get(endpoint: str, token: str, what: str):
+    """Read-only authenticated GET against the GitHub API. Raises AdapterError."""
+    request = Request(endpoint, headers={
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "demerzel-ecosystem-freshness",
+    })
+    try:
+        with urlopen(request, timeout=20) as response:
+            return json.load(response)
+    except HTTPError as exc:
+        raise AdapterError(
+            f"GitHub API returned HTTP {exc.code} for {what}"
+        ) from exc
+    except (URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise AdapterError(
+            f"GitHub API failed for {what}: {type(exc).__name__}"
+        ) from exc
+
+
+def default_event_supply_runner(
+    workflow: str,
+    event: str,
+    repository: str,
+    token: str,
+) -> tuple[str | None, dict | None]:
+    """Return (newest triggering event ISO timestamp, latest completed run).
+
+    Two reads, one seam, so tests inject a single stub:
+
+      * event supply — the newest pull request CREATED on the repo. `created_at`
+        is used, not `updated_at`: the `opened` activity type dispatches
+        unconditionally, so a PR created inside the window is *proof* that a run
+        was due. `updated_at` also bumps on comments and label edits, which are
+        not triggers, and would demand runs that were never owed (a guard that
+        cries wolf is worse than none). The cost is that a window containing
+        only `synchronize` pushes reads as quiet — under-claiming, not
+        over-claiming.
+      * latest completed run of `workflow` for that event, on ANY branch. There
+        is deliberately no branch filter: a `pull_request` run is attributed to
+        the PR's head branch, so filtering on the default branch would find
+        nothing and every healthy loop would read as dead.
+    """
+    if not repository or "/" not in repository:
+        raise AdapterError(
+            "event-supply proof requires GITHUB_REPOSITORY (owner/repo)"
+        )
+    if not token:
+        raise AdapterError("event-supply proof requires the existing GITHUB_TOKEN")
+    if event != "pull_request":
+        raise AdapterError(f"no event-supply adapter for event {event!r}")
+
+    repo_path = quote(repository, safe="/")
+    pulls = _github_get(
+        f"https://api.github.com/repos/{repo_path}/pulls?"
+        + urlencode({
+            "state": "all",
+            "sort": "created",
+            "direction": "desc",
+            "per_page": 1,
+        }),
+        token,
+        f"{event} supply on {repository}",
+    )
+    if not isinstance(pulls, list):
+        raise AdapterError(f"GitHub API returned malformed pull data for {repository}")
+    newest_event = None
+    if pulls and isinstance(pulls[0], dict):
+        newest_event = pulls[0].get("created_at")
+
+    payload = _github_get(
+        f"https://api.github.com/repos/{repo_path}/actions/workflows/"
+        f"{quote(workflow, safe='')}/runs?"
+        + urlencode({"event": event, "status": "completed", "per_page": 1}),
+        token,
+        f"{workflow} runs",
+    )
+    runs = payload.get("workflow_runs") if isinstance(payload, dict) else None
+    if not isinstance(runs, list):
+        raise AdapterError(
+            f"GitHub Actions API returned malformed run data for {workflow}"
+        )
+    return newest_event, (runs[0] if runs else None)
+
+
 # ---------------------------------------------------------------------------
 # time helpers
 # ---------------------------------------------------------------------------
@@ -183,13 +296,18 @@ def _age_days(newest: datetime, now: datetime) -> float:
 # workflow enumeration (which scheduled producers exist on disk)
 # ---------------------------------------------------------------------------
 
-def _schedule_block(doc: dict):
+def _on_block(doc: dict):
     """`on:` parses to the YAML 1.1 boolean True under PyYAML, so look under both."""
     if not isinstance(doc, dict):
         return None
     on = doc.get("on")
     if on is None:
         on = doc.get(True)
+    return on
+
+
+def _schedule_block(doc: dict):
+    on = _on_block(doc)
     if isinstance(on, dict):
         return on.get("schedule")
     return None
@@ -230,6 +348,29 @@ def workflow_crons(workflows_dir: Path, workflow: str) -> list[str] | None:
         for entry in sched
         if isinstance(entry, dict) and isinstance(entry.get("cron"), str)
     )
+
+
+def workflow_events(workflows_dir: Path, workflow: str) -> set[str] | None:
+    """Trigger names under `on:`, or None when the workflow file is absent.
+
+    Handles all three YAML shapes GitHub accepts: mapping (`on: {pull_request:
+    ...}`), sequence (`on: [push, pull_request]`), and scalar (`on: push`).
+    """
+    path = workflows_dir / workflow
+    if not path.exists():
+        return None
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"{workflow}: workflow YAML is invalid: {exc}") from exc
+    on = _on_block(doc)
+    if isinstance(on, dict):
+        return {str(k) for k in on}
+    if isinstance(on, list):
+        return {str(k) for k in on}
+    if isinstance(on, str):
+        return {on}
+    return set()
 
 
 def workflow_added_at(
@@ -430,9 +571,152 @@ def _eval_workflow_run(
     )
 
 
+def _eval_event_producer(
+    workflow: str,
+    spec: dict,
+    now: datetime,
+    repo_root: Path,
+    workflows_dir: Path,
+    default_branch: str,
+    git_runner,
+    event_supply_runner,
+    repository: str,
+    token: str,
+) -> tuple[str, str]:
+    """Prove an event-triggered loop against its EVENT SUPPLY, not a clock.
+
+    An event-triggered loop has no cadence, so "overdue" is undefined in the
+    abstract — inventing a pseudo-cron for it would be a fabricated oracle. The
+    honest observable is conditional:
+
+        a `pull_request` loop is expected to have run only when a pull request
+        actually happened.
+
+    So `max_stale_days` does double duty as the width of the supply window and
+    the response tolerance:
+
+      * newest triggering event older than the window  -> QUIET. Nothing was
+        owed, so the guard says nothing. This is the "quiet but healthy" arm; a
+        repo with no PRs this week must not turn the board red.
+      * event inside the window, no completed run ever -> silent_green (red),
+        subject to the same newborn grace as #850.
+      * event inside the window, newest completed run older than the window
+        -> stale (red). This is the #844 shape: events kept arriving, the loop
+        stopped answering, and nothing enumerated it.
+      * newest completed run did not conclude 'success' -> failed_run (red),
+        matching _eval_workflow_run. For a PR loop this self-clears on the next
+        PR, so a one-off flake fades while a persistently broken loop stays red.
+
+    LIMIT, stated plainly: this proves the loop was DISPATCHED and did not fail,
+    not that its output was VALID. The specific #844 incident (runs green,
+    review body a placeholder) is only caught here via the run conclusion, which
+    exists because #840 made that failure loud. Asserting the artifact itself
+    needs per-workflow proof declarations in the registry — see the report.
+    """
+    event = spec["event"]
+    max_days = float(spec["max_stale_days"])
+
+    actual_events = workflow_events(workflows_dir, workflow)
+    if actual_events is None:
+        return ("activation_mismatch",
+                "declared event-triggered producer workflow is missing")
+    if event not in actual_events:
+        return ("activation_mismatch",
+                f"declared as an `{event}` producer but the workflow's `on:` "
+                f"triggers are {sorted(actual_events)}")
+
+    newest_event_iso, run = event_supply_runner(workflow, event, repository, token)
+    newest_event = _parse_iso(newest_event_iso)
+    if newest_event is None or _age_days(newest_event, now) > max_days:
+        return ("healthy",
+                f"quiet: no `{event}` event within the last {max_days:g}d, so no "
+                "run was owed (event-triggered loops are judged by event supply, "
+                "not by a clock)")
+    event_age = _age_days(newest_event, now)
+
+    if run is None:
+        kind, detail = ("silent_green",
+                        f"a `{event}` event arrived {event_age:.1f}d ago but the "
+                        "workflow has no completed run at all")
+        return _apply_newborn_grace(
+            kind, detail, workflow, max_days, now, repo_root, workflows_dir,
+            default_branch, git_runner,
+        )
+    if not isinstance(run, dict):
+        raise AdapterError(f"event-supply adapter returned invalid run data for {workflow}")
+
+    conclusion = run.get("conclusion")
+    url = run.get("html_url") or "(no run URL)"
+    if conclusion != "success":
+        return ("failed_run",
+                f"newest completed `{event}` run concluded {conclusion!r}: {url}")
+
+    newest_run = _parse_iso(run.get("run_started_at") or run.get("created_at"))
+    if newest_run is None:
+        return ("malformed_proof",
+                f"newest completed `{event}` run has no parseable start timestamp")
+    run_age = _age_days(newest_run, now)
+    if run_age > max_days:
+        return ("stale",
+                f"a `{event}` event arrived {event_age:.1f}d ago but the newest "
+                f"completed run is {run_age:.1f}d old (threshold {max_days:g}d): "
+                f"{url}")
+    return ("healthy",
+            f"answering `{event}` supply: newest event {event_age:.1f}d ago, "
+            f"newest successful run {run_age:.1f}d ago (threshold {max_days:g}d): "
+            f"{url}")
+
+
 # ---------------------------------------------------------------------------
 # per-loop evaluation
 # ---------------------------------------------------------------------------
+
+def _apply_newborn_grace(
+    kind: str,
+    detail: str,
+    workflow: str,
+    grace_days: float,
+    now: datetime,
+    repo_root: Path,
+    workflows_dir: Path,
+    default_branch: str,
+    git_runner,
+) -> tuple[str, str]:
+    """Withhold a no-evidence-ever finding while the loop is still newborn (#850).
+
+    "No evidence ever" is ambiguous: a daily loop with nothing after three days
+    is dead, but a monthly loop added eleven days ago has simply not reached its
+    first scheduled opportunity — and an event-triggered loop added yesterday
+    cannot have answered a pull request opened the day before it existed.
+    Alarming on the newborn is a false positive, and a guard that cries wolf is
+    one people stop reading, which is exactly how a real dead loop hides.
+
+    The grace window is the loop's OWN max_stale_days, measured from the
+    default-branch add-commit. Reasons for that exact boundary:
+      * It is already cadence-scaled (35d monthly, 1d for a */15 loop), so no
+        cron arithmetic and no second dial to keep in sync with the first.
+      * It is the tolerance the loop's author already declared as "longer than
+        this without output means dead". A newborn cannot be judged by a softer
+        standard than a running loop without inventing a weaker one.
+      * It is therefore not over-broad: a missed FIRST run surfaces exactly as
+        late as a missed subsequent run already does, no later.
+    Silence past that window is proof of death and still turns the board red.
+    """
+    added = workflow_added_at(
+        workflow, workflows_dir, repo_root, default_branch, git_runner
+    )
+    if added is None:
+        return kind, detail
+    age = _age_days(added, now)
+    if age > grace_days:
+        return kind, detail
+    return (
+        "newborn",
+        f"added to `{default_branch}` {age:.1f}d ago and has not yet had a "
+        f"full {grace_days:g}d window to produce evidence — "
+        f"withheld until then, after which silence is red. Original finding: "
+        f"{detail}",
+    )
 
 def _evaluate_loop(
     loop: dict,
@@ -531,37 +815,10 @@ def _evaluate_loop(
     if kind != "silent_green":
         return kind, detail
 
-    # Newborn grace (#850). "No evidence ever" is ambiguous: a daily loop with
-    # nothing after three days is dead, but a monthly loop added eleven days
-    # ago has simply not reached its first scheduled opportunity. Alarming on
-    # the newborn is a false positive, and a guard that cries wolf is one
-    # people stop reading — which is exactly how a real dead loop hides.
-    #
-    # The grace window is the loop's OWN max_stale_days, measured from the
-    # default-branch add-commit. Reasons for that exact boundary:
-    #   * It is already cadence-scaled (35d monthly, 1d for a */15 loop), so no
-    #     cron arithmetic and no second dial to keep in sync with the first.
-    #   * It is the tolerance the loop's author already declared as "longer
-    #     than this without output means dead". A newborn cannot be judged by a
-    #     softer standard than a running loop without inventing a weaker one.
-    #   * It is therefore not over-broad: a missed FIRST run surfaces exactly as
-    #     late as a missed subsequent run already does, no later.
-    # Silence past that window is proof of death and still turns the board red.
-    grace_days = float(proof["max_stale_days"])
-    added = workflow_added_at(
-        wf, workflows_dir, repo_root, default_branch, git_runner
-    )
-    if added is None:
-        return kind, detail
-    age = _age_days(added, now)
-    if age > grace_days:
-        return kind, detail
-    return (
-        "newborn",
-        f"added to `{default_branch}` {age:.1f}d ago and has not yet had a "
-        f"full {grace_days:g}d window to produce evidence — "
-        f"withheld until then, after which silence is red. Original finding: "
-        f"{detail}",
+    # Newborn grace (#850) — rationale lives on _apply_newborn_grace.
+    return _apply_newborn_grace(
+        kind, detail, wf, float(proof["max_stale_days"]), now, repo_root,
+        workflows_dir, default_branch, git_runner,
     )
 
 
@@ -577,6 +834,8 @@ def evaluate(
     repo_root: Path,
     git_runner=default_git_runner,
     actions_runner=default_actions_runner,
+    event_supply_runner=default_event_supply_runner,
+    event_producers: dict | None = None,
     repository: str = "",
     token: str = "",
 ) -> list[dict]:
@@ -589,6 +848,8 @@ def evaluate(
     monitors = set(registry.get("monitors") or [])
     default_branch = registry.get("default_branch") or DEFAULT_BRANCH
     loops = registry.get("loops") or []
+    if event_producers is None:
+        event_producers = EVENT_PRODUCERS
 
     registered: dict[str, dict] = {}
     findings: list[dict] = []
@@ -646,6 +907,37 @@ def evaluate(
                 repository,
                 token,
                 crons,
+            )
+        except AdapterError as exc:
+            kind, detail = "adapter_error", str(exc)
+        except ConfigError as exc:
+            kind, detail = "config_error", str(exc)
+        findings.append({"workflow": wf, "kind": kind, "detail": detail})
+
+    # Event-triggered producers (#844): no cron, so scheduled_workflows() below
+    # cannot see them and the registry cannot express them. Evaluated from the
+    # in-code declaration against live event supply.
+    for wf in sorted(event_producers):
+        if wf in monitors or wf in registered:
+            findings.append({
+                "workflow": wf,
+                "kind": "config_error",
+                "detail": "workflow is declared as an event-triggered producer "
+                          "and also registered as a monitor or scheduled loop",
+            })
+            continue
+        try:
+            kind, detail = _eval_event_producer(
+                wf,
+                event_producers[wf],
+                now,
+                repo_root,
+                workflows_dir,
+                default_branch,
+                git_runner,
+                event_supply_runner,
+                repository,
+                token,
             )
         except AdapterError as exc:
             kind, detail = "adapter_error", str(exc)

--- a/scripts/ecosystem_freshness.py
+++ b/scripts/ecosystem_freshness.py
@@ -19,7 +19,10 @@ Event-triggered producers (#844) have no cron and so cannot be expressed in that
 registry at all — an `active` entry requires at least one cron expression, and
 the schema is closed to new fields. They are declared in EVENT_PRODUCERS below
 and judged against their EVENT SUPPLY rather than a clock: a `pull_request` loop
-is only expected to have run when a pull request actually happened. See
+is only expected to have run when a pull request actually happened. Supply is
+bounded below by a declared per-event ACTIVATION CUTOFF, because changing a
+workflow's trigger does not replay the events that predate it, and closing a pull
+request does not discharge an obligation its head never had a run for. See
 _eval_event_producer for the semantics and their stated limit.
 
 Findings and exit codes (a producer with a real problem must fail CI):
@@ -47,7 +50,7 @@ import glob as globmod
 import json
 import os
 import sys
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
@@ -81,13 +84,59 @@ ALLOWED_MONITORS = {
 # The secured workflow from #935 uses `pull_request_target`; the legacy branch
 # uses `pull_request`. Exactly one must be active, and both share the same PR/head
 # supply adapter.
+#
+# `activation` is the ACTIVATION CUTOFF per event: the instant from which this
+# monitor may infer an obligation for that event. It exists because changing a
+# workflow's trigger does not synthesize `opened`/`synchronize` events for heads
+# that already exist — a head pushed before `pull_request_target` was ever
+# configured cannot have a `pull_request_target` run, and demanding one invents a
+# retroactive obligation the producer never owed. It is deliberately NOT derived
+# from the workflow file's creation (or last-modified) date: a file's git history
+# says when text changed, not when GitHub began dispatching that event, and
+# committer dates are author-controlled anyway.
+#
+# The source of truth is the activation decision itself, recorded here by the
+# human who activates enforcement, and every PR head observed before it is
+# explicitly waived as pre-cutover. It doubles as the relevant-history boundary
+# for retrieval, so the supply adapter never walks the whole PR archive.
+#
+#   pull_request         2026-08-03T00:00:00Z — the instant per-head obligation
+#     enforcement is activated. #844's event-supply binding has never run on the
+#     default branch (its commit is part of this change), so no head observed
+#     before activation has a recorded obligation and none may be inferred.
+#
+#   pull_request_target  None — GuitarAlchemist/Demerzel PR #935 performs the
+#     trigger migration and has not merged, so the cutover instant does not exist
+#     yet. `None` is not a hole: _eval_event_producer raises ConfigError (exit 2)
+#     if this event is ever the ACTIVE one without a cutoff, so the board goes red
+#     rather than fabricating obligations for pre-cutover heads. Whoever merges
+#     #935 replaces this None with that merge commit's instant on the default
+#     branch, in the same change that flips the trigger.
 EVENT_PRODUCERS: dict[str, dict] = {
     "cross-model-review.yml": {
         "events": ["pull_request", "pull_request_target"],
         "activities": ["opened", "synchronize"],
         "max_stale_days": 3,
+        "activation": {
+            "pull_request": "2026-08-03T00:00:00Z",
+            "pull_request_target": None,
+        },
     },
 }
+
+# Hard pagination ceilings for the event-supply adapter. Retrieval that has not
+# reached the activation cutoff within this many pages is INCOMPLETE, and
+# incomplete retrieval must never be read as "no run exists" — it raises
+# AdapterError (exit 2) instead. 100 items/page.
+_MAX_SUPPLY_PAGES = 20
+
+# Timestamps are issued by GitHub but compared against the runner's clock, so a
+# genuinely fresh event can read a hair "in the future" under NTP skew. Rejecting
+# those as forged would be pure cry-wolf. The tolerance is deliberately tiny
+# against a response allowance measured in days: it buys an attacker five minutes
+# of an allowance they can already refresh by pushing, while removing a false-red
+# that would train people to ignore this guard.
+_CLOCK_SKEW_TOLERANCE = timedelta(minutes=5)
 
 for _stream in (sys.stdout, sys.stderr):  # Windows consoles default to cp1252.
     if hasattr(_stream, "reconfigure"):
@@ -211,22 +260,152 @@ def _github_get(endpoint: str, token: str, what: str):
         ) from exc
 
 
+def _collect_relevant_pulls(
+    repo_path: str,
+    repository: str,
+    event: str,
+    token: str,
+    since: datetime,
+) -> list[dict]:
+    """Pull requests with GitHub-recorded activity at or after `since`.
+
+    `state=all`, not `state=open`. A merged or closed pull request does NOT
+    discharge an obligation whose head never got a correlated run: closing a PR
+    is not an answer to it, and only a correlated terminal run resolves an
+    obligation. Requesting open PRs alone let a merge erase the evidence and the
+    monitor turn green — the exact silent-green failure this guard exists for.
+
+    Survival is bounded, not unbounded: `since` is the activation cutoff, so the
+    archive is walked back to that instant and no further.
+
+    `updated_at` is used ONLY as this retrieval boundary, never as dispatch
+    evidence. Every head push bumps it, so a PR whose head moved after `since`
+    can never be paginated away; comments, labels and merges bump it too, which
+    is exactly why it is not proof that a dispatch happened.
+    """
+    pulls: list[dict] = []
+    page = 1
+    while True:
+        pull_page = _github_get(
+            f"https://api.github.com/repos/{repo_path}/pulls?"
+            + urlencode({
+                "state": "all",
+                "sort": "updated",
+                "direction": "desc",
+                "per_page": 100,
+                "page": page,
+            }),
+            token,
+            f"{event} supply on {repository} page {page}",
+        )
+        if not isinstance(pull_page, list):
+            raise AdapterError(
+                f"GitHub API returned malformed pull data for {repository}"
+            )
+        reached_boundary = False
+        for index, entry in enumerate(pull_page):
+            if not isinstance(entry, dict):
+                raise AdapterError(
+                    f"GitHub API returned malformed pull at index {index} for "
+                    f"{repository}"
+                )
+            updated_at = _parse_iso(entry.get("updated_at"))
+            if updated_at is None:
+                raise AdapterError(
+                    f"GitHub API returned malformed pull updated_at for "
+                    f"{repository}"
+                )
+            if updated_at < since:
+                reached_boundary = True
+                continue
+            pulls.append(entry)
+        if reached_boundary or len(pull_page) < 100:
+            return pulls
+        page += 1
+        if page > _MAX_SUPPLY_PAGES:
+            raise AdapterError(
+                f"{event} supply on {repository} did not reach the activation "
+                f"cutoff {since.isoformat()} within {_MAX_SUPPLY_PAGES} pages; "
+                "retrieval is incomplete and cannot be read as absence"
+            )
+
+
+def _collect_target_runs(
+    repo_path: str,
+    workflow: str,
+    event: str,
+    token: str,
+    since: datetime,
+) -> list:
+    """Every `pull_request_target` run back to the activation cutoff.
+
+    The newest page alone is not enough. `pull_request_target` runs cannot be
+    filtered by head SHA (they execute against the trusted BASE commit), so the
+    adapter correlates them client-side out of a listing — and a listing capped
+    at one page silently drops any valid run beyond the newest 100. Its
+    obligation then reads "no run", which is a fabricated alarm indistinguishable
+    from a real one.
+
+    Retrieval stops at the relevant-history boundary, and retrieval that cannot
+    reach it raises instead of reporting absence.
+    """
+    runs: list = []
+    page = 1
+    while True:
+        payload = _github_get(
+            f"https://api.github.com/repos/{repo_path}/actions/workflows/"
+            f"{quote(workflow, safe='')}/runs?"
+            + urlencode({"event": event, "per_page": 100, "page": page}),
+            token,
+            f"{workflow} secured pull-request runs page {page}",
+        )
+        page_runs = (payload.get("workflow_runs")
+                     if isinstance(payload, dict) else None)
+        if not isinstance(page_runs, list):
+            raise AdapterError(
+                f"GitHub Actions API returned malformed run data for {workflow}"
+            )
+        runs.extend(page_runs)
+        if len(page_runs) < 100:
+            return runs
+        oldest = page_runs[-1]
+        oldest_at = (
+            _parse_iso(oldest.get("created_at") or oldest.get("run_started_at"))
+            if isinstance(oldest, dict) else None
+        )
+        # An unparseable boundary timestamp is not permission to stop early; keep
+        # paging and let the ceiling below convert the ambiguity into a failure.
+        if oldest_at is not None and oldest_at < since:
+            return runs
+        page += 1
+        if page > _MAX_SUPPLY_PAGES:
+            raise AdapterError(
+                f"{workflow} `{event}` runs did not reach the activation cutoff "
+                f"{since.isoformat()} within {_MAX_SUPPLY_PAGES} pages; retrieval "
+                "is incomplete and cannot be read as absence"
+            )
+
+
 def default_event_supply_runner(
     workflow: str,
     event: str,
     repository: str,
     token: str,
     activities: tuple[str, ...] = ("opened", "synchronize"),
+    since: datetime | None = None,
 ) -> list[tuple[dict, dict | None]]:
     """Return PR/head dispatch obligations and their exact-head candidate runs.
 
-    Every open pull request is evaluated, so one healthy PR cannot mask another.
-    `updated_at` is deliberately not evidence: comments, labels, merges, and
-    other non-dispatch activity all change it. The observable obligation is each
-    PR's current head SHA. A matching Actions run supplies the dispatch time; if
-    no run exists, the head commit date is the conservative head-correlated
-    lower bound. Both configured activities remain explicit because current API
-    state cannot soundly distinguish an opening head from a synchronized head.
+    Every pull request with activity since the activation cutoff is evaluated —
+    open or closed — so neither one healthy PR nor a merge button can mask an
+    unanswered one. `updated_at` is deliberately not evidence: comments, labels,
+    merges, and other non-dispatch activity all change it. The observable
+    obligation is each PR's head SHA. A matching Actions run supplies the
+    dispatch time; if no run exists, the head commit date is used only as a hint
+    bounded by the GitHub-controlled `[created_at, updated_at]` envelope, because
+    the commit date is written by whoever authored the commit. Both configured
+    activities remain explicit because current API state cannot soundly
+    distinguish an opening head from a synchronized head.
     """
     if not repository or "/" not in repository:
         raise AdapterError(
@@ -241,66 +420,48 @@ def default_event_supply_runner(
         raise AdapterError(
             f"unsupported pull_request activities for event supply: {activities!r}"
         )
+    if since is None:
+        raise AdapterError(
+            f"event-supply proof requires an explicit activation cutoff for "
+            f"`{event}`; without one the relevant history has no boundary"
+        )
 
     repo_path = quote(repository, safe="/")
-    pulls: list = []
-    page = 1
-    while True:
-        pull_page = _github_get(
-            f"https://api.github.com/repos/{repo_path}/pulls?"
-            + urlencode({
-                "state": "open",
-                "sort": "updated",
-                "direction": "desc",
-                "per_page": 100,
-                "page": page,
-            }),
-            token,
-            f"{event} supply on {repository} page {page}",
-        )
-        if not isinstance(pull_page, list):
-            raise AdapterError(
-                f"GitHub API returned malformed pull data for {repository}"
-            )
-        pulls.extend(pull_page)
-        if len(pull_page) < 100:
-            break
-        page += 1
+    pulls = _collect_relevant_pulls(repo_path, repository, event, token, since)
     if not pulls:
         return []
 
     supplies: list[tuple[dict, dict | None]] = []
     target_runs: list | None = None
     if event == "pull_request_target":
-        target_payload = _github_get(
-            f"https://api.github.com/repos/{repo_path}/actions/workflows/"
-            f"{quote(workflow, safe='')}/runs?"
-            + urlencode({"event": event, "per_page": 100}),
-            token,
-            f"{workflow} secured pull-request runs",
+        target_runs = _collect_target_runs(
+            repo_path, workflow, event, token, since
         )
-        target_runs = (target_payload.get("workflow_runs")
-                       if isinstance(target_payload, dict) else None)
-        if not isinstance(target_runs, list):
-            raise AdapterError(
-                f"GitHub Actions API returned malformed run data for {workflow}"
-            )
 
     for index, pull in enumerate(pulls):
-        if not isinstance(pull, dict):
-            raise AdapterError(
-                f"GitHub API returned malformed pull at index {index} for {repository}"
-            )
         pull_number = pull.get("number")
         created_at = _parse_iso(pull.get("created_at"))
+        updated_at = _parse_iso(pull.get("updated_at"))
+        pull_state = pull.get("state")
         head = pull.get("head")
         head_sha = head.get("sha") if isinstance(head, dict) else None
         if (not isinstance(pull_number, int) or isinstance(pull_number, bool)
-                or created_at is None
+                or created_at is None or updated_at is None
+                or pull_state not in {"open", "closed"}
                 or not isinstance(head_sha, str) or not head_sha.strip()):
             raise AdapterError(
                 f"GitHub API returned malformed pull at index {index} for "
-                f"{repository}: integer number, created_at, and head.sha are required"
+                f"{repository}: integer number, created_at, updated_at, state, "
+                "and head.sha are required"
+            )
+        # GitHub never records a pull request as updated before it was created.
+        # If it appears to, the envelope this adapter bounds author-controlled
+        # timestamps against is itself untrustworthy — fail closed.
+        if created_at > updated_at:
+            raise AdapterError(
+                f"GitHub API returned an implausible pull timeline for "
+                f"#{pull_number} on {repository}: created_at is newer than "
+                "updated_at"
             )
 
         if target_runs is None:
@@ -333,6 +494,7 @@ def default_event_supply_runner(
                             for identity in candidate["pull_requests"]
                         )), None)
 
+        malformed_reason: str | None = None
         if run is None:
             commit = _github_get(
                 f"https://api.github.com/repos/{repo_path}/commits/"
@@ -350,7 +512,29 @@ def default_event_supply_runner(
                 raise AdapterError(
                     f"GitHub API returned malformed head commit time for {head_sha}"
                 )
-            occurred_at = max(created_at, commit_at)
+            # The committer date is written by whoever produced the commit, so it
+            # is NOT the authority for allowance aging. Dating an obligation from
+            # `2099-01-01` would hold it "pending" for decades and silence this
+            # guard for as long as the PR author likes.
+            #
+            # The GitHub-controlled envelope for when this head became the PR
+            # head is [created_at, updated_at]: the obligation cannot predate the
+            # pull request, and a head push always bumps updated_at. Inside that
+            # envelope the commit date is a useful refinement — it distinguishes a
+            # head pushed an hour ago from the day the PR was opened. Outside it,
+            # on the late side, it is not evidence but a forged clock, and forged
+            # evidence is reported as malformed proof (red) rather than clamped
+            # and believed.
+            if commit_at > updated_at:
+                malformed_reason = (
+                    f"head commit date {commit_at_raw!r} is newer than the pull "
+                    f"request's GitHub-recorded last activity "
+                    f"({pull.get('updated_at')!r}); an author-controlled commit "
+                    "date cannot extend the response allowance"
+                )
+                occurred_at = updated_at
+            else:
+                occurred_at = max(created_at, commit_at)
         else:
             if not isinstance(run, dict):
                 raise AdapterError(
@@ -376,12 +560,16 @@ def default_event_supply_runner(
                 run = dict(run)
                 run["associated_pull_requests"] = associated_pulls
 
-        supplies.append(({
+        obligation = {
             "activities": list(activities),
             "occurred_at": occurred_at.isoformat(),
             "pull_number": pull_number,
             "head_sha": head_sha,
-        }, run))
+            "pull_state": pull_state,
+        }
+        if malformed_reason:
+            obligation["malformed_reason"] = malformed_reason
+        supplies.append((obligation, run))
     return supplies
 
 
@@ -728,13 +916,22 @@ def _eval_event_producer(
         a `pull_request` loop is expected to have run only when a pull request
         actually happened.
 
-    Each sampled pull request contributes its current PR/head identity, so one
-    answered PR cannot mask another unanswered one. Opening and synchronize stay
-    explicit as a candidate activity set: generic `updated_at` is not dispatch
-    evidence. A run answers only when both its PR number and head SHA match; a
-    newer global run for another PR is irrelevant. Queued, in-progress, absent,
-    or mismatched runs remain pending within `max_stale_days` and turn red only
-    after that response allowance. A correlated completed failure is red at once.
+    Each sampled pull request contributes its PR/head identity, so one answered
+    PR cannot mask another unanswered one — and closing or merging a PR does not
+    discharge its obligation, because a merge is not an answer. Opening and
+    synchronize stay explicit as a candidate activity set: generic `updated_at`
+    is not dispatch evidence. A run answers only when both its PR number and head
+    SHA match; a newer global run for another PR is irrelevant. Queued,
+    in-progress, absent, or mismatched runs remain pending within
+    `max_stale_days` and turn red only after that response allowance. A
+    correlated completed failure is red at once.
+
+    Obligations are bounded below by the event's ACTIVATION CUTOFF (declared in
+    EVENT_PRODUCERS). Heads observed before it are explicitly waived: changing a
+    workflow's trigger does not synthesize `opened`/`synchronize` events for
+    heads that already exist, so demanding a run for them would manufacture
+    alarms no producer could ever answer. An event that is active on disk with no
+    declared cutoff is a ConfigError, not a free pass.
 
     LIMIT, stated plainly: this proves the loop was DISPATCHED and did not fail,
     not that its output was VALID. The specific #844 incident (runs green,
@@ -776,12 +973,41 @@ def _eval_event_producer(
             f"match workflow activities {sorted(configured_activities or [])}",
         )
 
+    # Activation cutoff for the SELECTED event. Absent or unusable is fail-closed:
+    # inferring obligations from an unknown activation instant is exactly the
+    # retroactive-obligation defect this boundary exists to prevent.
+    activation = spec.get("activation")
+    if not isinstance(activation, dict) or event not in activation:
+        raise ConfigError(
+            f"{workflow}: no activation cutoff is declared for `{event}`; an "
+            "event-triggered producer cannot be judged without the instant from "
+            "which it began owing runs"
+        )
+    cutoff_raw = activation[event]
+    cutoff = _parse_iso(cutoff_raw) if isinstance(cutoff_raw, str) else None
+    if cutoff is None:
+        raise ConfigError(
+            f"{workflow}: `{event}` is the active trigger but its activation "
+            f"cutoff is {cutoff_raw!r}. Changing a trigger does not synthesize "
+            "past events, so obligations must not be inferred before the instant "
+            "the trigger went live on the default branch. Record that instant "
+            "(or waive the event) in EVENT_PRODUCERS before this producer can be "
+            "judged"
+        )
+    if cutoff > now:
+        raise ConfigError(
+            f"{workflow}: `{event}` activation cutoff {cutoff.isoformat()} is in "
+            "the future, which would waive every obligation and leave this guard "
+            "reading green while blind"
+        )
+
     supplies = event_supply_runner(
         workflow,
         event,
         repository,
         token,
         tuple(sorted(declared_activities)),
+        cutoff,
     )
     if not isinstance(supplies, list):
         raise AdapterError(
@@ -789,10 +1015,12 @@ def _eval_event_producer(
         )
     if not supplies:
         return ("healthy",
-                f"quiet: no `{event}` event has ever occurred, so no run was owed "
+                f"quiet: no `{event}` event has occurred since the "
+                f"{cutoff.isoformat()} activation cutoff, so no run was owed "
                 "(event-triggered loops are judged by event supply, not by a clock)")
 
     results: list[tuple[str, str]] = []
+    waived = 0
     for item in supplies:
         if not isinstance(item, (list, tuple)) or len(item) != 2:
             results.append((
@@ -826,11 +1054,46 @@ def _eval_event_producer(
             ))
             continue
 
-        event_age = _age_days(occurred_at, now)
         activity_label = "/".join(sorted(declared_activities))
-        obligation_label = (
-            f"PR #{pull_number} `{activity_label}` at {head_sha[:12]}"
+        pull_state = obligation.get("pull_state")
+        state_label = (
+            f" ({pull_state})" if pull_state in {"open", "closed"} else ""
         )
+        obligation_label = (
+            f"PR #{pull_number}{state_label} `{activity_label}` at {head_sha[:12]}"
+        )
+
+        # A monitor cannot have observed an event that has not happened yet. A
+        # future observation time is a broken or forged clock, and believing it
+        # would grant an allowance that never expires.
+        if occurred_at > now + _CLOCK_SKEW_TOLERANCE:
+            results.append((
+                "malformed_proof",
+                f"{obligation_label} claims an observation time of "
+                f"{obligation.get('occurred_at')!r}, which is in the future; a "
+                "timestamp the monitor cannot have observed is not proof",
+            ))
+            continue
+
+        # Pre-cutover head: explicitly waived, never silently dropped. The count
+        # is reported in the summary so a waiver can be audited rather than
+        # mistaken for an absence of pull requests.
+        if occurred_at < cutoff:
+            waived += 1
+            continue
+
+        # Evidence the adapter could retrieve but not trust (see
+        # default_event_supply_runner) is red, not clamped-and-believed.
+        malformed_reason = obligation.get("malformed_reason")
+        if malformed_reason:
+            results.append((
+                "malformed_proof",
+                f"{obligation_label} has untrustworthy timing evidence: "
+                f"{malformed_reason}",
+            ))
+            continue
+
+        event_age = _age_days(occurred_at, now)
         if run is None:
             if event_age <= max_days:
                 results.append((
@@ -946,6 +1209,16 @@ def _eval_event_producer(
             f"({_age_days(run_started, now):.1f}d ago): {url}",
         ))
 
+    waiver_note = (
+        f" ({waived} pre-cutoff obligation(s) waived at {cutoff.isoformat()})"
+        if waived else ""
+    )
+    if not results:
+        return ("healthy",
+                f"quiet: every observed `{event}` obligation{waiver_note} "
+                "predates the activation cutoff and is explicitly waived — "
+                "changing a trigger does not synthesize past events")
+
     priority = {
         "malformed_proof": 4,
         "failed_run": 3,
@@ -956,7 +1229,7 @@ def _eval_event_producer(
         "healthy": 0,
     }
     kind, detail = max(results, key=lambda result: priority.get(result[0], 5))
-    return kind, f"evaluated {len(results)} PR obligation(s): {detail}"
+    return kind, f"evaluated {len(results)} PR obligation(s){waiver_note}: {detail}"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ecosystem_freshness.py
+++ b/scripts/ecosystem_freshness.py
@@ -627,11 +627,10 @@ def _eval_event_producer(
 
     newest_event_iso, run = event_supply_runner(workflow, event, repository, token)
     newest_event = _parse_iso(newest_event_iso)
-    if newest_event is None or _age_days(newest_event, now) > max_days:
+    if newest_event is None:
         return ("healthy",
-                f"quiet: no `{event}` event within the last {max_days:g}d, so no "
-                "run was owed (event-triggered loops are judged by event supply, "
-                "not by a clock)")
+                f"quiet: no `{event}` event has ever occurred, so no run was owed "
+                "(event-triggered loops are judged by event supply, not by a clock)")
     event_age = _age_days(newest_event, now)
 
     if run is None:
@@ -656,15 +655,55 @@ def _eval_event_producer(
         return ("malformed_proof",
                 f"newest completed `{event}` run has no parseable start timestamp")
     run_age = _age_days(newest_run, now)
-    if run_age > max_days:
+
+    # Compare the run to the EVENT it should have answered — not both to the clock.
+    #
+    # The first version of this adapter tested `event_age <= max_days AND run_age >
+    # max_days`, i.e. both against `now`. That makes the detection window exactly as wide
+    # as the gap between the dead loop's last run and the unanswered event, and then it
+    # closes: once the event ages past max_days the quiet arm returns healthy and a dead
+    # loop reads green FOREVER. Worked example — loop answers PR A at 09:00 and dies, PR B
+    # opens at 15:00, repo goes quiet: `stale` is true only between run_age=3d and
+    # event_age=3d, a six-hour window, and this guard runs once a day
+    # (ecosystem-freshness.yml, cron `15 13 * * *`). Evidence of death decayed at exactly
+    # the rate the obligation did. Caught in adversarial review before merge.
+    #
+    # Ordering has no window. An event newer than the newest run is unanswered, and stays
+    # unanswered until a run actually answers it, so the finding is STICKY: missing one
+    # daily sweep costs nothing. max_days stops being a detection threshold and becomes a
+    # pure response allowance — how long the loop may take to answer — which is what the
+    # registry field should have meant here all along. It also removes an unstated
+    # coupling: detection no longer requires max_days to exceed this guard's own cadence.
+    if newest_run >= newest_event:
+        return ("healthy",
+                f"answering `{event}` supply: newest successful run ({run_age:.1f}d ago) "
+                f"postdates the newest event ({event_age:.1f}d ago): {url}")
+
+    # The newest event is UNANSWERED. Two independent ways that becomes overdue, and the
+    # loop is dead if either holds — neither alone is sufficient:
+    #
+    #   unanswered_for : how long this event has gone unanswered (now - event). Grows
+    #                    without bound, so it catches a loop that died just before a final
+    #                    event and then went quiet — the case a lag-only test misses,
+    #                    because there the lag is fixed and small.
+    #   lag            : how far the run already trailed the event when it arrived
+    #                    (event - run). Catches a loop that has been behind for a long
+    #                    time even though its newest event is recent — the case an
+    #                    age-only test misses for up to the full allowance.
+    #
+    # Both are monotonic while the loop stays dead, so the finding is STICKY once it
+    # fires: unlike the previous `event_age <= max AND run_age > max` form, there is no
+    # window to miss and no path back to green except an actual answering run.
+    unanswered_for = event_age
+    lag = _age_days(newest_run, newest_event)
+    if unanswered_for > max_days or lag > max_days:
         return ("stale",
-                f"a `{event}` event arrived {event_age:.1f}d ago but the newest "
-                f"completed run is {run_age:.1f}d old (threshold {max_days:g}d): "
-                f"{url}")
+                f"a `{event}` event arrived {event_age:.1f}d ago and is still "
+                f"unanswered: the newest completed run started {run_age:.1f}d ago, "
+                f"{lag:.1f}d BEFORE that event (allowance {max_days:g}d): {url}")
     return ("healthy",
-            f"answering `{event}` supply: newest event {event_age:.1f}d ago, "
-            f"newest successful run {run_age:.1f}d ago (threshold {max_days:g}d): "
-            f"{url}")
+            f"a `{event}` event arrived {event_age:.1f}d ago and is not answered yet, "
+            f"still within the {max_days:g}d response allowance: {url}")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/test_ecosystem_freshness.py
+++ b/scripts/test_ecosystem_freshness.py
@@ -27,6 +27,9 @@ except ModuleNotFoundError:
     import ecosystem_freshness as ef
 
 NOW = datetime(2026, 7, 18, 12, 0, 0, tzinfo=timezone.utc)
+# Activation cutoff used by the adapter-level tests: old enough that none of
+# their fixtures are waived, so each test still exercises what it names.
+SINCE = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
 
 def _iso(dt: datetime) -> str:
@@ -129,6 +132,28 @@ class EcosystemFreshnessTest(unittest.TestCase):
 
     def _one(self, findings: list[dict], workflow: str) -> dict:
         return next(f for f in findings if f["workflow"] == workflow)
+
+    @staticmethod
+    def _json_urlopen(payloads, seen):
+        """urlopen stub serving `payloads` in request order, recording requests."""
+        class Response:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps(self.payload).encode()
+
+        def fake_urlopen(request, timeout):
+            seen.append(request)
+            return Response(payloads[len(seen) - 1])
+
+        return fake_urlopen
 
     # ── tracer-bullet outcomes ────────────────────────────────────────────
 
@@ -526,10 +551,19 @@ class EcosystemFreshnessTest(unittest.TestCase):
     # Both directions matter — a genuinely dead loop must fire, and a quiet but
     # healthy one must stay silent.
 
+    # The activation cutoff is deliberately far older than any event age these
+    # tests use, so cutoff waiving never silently swallows a case that is meant
+    # to be about liveness. Cutoff behaviour has its own tests below.
+    ACTIVATION = "2024-01-01T00:00:00Z"
+
     EVENT_SPEC = {"reviewer.yml": {
         "events": ["pull_request", "pull_request_target"],
         "activities": ["opened", "synchronize"],
         "max_stale_days": 3,
+        "activation": {
+            "pull_request": ACTIVATION,
+            "pull_request_target": ACTIVATION,
+        },
     }}
 
     def _event_repo(self, events=("pull_request",)):
@@ -540,7 +574,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
     def _supply(self, event_age_days=None, run_age_days=None,
                 conclusion="success", pull_number=17,
                 obligation_sha="current-head", run_sha="current-head",
-                run_pull_number=17):
+                run_pull_number=17, pull_state="open"):
         """Stub the (current dispatch obligation, candidate run) seam."""
         event_iso = (
             None if event_age_days is None
@@ -551,6 +585,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
             "occurred_at": event_iso,
             "pull_number": pull_number,
             "head_sha": obligation_sha,
+            "pull_state": pull_state,
         }
         run = None if run_age_days is None else {
             "status": "completed",
@@ -908,6 +943,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
         payloads = [
             [{
                 "number": 939,
+                "state": "open",
                 "created_at": "2026-07-18T09:00:00Z",
                 "updated_at": "2026-07-18T10:00:00Z",
                 "head": {"sha": "current-head"},
@@ -931,6 +967,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
             supplies = ef.default_event_supply_runner(
                 "cross-model-review.yml", "pull_request",
                 "GuitarAlchemist/Demerzel", "secret",
+                ("opened", "synchronize"), SINCE,
             )
         obligation, run = supplies[0]
         self.assertEqual(obligation, {
@@ -938,6 +975,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
             "occurred_at": "2026-07-18T09:00:03+00:00",
             "pull_number": 939,
             "head_sha": "current-head",
+            "pull_state": "open",
         })
         self.assertEqual(run, {
             "id": 7,
@@ -951,7 +989,9 @@ class EcosystemFreshnessTest(unittest.TestCase):
 
         pulls_q = parse_qs(urlparse(seen[0].full_url).query)
         self.assertEqual(pulls_q, {
-            "state": ["open"], "sort": ["updated"],
+            # `all`, not `open`: a merge is not an answer, so a closed pull
+            # request keeps its unresolved obligation visible.
+            "state": ["all"], "sort": ["updated"],
             "direction": ["desc"], "per_page": ["100"], "page": ["1"],
         })
         runs_q = parse_qs(urlparse(seen[1].full_url).query)
@@ -987,6 +1027,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
             supplies = ef.default_event_supply_runner(
                 "cross-model-review.yml", "pull_request",
                 "GuitarAlchemist/Demerzel", "secret",
+                ("opened", "synchronize"), SINCE,
             )
         self.assertEqual(supplies, [])
         self.assertEqual(len(seen), 1)
@@ -1010,6 +1051,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
         payloads = [
             [{
                 "number": 17,
+                "state": "closed",
                 "created_at": "2026-07-18T09:00:00Z",
                 "updated_at": "2026-07-18T10:00:00Z",
                 "head": {"sha": "merged-head"},
@@ -1033,6 +1075,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
             supplies = ef.default_event_supply_runner(
                 "cross-model-review.yml", "pull_request",
                 "GuitarAlchemist/Demerzel", "secret",
+                ("opened", "synchronize"), SINCE,
             )
         _, run = supplies[0]
         self.assertEqual(run["associated_pull_requests"], [{"number": 17}])
@@ -1057,6 +1100,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
         payloads = [
             [{
                 "number": 17,
+                "state": "open",
                 "created_at": "2026-07-18T09:00:00Z",
                 # A comment or label may cause this update; it is not a dispatch.
                 "updated_at": "2026-07-20T10:00:00Z",
@@ -1081,6 +1125,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
             supplies = ef.default_event_supply_runner(
                 "cross-model-review.yml", "pull_request",
                 "GuitarAlchemist/Demerzel", "secret",
+                ("opened", "synchronize"), SINCE,
             )
         obligation, _ = supplies[0]
         self.assertEqual(obligation["activities"], ["opened", "synchronize"])
@@ -1105,6 +1150,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
         payloads = [
             [{
                 "number": 17,
+                "state": "open",
                 "created_at": "2026-07-18T09:00:00Z",
                 "updated_at": "2026-07-20T10:00:00Z",
                 "head": {"sha": "unanswered-head"},
@@ -1121,10 +1167,14 @@ class EcosystemFreshnessTest(unittest.TestCase):
             supplies = ef.default_event_supply_runner(
                 "cross-model-review.yml", "pull_request",
                 "GuitarAlchemist/Demerzel", "secret",
+                ("opened", "synchronize"), SINCE,
             )
         obligation, run = supplies[0]
         self.assertIsNone(run)
+        # Inside the GitHub-controlled [created_at, updated_at] envelope, so the
+        # commit date is an accepted refinement rather than an authority.
         self.assertEqual(obligation["occurred_at"], "2026-07-19T11:00:00+00:00")
+        self.assertNotIn("malformed_reason", obligation)
         self.assertIn("/commits/unanswered-head", seen[2].full_url)
 
     def test_pull_request_target_adapter_matches_nested_pr_head_identity(self):
@@ -1146,7 +1196,9 @@ class EcosystemFreshnessTest(unittest.TestCase):
         payloads = [
             [{
                 "number": 17,
+                "state": "open",
                 "created_at": "2026-07-18T09:00:00Z",
+                "updated_at": "2026-07-18T09:30:00Z",
                 "head": {"sha": "pr-head"},
             }],
             {"workflow_runs": [{
@@ -1171,6 +1223,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
             supplies = ef.default_event_supply_runner(
                 "cross-model-review.yml", "pull_request_target",
                 "GuitarAlchemist/Demerzel", "secret",
+                ("opened", "synchronize"), SINCE,
             )
         _, run = supplies[0]
         self.assertEqual(run["id"], 7)
@@ -1193,6 +1246,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
                 ef.default_event_supply_runner(
                     "cross-model-review.yml", "pull_request",
                     "GuitarAlchemist/Demerzel", "secret",
+                    ("opened", "synchronize"), SINCE,
                 )
 
     def test_event_supply_adapter_rejects_an_unparseable_pull_timestamp(self):
@@ -1206,6 +1260,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
             def read(self):
                 return json.dumps([{
                     "number": 17,
+                    "state": "open",
                     "created_at": "not-a-timestamp",
                     "updated_at": "2026-07-18T10:00:00Z",
                     "head": {"sha": "current-head"},
@@ -1216,6 +1271,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
                 ef.default_event_supply_runner(
                     "cross-model-review.yml", "pull_request",
                     "GuitarAlchemist/Demerzel", "secret",
+                    ("opened", "synchronize"), SINCE,
                 )
 
     def test_event_supply_adapter_requires_repository_and_token(self):
@@ -1225,6 +1281,430 @@ class EcosystemFreshnessTest(unittest.TestCase):
             ef.default_event_supply_runner("w.yml", "pull_request", "o/r", "")
         with self.assertRaises(ef.AdapterError):
             ef.default_event_supply_runner("w.yml", "issues", "o/r", "t")
+
+    def test_event_supply_adapter_requires_an_activation_cutoff(self):
+        # Without a boundary the "relevant history" is unbounded and the waiver
+        # has no meaning; refuse rather than walk the whole archive.
+        with patch.object(ef, "urlopen",
+                          lambda *a, **k: self.fail("must not call API")):
+            with self.assertRaises(ef.AdapterError):
+                ef.default_event_supply_runner(
+                    "cross-model-review.yml", "pull_request",
+                    "GuitarAlchemist/Demerzel", "secret",
+                )
+
+    # ── obligations survive PR closure (adversarial review, defect 1) ──────
+    #
+    # Requesting only OPEN pull requests made the merge button an eraser: a PR
+    # whose head never got a correlated run vanished from the supply the moment
+    # it closed, and the monitor went green. Closing is not answering.
+
+    def _closed_obligation(self, days=4, head="unanswered-head"):
+        return {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW - timedelta(days=days)),
+            "pull_number": 17,
+            "head_sha": head,
+            "pull_state": "closed",
+        }
+
+    def test_unresolved_obligation_survives_its_pull_request_closing(self):
+        findings = self._event_findings(
+            lambda *args: [(self._closed_obligation(), None)]
+        )
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(
+            finding["kind"], "silent_green",
+            "closing a pull request must not discharge an obligation its head "
+            "never had a correlated run for")
+        self.assertIn("(closed)", finding["detail"])
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_closing_after_a_correlated_successful_run_is_not_an_alarm(self):
+        # The other direction: a PR that WAS answered and then merged is
+        # resolved, and resurrecting it would be pure cry-wolf.
+        run = {
+            "status": "completed",
+            "conclusion": "success",
+            "run_started_at": _iso(NOW - timedelta(days=4)),
+            "html_url": "https://example.test/answered",
+            "head_sha": "unanswered-head",
+            "pull_requests": [{"number": 17}],
+        }
+        findings = self._event_findings(
+            lambda *args: [(self._closed_obligation(), run)]
+        )
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "healthy")
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_a_merged_pull_request_cannot_erase_its_unanswered_obligation(self):
+        """End-to-end oracle for the erasure defect, adapter through evaluator.
+
+        The stub HONOURS the `state` query the way GitHub does, so asking for
+        open pull requests really does return nothing. That is the whole bug: the
+        one PR in this repo is closed and its head never got a run, and querying
+        `state=open` made the supply empty, which the evaluator correctly reads as
+        "no event ever happened" — green. The obligation was never discharged;
+        it was deleted.
+        """
+        merged_pull = {
+            "number": 17,
+            "state": "closed",
+            "created_at": "2026-07-10T09:00:00Z",
+            "updated_at": "2026-07-12T10:00:00Z",
+            "head": {"sha": "merged-head"},
+        }
+
+        def state_honouring_urlopen(request, timeout):
+            query = parse_qs(urlparse(request.full_url).query)
+            if "/pulls?" in request.full_url:
+                requested = query.get("state", ["open"])[0]
+                pulls = [merged_pull] if requested == "all" else []
+                return self._json_urlopen([pulls], [])(request, timeout)
+            if "/runs?" in request.full_url:
+                return self._json_urlopen(
+                    [{"workflow_runs": []}], [])(request, timeout)
+            return self._json_urlopen(
+                [{"commit": {"committer": {"date": "2026-07-11T09:00:00Z"}}}],
+                [])(request, timeout)
+
+        with patch.object(ef, "urlopen", state_honouring_urlopen):
+            supplies = ef.default_event_supply_runner(
+                "cross-model-review.yml", "pull_request",
+                "GuitarAlchemist/Demerzel", "secret",
+                ("opened", "synchronize"), SINCE,
+            )
+        self.assertEqual(
+            len(supplies), 1,
+            "a closed pull request whose head never ran must stay in the supply")
+        obligation, run = supplies[0]
+        self.assertIsNone(run)
+        self.assertEqual(obligation["pull_state"], "closed")
+
+        # …and the surviving obligation really does turn the board red.
+        findings = self._event_findings(lambda *args: supplies)
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "silent_green")
+        self.assertIn("(closed)", finding["detail"])
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    # ── bounded relevant history, not an unbounded archive walk ────────────
+
+    def test_pull_retrieval_stops_at_the_activation_cutoff(self):
+        seen = []
+        fresh = [{
+            "number": n,
+            "state": "open",
+            "created_at": "2026-07-17T00:00:00Z",
+            "updated_at": "2026-07-17T00:00:00Z",
+            "head": {"sha": f"h{n}"},
+        } for n in range(100)]
+        ancient = [{
+            "number": 999,
+            "state": "closed",
+            "created_at": "2023-01-01T00:00:00Z",
+            "updated_at": "2023-01-02T00:00:00Z",
+            "head": {"sha": "ancient"},
+        }]
+        with patch.object(ef, "urlopen",
+                          self._json_urlopen([fresh, ancient], seen)):
+            pulls = ef._collect_relevant_pulls(
+                "GuitarAlchemist/Demerzel", "GuitarAlchemist/Demerzel",
+                "pull_request", "secret", SINCE,
+            )
+        self.assertEqual(len(pulls), 100, "pre-cutoff pulls must be dropped")
+        self.assertEqual(len(seen), 2, "retrieval must stop at the boundary")
+
+    def test_incomplete_pull_retrieval_is_adapter_error_not_absence(self):
+        fresh = [{
+            "number": n,
+            "state": "open",
+            "created_at": "2026-07-17T00:00:00Z",
+            "updated_at": "2026-07-17T00:00:00Z",
+            "head": {"sha": f"h{n}"},
+        } for n in range(100)]
+        with patch.object(ef, "urlopen",
+                          self._json_urlopen([fresh] * 200, [])):
+            with self.assertRaises(ef.AdapterError):
+                ef._collect_relevant_pulls(
+                    "GuitarAlchemist/Demerzel", "GuitarAlchemist/Demerzel",
+                    "pull_request", "secret", SINCE,
+                )
+
+    # ── author-controlled commit dates cannot buy allowance (defect 2) ─────
+
+    def test_future_commit_timestamp_cannot_extend_the_allowance(self):
+        # A PR author controls the committer date. `2099-01-01` dated the
+        # obligation decades into the future, so `event_age` went negative, the
+        # obligation stayed forever "pending", and the guard never fired.
+        seen = []
+        payloads = [
+            [{
+                "number": 17,
+                "state": "open",
+                "created_at": "2026-06-01T09:00:00Z",
+                "updated_at": "2026-06-02T09:00:00Z",
+                "head": {"sha": "forged-head"},
+            }],
+            {"workflow_runs": []},
+            {"commit": {"committer": {"date": "2099-01-01T00:00:00Z"}}},
+        ]
+        with patch.object(ef, "urlopen",
+                          self._json_urlopen(payloads, seen)):
+            supplies = ef.default_event_supply_runner(
+                "cross-model-review.yml", "pull_request",
+                "GuitarAlchemist/Demerzel", "secret",
+                ("opened", "synchronize"), SINCE,
+            )
+        obligation, _ = supplies[0]
+        occurred_at = ef._parse_iso(obligation["occurred_at"])
+        self.assertLessEqual(
+            occurred_at, ef._parse_iso("2026-06-02T09:00:00Z"),
+            "the obligation must stay inside the GitHub-controlled envelope")
+        self.assertIn("malformed_reason", obligation)
+
+        # …and the evaluator reports it as bad evidence, not as a fresh event.
+        findings = self._event_findings(lambda *args: supplies)
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "malformed_proof")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_future_observation_time_fails_closed(self):
+        # Whatever produced it — a forged commit, a broken clock, a GitHub
+        # timestamp this monitor cannot have observed — an obligation dated in
+        # the future is not proof and must never buy an unexpiring allowance.
+        obligation = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW + timedelta(days=26000)),
+            "pull_number": 17,
+            "head_sha": "future-head",
+            "pull_state": "open",
+        }
+        findings = self._event_findings(lambda *args: [(obligation, None)])
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "malformed_proof")
+        self.assertIn("future", finding["detail"])
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_clock_skew_does_not_manufacture_a_forged_timestamp(self):
+        # GitHub issues the timestamp, the runner owns the clock. A few seconds
+        # of NTP skew on a genuinely fresh event must not read as forgery — a
+        # guard that cries wolf is one people stop reading.
+        obligation = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW + timedelta(seconds=30)),
+            "pull_number": 17,
+            "head_sha": "just-pushed",
+            "pull_state": "open",
+        }
+        findings = self._event_findings(lambda *args: [(obligation, None)])
+        self.assertEqual(self._one(findings, "reviewer.yml")["kind"], "pending")
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_adapter_rejects_an_implausible_github_pull_timeline(self):
+        # created_at newer than updated_at means the envelope this adapter
+        # bounds author-controlled timestamps against is itself untrustworthy.
+        payloads = [[{
+            "number": 17,
+            "state": "open",
+            "created_at": "2026-07-18T09:00:00Z",
+            "updated_at": "2026-07-17T09:00:00Z",
+            "head": {"sha": "current-head"},
+        }]]
+        with patch.object(ef, "urlopen", self._json_urlopen(payloads, [])):
+            with self.assertRaises(ef.AdapterError):
+                ef.default_event_supply_runner(
+                    "cross-model-review.yml", "pull_request",
+                    "GuitarAlchemist/Demerzel", "secret",
+                    ("opened", "synchronize"), SINCE,
+                )
+
+    # ── activation cutoff: no retroactive obligations (defect 3) ───────────
+
+    def _cutoff_spec(self, cutoff, event="pull_request"):
+        spec = json.loads(json.dumps(self.EVENT_SPEC))
+        spec["reviewer.yml"]["activation"][event] = cutoff
+        return spec
+
+    def _cutoff_findings(self, cutoff, supply):
+        self._event_repo()
+        return self._evaluate(
+            {"version": 1, "loops": []},
+            event_producers=self._cutoff_spec(cutoff),
+            event_supply_runner=supply,
+            git_runner=lambda args, cwd: "",
+        )
+
+    def test_pre_cutover_head_is_explicitly_waived(self):
+        # #935 flips the trigger to pull_request_target. Existing open heads
+        # predate that flip and CANNOT have such a run — changing `on:` does not
+        # replay opened/synchronize events. Demanding one manufactures an alarm
+        # no producer could ever answer.
+        stale_head = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW - timedelta(days=40)),
+            "pull_number": 17,
+            "head_sha": "pre-cutover-head",
+            "pull_state": "open",
+        }
+        findings = self._cutoff_findings(
+            _iso(NOW - timedelta(days=10)),
+            lambda *args: [(stale_head, None)],
+        )
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "healthy")
+        self.assertIn("waived", finding["detail"])
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_post_cutover_absent_run_becomes_pending_then_stale(self):
+        cutoff = _iso(NOW - timedelta(days=10))
+
+        def head(age_days):
+            return {
+                "activities": ["opened", "synchronize"],
+                "occurred_at": _iso(NOW - timedelta(days=age_days)),
+                "pull_number": 17,
+                "head_sha": "post-cutover-head",
+                "pull_state": "open",
+            }
+
+        # Inside the 3d response allowance: pending, board stays green.
+        pending = self._cutoff_findings(
+            cutoff, lambda *args: [(head(1), None)])
+        self.assertEqual(self._one(pending, "reviewer.yml")["kind"], "pending")
+        self.assertEqual(ef.exit_code(pending), 0)
+
+        # Past it: no run ever arrived for a head that really did dispatch.
+        overdue = self._cutoff_findings(
+            cutoff, lambda *args: [(head(4), None)])
+        self.assertEqual(self._one(overdue, "reviewer.yml")["kind"],
+                         "silent_green")
+        self.assertEqual(ef.exit_code(overdue), 1)
+
+    def test_waiving_pre_cutover_heads_cannot_mask_a_post_cutover_one(self):
+        cutoff = _iso(NOW - timedelta(days=10))
+        waived = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW - timedelta(days=40)),
+            "pull_number": 1,
+            "head_sha": "pre-cutover-head",
+            "pull_state": "closed",
+        }
+        overdue = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW - timedelta(days=4)),
+            "pull_number": 2,
+            "head_sha": "post-cutover-head",
+            "pull_state": "open",
+        }
+        findings = self._cutoff_findings(
+            cutoff, lambda *args: [(waived, None), (overdue, None)])
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "silent_green")
+        self.assertIn("#2", finding["detail"])
+        self.assertIn("waived", finding["detail"])
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_active_event_without_an_activation_cutoff_is_config_error(self):
+        # The shipped `pull_request_target` state until #935 merges: refuse to
+        # judge rather than invent a boundary.
+        findings = self._cutoff_findings(
+            None, lambda *args: self.fail("must not call API"))
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "config_error")
+        self.assertEqual(ef.exit_code(findings), 2)
+
+    def test_future_activation_cutoff_is_config_error(self):
+        # A cutoff after `now` waives every obligation — a guard that reads
+        # green because it is blind is the exact failure this repo exists for.
+        findings = self._cutoff_findings(
+            _iso(NOW + timedelta(days=1)),
+            lambda *args: self.fail("must not call API"))
+        self.assertEqual(self._one(findings, "reviewer.yml")["kind"],
+                         "config_error")
+        self.assertEqual(ef.exit_code(findings), 2)
+
+    # ── pull_request_target correlation must paginate (defect 4) ───────────
+
+    def _target_run(self, run_id, number, head, created="2026-07-17T00:00:00Z"):
+        return {
+            "id": run_id,
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": created,
+            "run_started_at": created,
+            "head_sha": "base-head",
+            "pull_requests": [{"number": number, "head": {"sha": head}}],
+        }
+
+    def test_correlated_target_run_on_page_two_is_found(self):
+        # A single 100-run page is not the run history. With a busy repo the
+        # valid run falls onto page 2 and the obligation reads "no run" — an
+        # alarm indistinguishable from a genuinely dead loop.
+        seen = []
+        payloads = [
+            [{
+                "number": 17,
+                "state": "open",
+                "created_at": "2026-07-17T09:00:00Z",
+                "updated_at": "2026-07-17T09:30:00Z",
+                "head": {"sha": "pr-head"},
+            }],
+            {"workflow_runs": [
+                self._target_run(i, 900 + i, f"other-head-{i}")
+                for i in range(100)
+            ]},
+            {"workflow_runs": [self._target_run(7, 17, "pr-head")]},
+        ]
+        with patch.object(ef, "urlopen",
+                          self._json_urlopen(payloads, seen)):
+            supplies = ef.default_event_supply_runner(
+                "cross-model-review.yml", "pull_request_target",
+                "GuitarAlchemist/Demerzel", "secret",
+                ("opened", "synchronize"), SINCE,
+            )
+        _, run = supplies[0]
+        self.assertIsNotNone(run, "a valid run on page 2 must not read as absent")
+        self.assertEqual(run["id"], 7)
+        self.assertEqual(
+            parse_qs(urlparse(seen[2].full_url).query)["page"], ["2"])
+
+    def test_incomplete_target_run_retrieval_is_adapter_error_not_absence(self):
+        full_page = {"workflow_runs": [
+            self._target_run(i, 900 + i, f"other-head-{i}") for i in range(100)
+        ]}
+        with patch.object(ef, "urlopen",
+                          self._json_urlopen([full_page] * 200, [])):
+            with self.assertRaises(ef.AdapterError):
+                ef._collect_target_runs(
+                    "GuitarAlchemist/Demerzel", "cross-model-review.yml",
+                    "pull_request_target", "secret", SINCE,
+                )
+
+    def test_target_run_retrieval_stops_at_the_activation_cutoff(self):
+        seen = []
+        recent = {"workflow_runs": [
+            self._target_run(i, 900 + i, f"h{i}") for i in range(100)
+        ]}
+        recent["workflow_runs"][-1]["created_at"] = "2023-06-01T00:00:00Z"
+        with patch.object(ef, "urlopen",
+                          self._json_urlopen([recent, recent], seen)):
+            runs = ef._collect_target_runs(
+                "GuitarAlchemist/Demerzel", "cross-model-review.yml",
+                "pull_request_target", "secret", SINCE,
+            )
+        self.assertEqual(len(runs), 100)
+        self.assertEqual(len(seen), 1, "retrieval must stop at the boundary")
+
+    def test_malformed_target_run_page_is_adapter_error(self):
+        with patch.object(ef, "urlopen",
+                          self._json_urlopen([{"workflow_runs": "nope"}], [])):
+            with self.assertRaises(ef.AdapterError):
+                ef._collect_target_runs(
+                    "GuitarAlchemist/Demerzel", "cross-model-review.yml",
+                    "pull_request_target", "secret", SINCE,
+                )
 
     def test_shipped_event_producers_match_live_workflow_yaml(self):
         # THE LIVE ORACLE for #844: cross-model-review.yml is on: pull_request,
@@ -1245,6 +1725,51 @@ class EcosystemFreshnessTest(unittest.TestCase):
             self.assertNotIn(wf, scheduled,
                              f"{wf} has a cron and belongs in the registry")
             self.assertGreater(spec["max_stale_days"], 0)
+
+            # Every candidate event must have an activation decision on record —
+            # an ISO instant, or an explicit None meaning "not activated yet".
+            # A missing key is an undeclared cutoff, which is how retroactive
+            # obligations get invented.
+            activation = spec.get("activation")
+            self.assertIsInstance(activation, dict, f"{wf} declares no activation")
+            for candidate in spec["events"]:
+                self.assertIn(candidate, activation,
+                              f"{wf} has no activation decision for {candidate}")
+                declared = activation[candidate]
+                if declared is None:
+                    continue
+                self.assertIsNotNone(
+                    ef._parse_iso(declared),
+                    f"{wf}: activation cutoff for {candidate} is unparseable",
+                )
+            # The ACTIVE event must carry a usable cutoff; a None there is the
+            # fail-closed state and must not reach production silently.
+            self.assertIsNotNone(
+                activation.get(active_event),
+                f"{wf}: `{active_event}` is the live trigger but has no "
+                "activation cutoff — see the #935 note on EVENT_PRODUCERS",
+            )
+
+    def test_shipped_pull_request_target_cutoff_is_explicitly_pending(self):
+        """The #935 dependency, asserted rather than remembered.
+
+        PR #935 migrates cross-model-review.yml to `pull_request_target`. Until
+        it merges, the cutover instant does not exist, so the declaration holds
+        None and _eval_event_producer refuses to judge that event. This test
+        fails the moment someone flips the trigger without recording the instant,
+        which is precisely when retroactive obligations would be invented.
+        """
+        spec = ef.EVENT_PRODUCERS["cross-model-review.yml"]
+        live = ef.workflow_events(
+            Path(ef.REPO) / ef.DEFAULT_WORKFLOWS_DIR, "cross-model-review.yml"
+        )
+        if "pull_request_target" in live:
+            self.assertIsNotNone(
+                spec["activation"]["pull_request_target"],
+                "the trigger migrated but its activation instant was not recorded",
+            )
+        else:
+            self.assertIsNone(spec["activation"]["pull_request_target"])
 
     def test_workflow_events_handles_every_on_shape(self):
         self.repo.write_event_workflow("mapping.yml", ["pull_request", "issues"])
@@ -1568,26 +2093,37 @@ class EcosystemFreshnessTest(unittest.TestCase):
         registry = ef.load_registry(
             repo / ef.DEFAULT_REGISTRY, repo / ef.DEFAULT_SCHEMA
         )
+        # The shipped activation cutoff is a real forward-moving instant, so this
+        # consistency check evaluates just after it rather than at the fixed NOW
+        # the behavioural tests share. Derived, not hardcoded, so it cannot rot.
+        declared = [
+            ef._parse_iso(value)
+            for spec in ef.EVENT_PRODUCERS.values()
+            for value in (spec.get("activation") or {}).values()
+            if isinstance(value, str)
+        ]
+        now = max([NOW, *(dt + timedelta(days=1) for dt in declared if dt)])
         findings = ef.evaluate(
             registry,
-            now=NOW,
+            now=now,
             workflows_dir=repo / ef.DEFAULT_WORKFLOWS_DIR,
             repo_root=repo,
-            git_runner=lambda args, cwd: _iso(NOW) + "\n",
+            git_runner=lambda args, cwd: _iso(now) + "\n",
             actions_runner=lambda *args: {
                 "conclusion": "success",
-                "run_started_at": _iso(NOW),
+                "run_started_at": _iso(now),
                 "html_url": "https://example.test/production-proof",
             },
             event_supply_runner=lambda *args: [({
                 "activities": ["opened", "synchronize"],
-                "occurred_at": _iso(NOW),
+                "occurred_at": _iso(now),
                 "pull_number": 939,
                 "head_sha": "production-head",
+                "pull_state": "open",
             }, {
                 "status": "completed",
                 "conclusion": "success",
-                "run_started_at": _iso(NOW),
+                "run_started_at": _iso(now),
                 "html_url": "https://example.test/production-event-proof",
                 "head_sha": "production-head",
                 "pull_requests": [{"number": 939}],

--- a/scripts/test_ecosystem_freshness.py
+++ b/scripts/test_ecosystem_freshness.py
@@ -556,20 +556,54 @@ class EcosystemFreshnessTest(unittest.TestCase):
         )
         finding = self._one(findings, "reviewer.yml")
         self.assertEqual(finding["kind"], "stale")
-        self.assertIn("9.0d old", finding["detail"])
+        # The run started 8.5d before the event it should have answered. That lag is
+        # what proves death here — the event itself is only 0.5d old, so an
+        # "unanswered for longer than the allowance" test alone would still be green.
+        self.assertIn("8.5d BEFORE that event", finding["detail"])
         self.assertEqual(ef.exit_code(findings), 1)
 
     def test_event_loop_quiet_with_no_event_supply_stays_silent(self):
-        # THE OTHER DIRECTION: no PR in the window, so no run was owed. A repo
-        # with a quiet week must not turn the board red — that is the cry-wolf
+        # THE OTHER DIRECTION: the last PR was 30d ago and was answered. A repo
+        # with a quiet month must not turn the board red — that is the cry-wolf
         # failure that trains people to ignore the guard.
         findings = self._event_findings(
             self._supply(event_age_days=30, run_age_days=30)
         )
         finding = self._one(findings, "reviewer.yml")
         self.assertEqual(finding["kind"], "healthy")
-        self.assertIn("quiet", finding["detail"])
+        self.assertIn("postdates the newest event", finding["detail"])
         self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_a_dead_loop_stays_red_however_long_the_repo_stays_quiet(self):
+        """Regression for the vanishing detection window (adversarial review, pre-merge).
+
+        The first version compared the event and the run each against `now`:
+        `event_age <= max AND run_age > max`. That makes the window in which both hold
+        exactly as wide as the gap between the dead loop's last run and the unanswered
+        event — here six hours — and then it CLOSES, because the event ages past the
+        window and the quiet arm returns healthy. A loop that died just before a final
+        event and then went quiet read green forever, and this guard runs once a day
+        (cron `15 13 * * *`), so it could miss the window entirely.
+
+        Ordering has no window. The event is unanswered and stays unanswered, so the
+        finding must hold at 4 days, 40 days and 400.
+        """
+        # Run at T, the event it never answered 6h later — a lag far INSIDE the
+        # allowance, so only the unanswered-duration arm can catch this one.
+        for quiet_days in (4, 40, 400):
+            with self.subTest(quiet_days=quiet_days):
+                findings = self._event_findings(
+                    self._supply(
+                        event_age_days=quiet_days,
+                        run_age_days=quiet_days + 0.25,
+                    )
+                )
+                finding = self._one(findings, "reviewer.yml")
+                self.assertEqual(
+                    finding["kind"], "stale",
+                    f"a loop dead for {quiet_days}d read {finding['kind']!r}; evidence of "
+                    "death must not decay at the same rate as the obligation")
+                self.assertEqual(ef.exit_code(findings), 1)
 
     def test_event_loop_never_triggered_at_all_stays_silent(self):
         # No PR has ever existed: absence of supply, not absence of life.

--- a/scripts/test_ecosystem_freshness.py
+++ b/scripts/test_ecosystem_freshness.py
@@ -1162,7 +1162,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
         persist_steps = guard["jobs"]["persist"]["steps"]
         self.assertTrue(any(step.get("if") == "always()" for step in persist_steps))
         self.assertEqual(guard["jobs"]["evaluate"]["permissions"], {
-            "actions": "read", "contents": "read",
+            "actions": "read", "contents": "read", "pull-requests": "read",
         })
         self.assertEqual(guard["jobs"]["persist"]["permissions"], {
             "contents": "write",

--- a/scripts/test_ecosystem_freshness.py
+++ b/scripts/test_ecosystem_freshness.py
@@ -66,6 +66,16 @@ class _Repo:
             encoding="utf-8",
         )
 
+    def write_event_workflow(self, name: str, events: list[str]) -> None:
+        """A workflow with only event triggers — no cron at all (#844)."""
+        (self.workflows / name).write_text(
+            "name: stub\n"
+            "on:\n"
+            + "".join(f"  {event}:\n" for event in events)
+            + "jobs: {}\n",
+            encoding="utf-8",
+        )
+
 
 class EcosystemFreshnessTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -73,7 +83,8 @@ class EcosystemFreshnessTest(unittest.TestCase):
         self.addCleanup(self.repo.close)
 
     def _evaluate(self, registry: dict, *, git_runner=None,
-                  actions_runner=None, auto_workflows=True) -> list[dict]:
+                  actions_runner=None, auto_workflows=True,
+                  event_supply_runner=None, event_producers=None) -> list[dict]:
         # Most unit tests exercise an adapter, not activation declarations. Give
         # them a matching scheduled stub; activation tests opt out explicitly.
         registry = json.loads(json.dumps(registry))
@@ -91,11 +102,17 @@ class EcosystemFreshnessTest(unittest.TestCase):
         kwargs = {
             "repository": "GuitarAlchemist/Demerzel",
             "token": "test-token",
+            # Event-triggered producers are opt-in per test: the shipped
+            # EVENT_PRODUCERS names a real workflow that does not exist in these
+            # throwaway repos.
+            "event_producers": event_producers or {},
         }
         if git_runner is not None:
             kwargs["git_runner"] = git_runner
         if actions_runner is not None:
             kwargs["actions_runner"] = actions_runner
+        if event_supply_runner is not None:
+            kwargs["event_supply_runner"] = event_supply_runner
         return ef.evaluate(
             registry,
             now=NOW,
@@ -496,6 +513,251 @@ class EcosystemFreshnessTest(unittest.TestCase):
         self.assertEqual(seen["request"].get_header("Authorization"),
                          "Bearer secret")
 
+    # ── event-triggered producers (#844) ──────────────────────────────────
+    #
+    # These loops have no cadence, so freshness is bound to EVENT SUPPLY: a
+    # `pull_request` loop is only expected to have run when a PR happened.
+    # Both directions matter — a genuinely dead loop must fire, and a quiet but
+    # healthy one must stay silent.
+
+    EVENT_SPEC = {"reviewer.yml": {"event": "pull_request", "max_stale_days": 3}}
+
+    def _event_repo(self, events=("pull_request",)):
+        self.repo.write_event_workflow("reviewer.yml", list(events))
+
+    def _supply(self, event_age_days=None, run_age_days=None,
+                conclusion="success"):
+        """Stub the (newest event, latest completed run) seam."""
+        event_iso = (
+            None if event_age_days is None
+            else _iso(NOW - timedelta(days=event_age_days))
+        )
+        run = None if run_age_days is None else {
+            "conclusion": conclusion,
+            "run_started_at": _iso(NOW - timedelta(days=run_age_days)),
+            "html_url": "https://example.test/pr-run",
+        }
+        return lambda *args: (event_iso, run)
+
+    def _event_findings(self, supply, git_runner=None):
+        self._event_repo()
+        return self._evaluate(
+            {"version": 1, "loops": []},
+            event_producers=self.EVENT_SPEC,
+            event_supply_runner=supply,
+            git_runner=git_runner or (lambda args, cwd: ""),
+        )
+
+    def test_event_loop_dead_while_events_flow_turns_red(self):
+        # THE #844 SHAPE: PRs kept arriving, the loop stopped answering, and
+        # nothing enumerated it because it has no cron.
+        findings = self._event_findings(
+            self._supply(event_age_days=0.5, run_age_days=9)
+        )
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "stale")
+        self.assertIn("9.0d old", finding["detail"])
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_event_loop_quiet_with_no_event_supply_stays_silent(self):
+        # THE OTHER DIRECTION: no PR in the window, so no run was owed. A repo
+        # with a quiet week must not turn the board red — that is the cry-wolf
+        # failure that trains people to ignore the guard.
+        findings = self._event_findings(
+            self._supply(event_age_days=30, run_age_days=30)
+        )
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "healthy")
+        self.assertIn("quiet", finding["detail"])
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_event_loop_never_triggered_at_all_stays_silent(self):
+        # No PR has ever existed: absence of supply, not absence of life.
+        findings = self._event_findings(self._supply(event_age_days=None))
+        self.assertEqual(self._one(findings, "reviewer.yml")["kind"], "healthy")
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_event_loop_answering_supply_is_healthy(self):
+        findings = self._event_findings(
+            self._supply(event_age_days=0.2, run_age_days=0.2)
+        )
+        self.assertEqual(self._one(findings, "reviewer.yml")["kind"], "healthy")
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_event_loop_with_live_supply_and_no_run_ever_is_red(self):
+        findings = self._event_findings(
+            self._supply(event_age_days=1, run_age_days=None)
+        )
+        self.assertEqual(self._one(findings, "reviewer.yml")["kind"],
+                         "silent_green")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_event_loop_failed_run_turns_red(self):
+        # Post-#840 a broken reviewer exits non-zero, so the conclusion is the
+        # leg that catches the original incident class.
+        findings = self._event_findings(
+            self._supply(event_age_days=0.5, run_age_days=0.5,
+                         conclusion="failure")
+        )
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "failed_run")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_newborn_event_loop_is_not_reported_dead(self):
+        # #850 grace applies unchanged: a loop added yesterday cannot have
+        # answered a PR opened before it existed.
+        findings = self._event_findings(
+            self._supply(event_age_days=1, run_age_days=None),
+            git_runner=lambda args, cwd: _iso(NOW - timedelta(days=0.5)) + "\n",
+        )
+        self.assertEqual(self._one(findings, "reviewer.yml")["kind"], "newborn")
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_event_loop_past_newborn_grace_still_fires(self):
+        findings = self._event_findings(
+            self._supply(event_age_days=1, run_age_days=None),
+            git_runner=lambda args, cwd: _iso(NOW - timedelta(days=40)) + "\n",
+        )
+        self.assertEqual(self._one(findings, "reviewer.yml")["kind"],
+                         "silent_green")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_event_loop_losing_its_trigger_turns_red(self):
+        # Silently rewriting `on:` must not make the producer vanish from the
+        # guard the way a cron-less workflow does today.
+        self.repo.write_event_workflow("reviewer.yml", ["workflow_dispatch"])
+        findings = self._evaluate(
+            {"version": 1, "loops": []},
+            event_producers=self.EVENT_SPEC,
+            event_supply_runner=lambda *args: self.fail("must not call API"),
+        )
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "activation_mismatch")
+        self.assertIn("pull_request", finding["detail"])
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_event_loop_deleted_workflow_turns_red(self):
+        findings = self._evaluate(
+            {"version": 1, "loops": []},
+            event_producers=self.EVENT_SPEC,
+            event_supply_runner=lambda *args: self.fail("must not call API"),
+        )
+        self.assertEqual(self._one(findings, "reviewer.yml")["kind"],
+                         "activation_mismatch")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_event_supply_adapter_failure_is_exit_2(self):
+        def boom(*args):
+            raise ef.AdapterError("GitHub API failed for pull_request supply")
+
+        findings = self._event_findings(boom)
+        self.assertEqual(self._one(findings, "reviewer.yml")["kind"],
+                         "adapter_error")
+        self.assertEqual(ef.exit_code(findings), 2)
+
+    def test_event_producer_cannot_also_be_a_registered_scheduled_loop(self):
+        self._event_repo()
+        self.repo.write_workflow("reviewer.yml", crons=["0 0 * * *"])
+        findings = self._evaluate({
+            "version": 1,
+            "loops": [{"workflow": "reviewer.yml", "status": "active",
+                       "schedule": ["0 0 * * *"],
+                       "proof": {"adapter": "workflow_run",
+                                 "max_stale_days": 1}}],
+        }, event_producers=self.EVENT_SPEC,
+            actions_runner=lambda *args: {
+                "conclusion": "success", "run_started_at": _iso(NOW)},
+            event_supply_runner=lambda *args: self.fail("must not call API"))
+        self.assertTrue(any(
+            f["kind"] == "config_error" and "event-triggered" in f["detail"]
+            for f in findings
+        ))
+
+    def test_default_event_supply_adapter_queries_pulls_and_pr_runs(self):
+        seen = []
+
+        class Response:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps(self.payload).encode()
+
+        payloads = [
+            [{"created_at": "2026-07-18T09:00:00Z"}],
+            {"workflow_runs": [{"id": 7, "conclusion": "success"}]},
+        ]
+
+        def fake_urlopen(request, timeout):
+            seen.append(request)
+            return Response(payloads[len(seen) - 1])
+
+        with patch.object(ef, "urlopen", fake_urlopen):
+            event_iso, run = ef.default_event_supply_runner(
+                "cross-model-review.yml", "pull_request",
+                "GuitarAlchemist/Demerzel", "secret",
+            )
+        self.assertEqual(event_iso, "2026-07-18T09:00:00Z")
+        self.assertEqual(run, {"id": 7, "conclusion": "success"})
+
+        pulls_q = parse_qs(urlparse(seen[0].full_url).query)
+        self.assertEqual(pulls_q, {
+            "state": ["all"], "sort": ["created"],
+            "direction": ["desc"], "per_page": ["1"],
+        })
+        runs_q = parse_qs(urlparse(seen[1].full_url).query)
+        self.assertEqual(runs_q, {
+            "event": ["pull_request"], "status": ["completed"], "per_page": ["1"],
+        })
+        # A pull_request run lives on the PR head branch, so a default-branch
+        # filter would find nothing and read every healthy loop as dead.
+        self.assertNotIn("branch", runs_q)
+        for request in seen:
+            self.assertNotIn("secret", request.full_url)
+            self.assertEqual(request.get_header("Authorization"), "Bearer secret")
+
+    def test_event_supply_adapter_requires_repository_and_token(self):
+        with self.assertRaises(ef.AdapterError):
+            ef.default_event_supply_runner("w.yml", "pull_request", "", "t")
+        with self.assertRaises(ef.AdapterError):
+            ef.default_event_supply_runner("w.yml", "pull_request", "o/r", "")
+        with self.assertRaises(ef.AdapterError):
+            ef.default_event_supply_runner("w.yml", "issues", "o/r", "t")
+
+    def test_shipped_event_producers_match_live_workflow_yaml(self):
+        # THE LIVE ORACLE for #844: cross-model-review.yml is on: pull_request,
+        # carries no cron, and was therefore invisible to scheduled_workflows().
+        workflows = Path(ef.REPO) / ef.DEFAULT_WORKFLOWS_DIR
+        self.assertIn("cross-model-review.yml", ef.EVENT_PRODUCERS)
+        scheduled = set(ef.scheduled_workflows(workflows))
+        for wf, spec in ef.EVENT_PRODUCERS.items():
+            events = ef.workflow_events(workflows, wf)
+            self.assertIsNotNone(events, f"{wf} is declared but does not exist")
+            self.assertIn(spec["event"], events)
+            self.assertNotIn(wf, scheduled,
+                             f"{wf} has a cron and belongs in the registry")
+            self.assertGreater(spec["max_stale_days"], 0)
+
+    def test_workflow_events_handles_every_on_shape(self):
+        self.repo.write_event_workflow("mapping.yml", ["pull_request", "issues"])
+        (self.repo.workflows / "seq.yml").write_text(
+            "name: s\non: [push, pull_request]\njobs: {}\n", encoding="utf-8")
+        (self.repo.workflows / "scalar.yml").write_text(
+            "name: s\non: push\njobs: {}\n", encoding="utf-8")
+        self.assertEqual(ef.workflow_events(self.repo.workflows, "mapping.yml"),
+                         {"pull_request", "issues"})
+        self.assertEqual(ef.workflow_events(self.repo.workflows, "seq.yml"),
+                         {"push", "pull_request"})
+        self.assertEqual(ef.workflow_events(self.repo.workflows, "scalar.yml"),
+                         {"push"})
+        self.assertIsNone(ef.workflow_events(self.repo.workflows, "gone.yml"))
+
     # ── registry activation must match actual workflow YAML ───────────────
 
     def test_active_schedule_mismatch_turns_red_before_adapter(self):
@@ -815,8 +1077,19 @@ class EcosystemFreshnessTest(unittest.TestCase):
                 "run_started_at": _iso(NOW),
                 "html_url": "https://example.test/production-proof",
             },
+            event_supply_runner=lambda *args: (_iso(NOW), {
+                "conclusion": "success",
+                "run_started_at": _iso(NOW),
+                "html_url": "https://example.test/production-event-proof",
+            }),
             repository="GuitarAlchemist/Demerzel",
             token="test-token",
+        )
+        # The event-triggered producers really are evaluated in production.
+        self.assertEqual(
+            {f["workflow"] for f in findings} & set(ef.EVENT_PRODUCERS),
+            set(ef.EVENT_PRODUCERS),
+            "every declared event-triggered producer must yield a finding",
         )
         # No unregistered producers and no config/adapter errors: coverage is
         # complete and the registry is internally consistent.

--- a/scripts/test_ecosystem_freshness.py
+++ b/scripts/test_ecosystem_freshness.py
@@ -66,12 +66,18 @@ class _Repo:
             encoding="utf-8",
         )
 
-    def write_event_workflow(self, name: str, events: list[str]) -> None:
+    def write_event_workflow(self, name: str, events: list[str],
+                             activities: list[str] | None = None) -> None:
         """A workflow with only event triggers — no cron at all (#844)."""
+        event_lines = ""
+        for event in events:
+            event_lines += f"  {event}:\n"
+            if event in {"pull_request", "pull_request_target"} and activities is not None:
+                event_lines += "    types: [" + ", ".join(activities) + "]\n"
         (self.workflows / name).write_text(
             "name: stub\n"
             "on:\n"
-            + "".join(f"  {event}:\n" for event in events)
+            + event_lines
             + "jobs: {}\n",
             encoding="utf-8",
         )
@@ -520,24 +526,41 @@ class EcosystemFreshnessTest(unittest.TestCase):
     # Both directions matter — a genuinely dead loop must fire, and a quiet but
     # healthy one must stay silent.
 
-    EVENT_SPEC = {"reviewer.yml": {"event": "pull_request", "max_stale_days": 3}}
+    EVENT_SPEC = {"reviewer.yml": {
+        "events": ["pull_request", "pull_request_target"],
+        "activities": ["opened", "synchronize"],
+        "max_stale_days": 3,
+    }}
 
     def _event_repo(self, events=("pull_request",)):
-        self.repo.write_event_workflow("reviewer.yml", list(events))
+        self.repo.write_event_workflow(
+            "reviewer.yml", list(events), ["opened", "synchronize"]
+        )
 
     def _supply(self, event_age_days=None, run_age_days=None,
-                conclusion="success"):
-        """Stub the (newest event, latest completed run) seam."""
+                conclusion="success", pull_number=17,
+                obligation_sha="current-head", run_sha="current-head",
+                run_pull_number=17):
+        """Stub the (current dispatch obligation, candidate run) seam."""
         event_iso = (
             None if event_age_days is None
             else _iso(NOW - timedelta(days=event_age_days))
         )
+        obligation = None if event_iso is None else {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": event_iso,
+            "pull_number": pull_number,
+            "head_sha": obligation_sha,
+        }
         run = None if run_age_days is None else {
+            "status": "completed",
             "conclusion": conclusion,
             "run_started_at": _iso(NOW - timedelta(days=run_age_days)),
             "html_url": "https://example.test/pr-run",
+            "head_sha": run_sha,
+            "pull_requests": [{"number": run_pull_number}],
         }
-        return lambda *args: (event_iso, run)
+        return lambda *args: [] if obligation is None else [(obligation, run)]
 
     def _event_findings(self, supply, git_runner=None):
         self._event_repo()
@@ -552,14 +575,16 @@ class EcosystemFreshnessTest(unittest.TestCase):
         # THE #844 SHAPE: PRs kept arriving, the loop stopped answering, and
         # nothing enumerated it because it has no cron.
         findings = self._event_findings(
-            self._supply(event_age_days=0.5, run_age_days=9)
+            self._supply(
+                event_age_days=4,
+                run_age_days=9,
+                obligation_sha="synchronized-head",
+                run_sha="opening-head",
+            )
         )
         finding = self._one(findings, "reviewer.yml")
         self.assertEqual(finding["kind"], "stale")
-        # The run started 8.5d before the event it should have answered. That lag is
-        # what proves death here — the event itself is only 0.5d old, so an
-        # "unanswered for longer than the allowance" test alone would still be green.
-        self.assertIn("8.5d BEFORE that event", finding["detail"])
+        self.assertIn("no correlated run after 4.0d", finding["detail"])
         self.assertEqual(ef.exit_code(findings), 1)
 
     def test_event_loop_quiet_with_no_event_supply_stays_silent(self):
@@ -571,7 +596,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
         )
         finding = self._one(findings, "reviewer.yml")
         self.assertEqual(finding["kind"], "healthy")
-        self.assertIn("postdates the newest event", finding["detail"])
+        self.assertIn("correlated successful run", finding["detail"])
         self.assertEqual(ef.exit_code(findings), 0)
 
     def test_a_dead_loop_stays_red_however_long_the_repo_stays_quiet(self):
@@ -596,6 +621,8 @@ class EcosystemFreshnessTest(unittest.TestCase):
                     self._supply(
                         event_age_days=quiet_days,
                         run_age_days=quiet_days + 0.25,
+                        obligation_sha="synchronized-head",
+                        run_sha="opening-head",
                     )
                 )
                 finding = self._one(findings, "reviewer.yml")
@@ -618,13 +645,137 @@ class EcosystemFreshnessTest(unittest.TestCase):
         self.assertEqual(self._one(findings, "reviewer.yml")["kind"], "healthy")
         self.assertEqual(ef.exit_code(findings), 0)
 
-    def test_event_loop_with_live_supply_and_no_run_ever_is_red(self):
+    def test_synchronize_is_unanswered_after_a_successful_opening_run(self):
+        findings = self._event_findings(self._supply(
+            event_age_days=4,
+            run_age_days=5,
+            obligation_sha="synchronized-head",
+            run_sha="opening-head",
+        ))
+        finding = self._one(findings, "reviewer.yml")
+        self.assertIn(finding["kind"], {"silent_green", "stale"})
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_unrelated_delayed_run_cannot_answer_a_pull_request(self):
+        findings = self._event_findings(self._supply(
+            event_age_days=4,
+            run_age_days=0.1,
+            pull_number=17,
+            obligation_sha="expected-head",
+            run_pull_number=99,
+            run_sha="unrelated-head",
+        ))
+        finding = self._one(findings, "reviewer.yml")
+        self.assertIn(finding["kind"], {"silent_green", "stale"})
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_commit_association_correlates_a_merged_pull_request_run(self):
+        obligation = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW - timedelta(days=30)),
+            "pull_number": 17,
+            "head_sha": "merged-head",
+        }
+        run = {
+            "status": "completed",
+            "conclusion": "success",
+            "run_started_at": _iso(NOW - timedelta(days=30)),
+            "html_url": "https://example.test/merged-pr-run",
+            "head_sha": "merged-head",
+            "pull_requests": [],
+            "associated_pull_requests": [{"number": 17}],
+        }
+        findings = self._event_findings(lambda *args: [(obligation, run)])
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "healthy")
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_recent_absent_run_is_pending_within_response_allowance(self):
+        obligation = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW - timedelta(days=1)),
+            "pull_number": 17,
+            "head_sha": "current-head",
+        }
+        findings = self._event_findings(lambda *args: [(obligation, None)])
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "pending")
+        self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_recent_queued_or_in_progress_run_is_pending_within_allowance(self):
+        obligation = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW - timedelta(days=1)),
+            "pull_number": 17,
+            "head_sha": "current-head",
+        }
+        for status in ("queued", "in_progress"):
+            with self.subTest(status=status):
+                run = {
+                    "status": status,
+                    "conclusion": None,
+                    "created_at": _iso(NOW - timedelta(days=1)),
+                    "head_sha": "current-head",
+                    "pull_requests": [{"number": 17}],
+                }
+                findings = self._event_findings(lambda *args: [(obligation, run)])
+                finding = self._one(findings, "reviewer.yml")
+                self.assertEqual(finding["kind"], "pending")
+                self.assertEqual(ef.exit_code(findings), 0)
+
+    def test_one_answered_pull_cannot_mask_an_overdue_pull(self):
+        answered = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW - timedelta(hours=1)),
+            "pull_number": 18,
+            "head_sha": "answered-head",
+        }
+        answered_run = {
+            "status": "completed",
+            "conclusion": "success",
+            "run_started_at": _iso(NOW - timedelta(hours=1)),
+            "head_sha": "answered-head",
+            "pull_requests": [{"number": 18}],
+        }
+        overdue = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW - timedelta(days=4)),
+            "pull_number": 17,
+            "head_sha": "unanswered-head",
+        }
+        findings = self._event_findings(
+            lambda *args: [(answered, answered_run), (overdue, None)]
+        )
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "silent_green")
+        self.assertIn("#17", finding["detail"])
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_boolean_pull_identity_is_malformed_evidence(self):
+        obligation = {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": _iso(NOW - timedelta(days=1)),
+            "pull_number": 1,
+            "head_sha": "current-head",
+        }
+        run = {
+            "status": "completed",
+            "conclusion": "success",
+            "run_started_at": _iso(NOW - timedelta(days=1)),
+            "head_sha": "current-head",
+            "pull_requests": [{"number": True}],
+        }
+        findings = self._event_findings(lambda *args: [(obligation, run)])
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "malformed_proof")
+        self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_event_loop_with_live_supply_and_no_run_is_pending_within_allowance(self):
         findings = self._event_findings(
             self._supply(event_age_days=1, run_age_days=None)
         )
-        self.assertEqual(self._one(findings, "reviewer.yml")["kind"],
-                         "silent_green")
-        self.assertEqual(ef.exit_code(findings), 1)
+        self.assertEqual(self._one(findings, "reviewer.yml")["kind"], "pending")
+        self.assertEqual(ef.exit_code(findings), 0)
 
     def test_event_loop_failed_run_turns_red(self):
         # Post-#840 a broken reviewer exits non-zero, so the conclusion is the
@@ -641,7 +792,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
         # #850 grace applies unchanged: a loop added yesterday cannot have
         # answered a PR opened before it existed.
         findings = self._event_findings(
-            self._supply(event_age_days=1, run_age_days=None),
+            self._supply(event_age_days=4, run_age_days=None),
             git_runner=lambda args, cwd: _iso(NOW - timedelta(days=0.5)) + "\n",
         )
         self.assertEqual(self._one(findings, "reviewer.yml")["kind"], "newborn")
@@ -649,7 +800,7 @@ class EcosystemFreshnessTest(unittest.TestCase):
 
     def test_event_loop_past_newborn_grace_still_fires(self):
         findings = self._event_findings(
-            self._supply(event_age_days=1, run_age_days=None),
+            self._supply(event_age_days=4, run_age_days=None),
             git_runner=lambda args, cwd: _iso(NOW - timedelta(days=40)) + "\n",
         )
         self.assertEqual(self._one(findings, "reviewer.yml")["kind"],
@@ -669,6 +820,37 @@ class EcosystemFreshnessTest(unittest.TestCase):
         self.assertEqual(finding["kind"], "activation_mismatch")
         self.assertIn("pull_request", finding["detail"])
         self.assertEqual(ef.exit_code(findings), 1)
+
+    def test_secured_pull_request_target_trigger_is_compatible(self):
+        self.repo.write_event_workflow(
+            "reviewer.yml",
+            ["pull_request_target"],
+            ["opened", "synchronize"],
+        )
+        findings = self._evaluate(
+            {"version": 1, "loops": []},
+            event_producers=self.EVENT_SPEC,
+            event_supply_runner=lambda *args: [({
+                "activities": ["opened", "synchronize"],
+                "occurred_at": _iso(NOW - timedelta(hours=1)),
+                "pull_number": 17,
+                "head_sha": "pr-head",
+            }, {
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": _iso(NOW - timedelta(hours=1)),
+                "run_started_at": _iso(NOW - timedelta(hours=1)),
+                # pull_request_target runs execute against the trusted base SHA.
+                "head_sha": "base-head",
+                "pull_requests": [{
+                    "number": 17,
+                    "head": {"sha": "pr-head"},
+                }],
+            })],
+        )
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "healthy")
+        self.assertEqual(ef.exit_code(findings), 0)
 
     def test_event_loop_deleted_workflow_turns_red(self):
         findings = self._evaluate(
@@ -724,8 +906,21 @@ class EcosystemFreshnessTest(unittest.TestCase):
                 return json.dumps(self.payload).encode()
 
         payloads = [
-            [{"created_at": "2026-07-18T09:00:00Z"}],
-            {"workflow_runs": [{"id": 7, "conclusion": "success"}]},
+            [{
+                "number": 939,
+                "created_at": "2026-07-18T09:00:00Z",
+                "updated_at": "2026-07-18T10:00:00Z",
+                "head": {"sha": "current-head"},
+            }],
+            {"workflow_runs": [{
+                "id": 7,
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-07-18T09:00:03Z",
+                "run_started_at": "2026-07-18T09:00:04Z",
+                "head_sha": "current-head",
+                "pull_requests": [{"number": 939}],
+            }]},
         ]
 
         def fake_urlopen(request, timeout):
@@ -733,21 +928,36 @@ class EcosystemFreshnessTest(unittest.TestCase):
             return Response(payloads[len(seen) - 1])
 
         with patch.object(ef, "urlopen", fake_urlopen):
-            event_iso, run = ef.default_event_supply_runner(
+            supplies = ef.default_event_supply_runner(
                 "cross-model-review.yml", "pull_request",
                 "GuitarAlchemist/Demerzel", "secret",
             )
-        self.assertEqual(event_iso, "2026-07-18T09:00:00Z")
-        self.assertEqual(run, {"id": 7, "conclusion": "success"})
+        obligation, run = supplies[0]
+        self.assertEqual(obligation, {
+            "activities": ["opened", "synchronize"],
+            "occurred_at": "2026-07-18T09:00:03+00:00",
+            "pull_number": 939,
+            "head_sha": "current-head",
+        })
+        self.assertEqual(run, {
+            "id": 7,
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-07-18T09:00:03Z",
+            "run_started_at": "2026-07-18T09:00:04Z",
+            "head_sha": "current-head",
+            "pull_requests": [{"number": 939}],
+        })
 
         pulls_q = parse_qs(urlparse(seen[0].full_url).query)
         self.assertEqual(pulls_q, {
-            "state": ["all"], "sort": ["created"],
-            "direction": ["desc"], "per_page": ["1"],
+            "state": ["open"], "sort": ["updated"],
+            "direction": ["desc"], "per_page": ["100"], "page": ["1"],
         })
         runs_q = parse_qs(urlparse(seen[1].full_url).query)
         self.assertEqual(runs_q, {
-            "event": ["pull_request"], "status": ["completed"], "per_page": ["1"],
+            "event": ["pull_request"], "head_sha": ["current-head"],
+            "per_page": ["1"],
         })
         # A pull_request run lives on the PR head branch, so a default-branch
         # filter would find nothing and read every healthy loop as dead.
@@ -755,6 +965,258 @@ class EcosystemFreshnessTest(unittest.TestCase):
         for request in seen:
             self.assertNotIn("secret", request.full_url)
             self.assertEqual(request.get_header("Authorization"), "Bearer secret")
+
+    def test_event_supply_adapter_treats_an_explicitly_empty_pull_list_as_quiet(self):
+        seen = []
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return b"[]"
+
+        def fake_urlopen(request, timeout):
+            seen.append(request)
+            return Response()
+
+        with patch.object(ef, "urlopen", fake_urlopen):
+            supplies = ef.default_event_supply_runner(
+                "cross-model-review.yml", "pull_request",
+                "GuitarAlchemist/Demerzel", "secret",
+            )
+        self.assertEqual(supplies, [])
+        self.assertEqual(len(seen), 1)
+
+    def test_event_supply_adapter_resolves_empty_run_pull_association(self):
+        seen = []
+
+        class Response:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps(self.payload).encode()
+
+        payloads = [
+            [{
+                "number": 17,
+                "created_at": "2026-07-18T09:00:00Z",
+                "updated_at": "2026-07-18T10:00:00Z",
+                "head": {"sha": "merged-head"},
+            }],
+            {"workflow_runs": [{
+                "id": 7,
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-07-18T10:00:00Z",
+                "head_sha": "merged-head",
+                "pull_requests": [],
+            }]},
+            [{"number": 17}],
+        ]
+
+        def fake_urlopen(request, timeout):
+            seen.append(request)
+            return Response(payloads[len(seen) - 1])
+
+        with patch.object(ef, "urlopen", fake_urlopen):
+            supplies = ef.default_event_supply_runner(
+                "cross-model-review.yml", "pull_request",
+                "GuitarAlchemist/Demerzel", "secret",
+            )
+        _, run = supplies[0]
+        self.assertEqual(run["associated_pull_requests"], [{"number": 17}])
+        self.assertIn("/commits/merged-head/pulls", seen[2].full_url)
+
+    def test_adapter_does_not_treat_generic_pull_updated_at_as_synchronize(self):
+        seen = []
+
+        class Response:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps(self.payload).encode()
+
+        payloads = [
+            [{
+                "number": 17,
+                "created_at": "2026-07-18T09:00:00Z",
+                # A comment or label may cause this update; it is not a dispatch.
+                "updated_at": "2026-07-20T10:00:00Z",
+                "head": {"sha": "opening-head"},
+            }],
+            {"workflow_runs": [{
+                "id": 7,
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-07-18T09:00:03Z",
+                "run_started_at": "2026-07-18T09:00:04Z",
+                "head_sha": "opening-head",
+                "pull_requests": [{"number": 17}],
+            }]},
+        ]
+
+        def fake_urlopen(request, timeout):
+            seen.append(request)
+            return Response(payloads[len(seen) - 1])
+
+        with patch.object(ef, "urlopen", fake_urlopen):
+            supplies = ef.default_event_supply_runner(
+                "cross-model-review.yml", "pull_request",
+                "GuitarAlchemist/Demerzel", "secret",
+            )
+        obligation, _ = supplies[0]
+        self.assertEqual(obligation["activities"], ["opened", "synchronize"])
+        self.assertEqual(obligation["occurred_at"], "2026-07-18T09:00:03+00:00")
+
+    def test_adapter_dates_an_absent_run_from_the_current_head_commit(self):
+        seen = []
+
+        class Response:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps(self.payload).encode()
+
+        payloads = [
+            [{
+                "number": 17,
+                "created_at": "2026-07-18T09:00:00Z",
+                "updated_at": "2026-07-20T10:00:00Z",
+                "head": {"sha": "unanswered-head"},
+            }],
+            {"workflow_runs": []},
+            {"commit": {"committer": {"date": "2026-07-19T11:00:00Z"}}},
+        ]
+
+        def fake_urlopen(request, timeout):
+            seen.append(request)
+            return Response(payloads[len(seen) - 1])
+
+        with patch.object(ef, "urlopen", fake_urlopen):
+            supplies = ef.default_event_supply_runner(
+                "cross-model-review.yml", "pull_request",
+                "GuitarAlchemist/Demerzel", "secret",
+            )
+        obligation, run = supplies[0]
+        self.assertIsNone(run)
+        self.assertEqual(obligation["occurred_at"], "2026-07-19T11:00:00+00:00")
+        self.assertIn("/commits/unanswered-head", seen[2].full_url)
+
+    def test_pull_request_target_adapter_matches_nested_pr_head_identity(self):
+        seen = []
+
+        class Response:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps(self.payload).encode()
+
+        payloads = [
+            [{
+                "number": 17,
+                "created_at": "2026-07-18T09:00:00Z",
+                "head": {"sha": "pr-head"},
+            }],
+            {"workflow_runs": [{
+                "id": 7,
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-07-18T09:00:03Z",
+                "run_started_at": "2026-07-18T09:00:04Z",
+                "head_sha": "base-head",
+                "pull_requests": [{
+                    "number": 17,
+                    "head": {"sha": "pr-head"},
+                }],
+            }]},
+        ]
+
+        def fake_urlopen(request, timeout):
+            seen.append(request)
+            return Response(payloads[len(seen) - 1])
+
+        with patch.object(ef, "urlopen", fake_urlopen):
+            supplies = ef.default_event_supply_runner(
+                "cross-model-review.yml", "pull_request_target",
+                "GuitarAlchemist/Demerzel", "secret",
+            )
+        _, run = supplies[0]
+        self.assertEqual(run["id"], 7)
+        runs_q = parse_qs(urlparse(seen[1].full_url).query)
+        self.assertNotIn("head_sha", runs_q)
+
+    def test_event_supply_adapter_rejects_a_malformed_first_pull(self):
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return b"[{}]"
+
+        with patch.object(ef, "urlopen", lambda *args, **kwargs: Response()):
+            with self.assertRaises(ef.AdapterError):
+                ef.default_event_supply_runner(
+                    "cross-model-review.yml", "pull_request",
+                    "GuitarAlchemist/Demerzel", "secret",
+                )
+
+    def test_event_supply_adapter_rejects_an_unparseable_pull_timestamp(self):
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return json.dumps([{
+                    "number": 17,
+                    "created_at": "not-a-timestamp",
+                    "updated_at": "2026-07-18T10:00:00Z",
+                    "head": {"sha": "current-head"},
+                }]).encode()
+
+        with patch.object(ef, "urlopen", lambda *args, **kwargs: Response()):
+            with self.assertRaises(ef.AdapterError):
+                ef.default_event_supply_runner(
+                    "cross-model-review.yml", "pull_request",
+                    "GuitarAlchemist/Demerzel", "secret",
+                )
 
     def test_event_supply_adapter_requires_repository_and_token(self):
         with self.assertRaises(ef.AdapterError):
@@ -773,7 +1235,13 @@ class EcosystemFreshnessTest(unittest.TestCase):
         for wf, spec in ef.EVENT_PRODUCERS.items():
             events = ef.workflow_events(workflows, wf)
             self.assertIsNotNone(events, f"{wf} is declared but does not exist")
-            self.assertIn(spec["event"], events)
+            active_events = set(spec["events"]) & events
+            self.assertEqual(len(active_events), 1)
+            active_event = next(iter(active_events))
+            self.assertEqual(
+                set(spec["activities"]),
+                ef.workflow_event_activities(workflows, wf, active_event),
+            )
             self.assertNotIn(wf, scheduled,
                              f"{wf} has a cron and belongs in the registry")
             self.assertGreater(spec["max_stale_days"], 0)
@@ -1111,11 +1579,19 @@ class EcosystemFreshnessTest(unittest.TestCase):
                 "run_started_at": _iso(NOW),
                 "html_url": "https://example.test/production-proof",
             },
-            event_supply_runner=lambda *args: (_iso(NOW), {
+            event_supply_runner=lambda *args: [({
+                "activities": ["opened", "synchronize"],
+                "occurred_at": _iso(NOW),
+                "pull_number": 939,
+                "head_sha": "production-head",
+            }, {
+                "status": "completed",
                 "conclusion": "success",
                 "run_started_at": _iso(NOW),
                 "html_url": "https://example.test/production-event-proof",
-            }),
+                "head_sha": "production-head",
+                "pull_requests": [{"number": 939}],
+            })],
             repository="GuitarAlchemist/Demerzel",
             token="test-token",
         )


### PR DESCRIPTION
**Partially addresses #844 — deliberately does not close it.** See "What this does not do".

Implemented by a delegated agent; I reviewed it and independently re-verified every claim, including one that turned out to be wrong.

## Root cause

`scheduled_workflows()` returns only workflows carrying a cron block, and it is the sole enumerator feeding the coverage sweep. `cross-model-review.yml` is `on: pull_request` with no cron, so it was never registered, never swept, never evaluated.

The registry cannot close the gap: `schemas/loop-health.schema.json` makes `schedule` (minItems 1) **required** for `status: active`, and `additionalProperties: false` blocks any new field. So the declaration lives in an `EVENT_PRODUCERS` constant in code, following the existing `ALLOWED_MONITORS` precedent — a list a producer cannot extend from its own workflow file.

## Semantics: freshness bound to event supply, not to a clock

An event-triggered loop has no cadence, so "overdue" is undefined. The question that *is* well-defined is whether the newest run answered the newest event — so the comparison is **run against event**, not each against the clock.

| state | finding | exit |
|---|---|---|
| newest run started at or after the newest event | healthy (*answering supply*) | 0 |
| no triggering event within `max_stale_days` | healthy (*quiet*) | 0 |
| event unanswered, but both event age and lag within `max_stale_days` | healthy (*within allowance*) | 0 |
| event in window, no completed run ever | `silent_green` (#850 newborn grace applies) | 1 |
| event unanswered longer than `max_stale_days`, **or** newest run predates it by more than that | `stale` | 1 |
| newest completed run not `success` | `failed_run` | 1 |

**Corrected at `aaaabad` — the first version of this check had a detection window that closed.** It compared the newest event against `now` and the newest run against `now`, never against each other. So a dead loop was only visible while the gap between its last run and the unanswered event happened to straddle the allowance; once the repo went quiet long enough, *both* readings aged out and the loop read healthy forever. Against a daily cron that is a guard that reports success on a corpse.

Comparing the two quantities to each other instead is sticky: a run that predates the event it should have answered stays that way no matter how much time passes. `test_a_dead_loop_stays_red_however_long_the_repo_stays_quiet` pins the verdict at 4, 40 and 400 quiet days; under the old logic all three read `healthy`.

Both arms are needed and each was reached by discarding a wrong single-arm fix. Lag alone misses the vanishing-window case; unanswered-duration alone turns `test_event_loop_dead_while_events_flow_turns_red` green.

Two boundary calls worth defending. Supply is dated from PR `created_at`, not `updated_at`: `opened` dispatches unconditionally, so a PR created in the window *proves* a run was owed, whereas comments bump `updated_at` without triggering anything. That under-claims rather than crying wolf. And the run query carries **no branch filter**, because a `pull_request` run is attributed to the PR head branch — the existing `default_actions_runner` filters on the default branch, which would read every healthy PR loop as dead.

## ⚠️ What this does not do — the reason #844 stays open

**This closes the enumeration gap in the issue's title. It does not detect the incident in the issue's body.**

Every `cross-model-review` run during the dead week concluded `success`. I verified against the API rather than taking it on report:

```
runs 2026-07-20..2026-07-27:  total=52,  success=52
```

The loop was dead behind **52 green runs**. This fix keys on run recency and conclusion, so it would not have caught that. Catching green-but-empty output needs the artifact-validity check — asserting a posted review body actually parses — which requires per-workflow proof declarations in `schemas/loop-health.schema.json` (a blocked path).

That check is also harder than the issue implies: the workflow skips docs-only and <10-line PRs, so "recent PRs must carry a review" would false-positive on a quiet docs week. The sound form is *conditional* — only reviews that exist must parse, keyed on the `*Cross-model review:` trailer — and needs a per-PR reviews API call.

**I am leaving #844 open with that scope remaining**, rather than closing it on a fix that does not address the failure it was filed for.

## A claim from the agent's report that I checked and disproved

The agent reported finding "a genuine dispatch gap" — PRs #829/#833/#836/#837 opened 2026-07-25 supposedly drawing no completed run between 07-23 and 07-27, and its replay firing `stale` on 07-26 as a real catch.

That is wrong. Each PR drew a run within about three seconds:

| PR | created | run |
|---|---|---|
| #829 | 01:31:42 | 01:31:45 |
| #833 | 01:43:46 | 01:43:50 |
| #836 | 01:49:15 | 01:49:18 |
| #837 | 01:54:44 | 01:54:47 |

There was no dispatch gap. The "newest run 3.0d old" figure came from the agent's **replay harness**, which cannot rewind a live "newest completed run" query — the shipped code queries current state, so a historical replay reads today's answer against a backdated clock. The replay is not evidence either way.

**The shipped code is correct** — I ran it live rather than relying on the replay:

```
GITHUB_REPOSITORY=GuitarAlchemist/Demerzel python scripts/ecosystem_freshness.py
  -> 1 problem loop, exit 1
  -> demerzel-ideation.yml — failed_run (the pre-existing API-quota failure)
  -> cross-model-review.yml — not flagged; it is answering PR supply right now
```

So: enumerated, evaluated, and correctly healthy. But the 07-26 `stale` result should not be cited as a defect this guard caught, because there was nothing there to catch.

## Verified

| | |
|---|---|
| before | `Ran 463 tests` — OK |
| after | `Ran 479 tests` — **OK** (+16) |
| new tests against unfixed module | `Ran 16` — **FAILED (errors=16)** |
| `validate_governance.py` | `PASSED: all checks green.` |
| files changed | 2 — `ecosystem_freshness.py`, its tests |
| blocked paths | none |

Both directions are covered: four tests where a dead loop must fire (`stale`, `silent_green`, `failed_run`, past-newborn-grace) and four where a quiet-but-healthy one must stay silent (no event supply, never triggered, answering supply, newborn).

## Open questions for you

**`max_stale_days: 3` for cross-model-review is a judgement, not a measurement.** The agent chose it; nothing validates it. That dial decides how long a genuinely dead PR loop stays invisible, and it deserves an owner's opinion.

**The recommended registry change is not made** (schema is blocked): add `events: [<trigger>]`, relax the `active` branch to require `schedule` **or** `events`, add an `event_supply` value to the `proof.adapter` enum. Then `EVENT_PRODUCERS` moves out of code into `.github/loop-health.yml` and the constant is deleted.

**General enumeration of all event-triggered workflows was deliberately not attempted**, and I agree with that call: 15 of 29 workflows are event-triggered without cron, but most are ordinary CI gates (`script-tests`, `governance-validate`, `agent-blackbox`). There is no mechanical way to separate "producer loop" from "CI gate" without a per-workflow declaration, and sweeping them all as `unregistered` would turn the board permanently red with no available remediation — the cry-wolf failure the doctrine warns about.

