### PR TITLE
fix(harness): declare cycle driver execution policy

### DIFF
--- a/scripts/run_afk_cycle.py
+++ b/scripts/run_afk_cycle.py
@@ -2,6 +2,12 @@
 """
 Demerzel run_afk_cycle — the AFK implement-lane governor.
 
+Execution policy: manual-or-external.
+No GitHub Actions workflow schedules this driver. An operator or external harness
+owns cadence and invokes one bounded cycle after issue authorization, HALT, and
+budget preflight. Because provider runs can spend metered budget, no automatic
+freshness guard or self-starting schedule is wanted.
+
 Reads the `agent-implement` GitHub issue queue, honors HALT, classifies risk per
 policies/autonomous-loop-policy.yaml, and for each eligible (non-critical) issue
 invokes the agent-agnostic sandcastle harness (../afk-harness) which runs headless

--- a/scripts/run_ml_feedback_cycle.py
+++ b/scripts/run_ml_feedback_cycle.py
@@ -3,6 +3,11 @@
 Demerzel run_ml_feedback_cycle — the orchestrator that turns the four hand-run
 ML-feedback legs into ONE unattended, bounded self-improvement cycle.
 
+Execution policy: externally-scheduled.
+An operator-managed cron or Task Scheduler owns the mutating cycle's cadence.
+GitHub Actions `ml-governance-schedule.yml` is a read-only freshness tripwire and
+strict dry-run smoke; it never runs the mutating cycle.
+
 It runs, in dependency order, a single pass of pipelines/ml-feedback-loop.ixql
 (standing in for the absent IxQL executor):
 
@@ -17,10 +22,10 @@ It runs, in dependency order, a single pass of pipelines/ml-feedback-loop.ixql
                         bounded auto-apply or escalate to human review
   4. Summarize        — write one cycle summary to state/oversight/
 
-One invocation = one cycle. Cadence comes from whatever schedules this (cron /
-Task Scheduler), NOT from a cycle-count gate here — the ml-feedback policy defines
-no per-day cap, and WAKE-time count gates have wedged loops before. The only
-loop-level bound is the HALT switch; per-decision bounds live in the governor.
+One invocation = one cycle. Cadence belongs to the external operator scheduler,
+NOT to a cycle-count gate here — the ml-feedback policy defines no per-day cap,
+and WAKE-time count gates have wedged loops before. The only loop-level bound is
+the HALT switch; per-decision bounds live in the governor.
 
 Producers that find nothing to do exit 4 (no-op) and are reported as such, not as
 errors. A producer/harvest error is logged but does not abort the cycle (the

--- a/scripts/test_cycle_driver_execution_policy.py
+++ b/scripts/test_cycle_driver_execution_policy.py
@@ -1,0 +1,64 @@
+"""Contract tests for Demerzel cycle-driver execution policy declarations."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import shlex
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "ml-governance-schedule.yml"
+
+
+def _module_docstring(relative_path: str) -> str:
+    source = (ROOT / relative_path).read_text(encoding="utf-8")
+    return ast.get_docstring(ast.parse(source)) or ""
+
+
+class CycleDriverExecutionPolicyTests(unittest.TestCase):
+    def test_afk_cycle_declares_manual_or_external_ownership(self) -> None:
+        docstring = _module_docstring("scripts/run_afk_cycle.py")
+
+        self.assertIn("Execution policy: manual-or-external.", docstring)
+        self.assertIn("No GitHub Actions workflow schedules this driver.", docstring)
+        self.assertIn("no automatic\nfreshness guard", docstring)
+
+    def test_ml_feedback_declares_external_cycle_and_read_only_tripwire(self) -> None:
+        docstring = _module_docstring("scripts/run_ml_feedback_cycle.py")
+        workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        triggers = workflow.get("on", workflow.get(True, {}))
+
+        self.assertIn("Execution policy: externally-scheduled.", docstring)
+        self.assertIn("read-only freshness tripwire", docstring)
+        self.assertIn("schedule", triggers)
+        self.assertEqual({"contents": "read"}, workflow.get("permissions"))
+        self.assertIn("freshness", workflow.get("jobs", {}))
+        self.assertTrue(
+            all("permissions" not in job for job in workflow["jobs"].values())
+        )
+
+        entrypoint_steps = workflow["jobs"]["entrypoint"]["steps"]
+        smoke = next(
+            step
+            for step in entrypoint_steps
+            if step.get("name") == "ML-feedback orchestrator dry-run (strict)"
+        )
+        self.assertEqual(
+            [
+                "python",
+                "scripts/run_ml_feedback_cycle.py",
+                "--dry-run",
+                "--strict",
+                "--repos-root",
+                "_siblings",
+            ],
+            shlex.split(smoke["run"]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- declare `run_afk_cycle.py` as manual-or-external, with no GitHub Actions schedule or automatic freshness guard because provider execution can consume metered budget
- declare the mutating ML-feedback cycle as externally scheduled while keeping `ml-governance-schedule.yml` a read-only freshness tripwire and strict dry-run smoke
- add focused contract tests for both declarations and the named tripwire configuration

## Verification

- `python -m unittest discover -s scripts -p "test_*.py"` — 485 tests passed
- `pwsh scripts/verify.ps1` in an LF checkout — IXQL 10/10; BAML generated client in step
- two independent read-only reviews — no P0/P1/P2 findings

## Risk

Documentation and contract-test only. No workflow, cadence, provider invocation, budget, or runtime behavior changes.

Fixes #776