### PR TITLE
fix(freshness): bound event-supply cost without forgetting obligations

### DIFF
--- a/docs/architecture/event-supply-retrieval-bound.md
+++ b/docs/architecture/event-supply-retrieval-bound.md
@@ -1,0 +1,140 @@
+# Bounding event-supply retrieval without forgetting obligations
+
+Status: partial — cost fuse shipped, the durable bound is designed but not built.
+Issue: [#963](https://github.com/GuitarAlchemist/Demerzel/issues/963).
+Follows: [#939](https://github.com/GuitarAlchemist/Demerzel/pull/939) (event-supply
+evaluation for `cross-model-review.yml`).
+
+## The problem
+
+`default_event_supply_runner` in `scripts/ecosystem_freshness.py` evaluates the
+event-triggered `cross-model-review.yml` loop by enumerating every pull request
+updated since the **activation cutoff** and asking, per pull request, whether its
+head SHA got a correlated run. The cutoff is immutable by design, so that set only
+grows, and so does the request count.
+
+## Measured baseline
+
+Read-only measurement against `GuitarAlchemist/Demerzel` on the activation day
+(2026-08-03, cutoff `2026-08-03T00:00:00Z`), issuing only authenticated `GET`s:
+
+| Metric | Value |
+|---|---|
+| Obligations evaluated | 11 |
+| GitHub requests | 22 |
+| Wall clock | 10.9 s |
+| Cost shape | `1 listing + ~2 requests per pull request` |
+
+Observed velocity, same measurement: 59 pull requests touched in the trailing 7
+days, 112 in 30 days, 201 in 90 days (204 in the whole archive).
+
+Extrapolating at ~3.7 newly-relevant pull requests per day, the daily job reaches
+GITHUB_TOKEN's 1,000 requests/hour/repository primary rate limit at roughly 500
+accumulated pull requests — months, not years — where it would fail as an opaque
+mid-retrieval HTTP 403. That is a nearer and less legible failure than the
+`_MAX_SUPPLY_PAGES = 20` listing ceiling (~2,000 pull requests) named in the issue.
+
+## Why the proposed formula is unsound
+
+The issue proposes
+
+```text
+retrieval_floor = max(activation_cutoff, now - k * max_stale_days)
+```
+
+as a hypothesis. Applied to the pull listing, it is silent-green by construction.
+
+The listing is filtered on `updated_at`. An obligation that is never answered —
+head pushed, no run, PR then closed or abandoned — stops bumping `updated_at`. Its
+verdict is correctly red today and stays red only because retrieval still reaches
+it. Under a moving floor it drops out of retrieval on day `k * max_stale_days`, the
+supply comes back empty, and the evaluator reports `quiet: no pull_request event
+has occurred since the activation cutoff` — exit 0.
+
+Spiked against the real adapter with `k = 3`, `max_stale_days = 3`, on a closed
+pull request whose head never ran and whose last activity is 60 days old:
+
+| | current | with retrieval floor |
+|---|---|---|
+| Obligations retrieved | 1 | 0 |
+| Verdict | `silent_green` | `healthy` |
+| Exit code | 1 | 0 |
+
+This is exactly the erasure defect the guard was built to catch — the one
+`state=all` and the pre-cutoff waiver machinery exist to prevent — reintroduced
+through the retrieval boundary instead of the query filter.
+
+`test_unanswered_obligation_survives_beyond_any_moving_horizon` in
+`scripts/test_ecosystem_freshness.py` is the executable form of that invariant.
+Any future bounding change must keep it green.
+
+## Why no stateless bound exists
+
+The sticky invariant is: an unanswered obligation stays red until a *correlated
+terminal run* resolves it, however old it gets, including after closure or merge.
+
+A stateless run knows only what it retrieves. To know an obligation of age `A`
+exists, it must page back `A` worth of activity, because every GitHub listing is
+ordered by recency. `A` is unbounded, because an unanswered obligation is exactly
+the one nothing ever resolves. Therefore bounded retrieval and stickiness are
+incompatible *without memory across runs*. Any real bound has to remember what it
+stops looking at.
+
+## What shipped here
+
+`_MAX_SUPPLY_REQUESTS = 600` — a per-evaluation request budget. Exceeding it raises
+`AdapterError` (exit 2), the same fail-closed doctrine as `_MAX_SUPPLY_PAGES`:
+retrieval that stopped early is incomplete, and incomplete retrieval is never read
+as absence.
+
+This bounds **cost**, not the obligation set. Nothing is dropped to stay inside it.
+It is a fuse, not a fix: it converts a future opaque 403 into a legible alarm that
+names the constant and the remedy, roughly 1–2 months before the rate limiter would
+fire. It is ~27x the measured baseline and ~60% of the hourly token allowance.
+
+**Consequence to accept deliberately:** if the durable bound below never lands, this
+budget turns the board red at ~300 accumulated pull requests. That is the intended
+behaviour — a loud, dated deadline rather than a silent slide into rate-limit
+failure — but it is a deadline, and the number is a policy choice the owner may
+retune.
+
+## Tracer plan for the real bound: a proven watermark
+
+Smallest sound design. One durable timestamp, the *retrieval watermark*, alongside
+the immutable activation cutoff:
+
+```text
+retrieval_floor = max(activation_cutoff, watermark)
+```
+
+The watermark differs from the rejected formula in one decisive way: **it only
+advances over history that has been proven clean.** After an evaluation, the
+watermark may advance to `now - k * max_stale_days` if and only if every obligation
+older than that candidate was resolved in that same run — correlated terminal run,
+or explicitly waived as pre-cutoff. If anything older is unresolved, the watermark
+does not move, retrieval keeps reaching back to it, and the obligation stays red
+for as long as it stays unanswered. History is forgotten only after it is proven to
+contain nothing left to answer.
+
+Properties:
+
+- Sticky invariant preserved: forgetting requires proof of resolution.
+- Cost bounded in the steady state (a clean repository walks back only
+  `k * max_stale_days`), and unbounded only while something is broken — which is
+  loud, finite, and self-clearing.
+- Activation cutoff untouched: still immutable, still the obligation boundary,
+  still the floor the watermark can never precede.
+- Tamper direction is visible: advancing the watermark is the dangerous move and it
+  lands in git history where it is reviewable. Losing or rewinding it only widens
+  retrieval, which is safe.
+
+Open work, deliberately not done in this change:
+
+1. Where the watermark lives (`state/`, committed by the daily job) and its schema.
+2. Malformed or missing watermark must fail closed to the activation cutoff, not to
+   `now`.
+3. Advancement requires the daily freshness job to gain write-and-commit
+   permission — a change to `.github/workflows/ecosystem-freshness.yml`, a
+   protected path, so it needs human review before implementation.
+4. `k` must be justified against the same measured velocity as above, with overlap
+   for pagination, delayed runs, and clock skew.

--- a/scripts/ecosystem_freshness.py
+++ b/scripts/ecosystem_freshness.py
@@ -130,6 +130,30 @@ EVENT_PRODUCERS: dict[str, dict] = {
 # AdapterError (exit 2) instead. 100 items/page.
 _MAX_SUPPLY_PAGES = 20
 
+# Hard REQUEST ceiling for one event-supply evaluation (#963). The activation
+# cutoff is immutable, so the set of pull requests "updated since the cutoff"
+# only ever grows, and the adapter spends roughly two requests per pull request
+# in it. Measured read-only against GuitarAlchemist/Demerzel on the activation
+# day: 11 obligations, 22 requests, ~11s. At the repository's observed velocity
+# (~112 pull requests touched per 30 days) that reaches GITHUB_TOKEN's 1,000
+# requests/hour/repository primary rate limit within months, where it would
+# surface as an opaque mid-retrieval HTTP 403.
+#
+# This budget is ~27x the measured baseline and ~60% of the hourly token
+# allowance: high enough that no plausible month of activity trips it, low
+# enough to fire FIRST, as a legible "retrieval is no longer affordable" alarm
+# naming this constant, instead of the rate limiter firing illegibly.
+#
+# It bounds COST, never the obligation set: exceeding it raises AdapterError
+# (exit 2) exactly like _MAX_SUPPLY_PAGES, because retrieval that stopped early
+# is incomplete, and incomplete retrieval must never be read as absence. Note
+# what this deliberately does NOT do — it does not narrow the retrieval window
+# to keep the cost down. An obligation the monitor stops retrieving is an
+# obligation it silently forgets. For why the sliding retrieval floor proposed
+# in #963 cannot supply this bound without durable carry-forward state, see
+# `docs/architecture/event-supply-retrieval-bound.md`.
+_MAX_SUPPLY_REQUESTS = 600
+
 # Timestamps are issued by GitHub but compared against the runner's clock, so a
 # genuinely fresh event can read a hair "in the future" under NTP skew. Rejecting
 # those as forged would be pure cry-wolf. The tolerance is deliberately tiny
@@ -239,8 +263,35 @@ def default_actions_runner(
     return runs[0] if runs else None
 
 
-def _github_get(endpoint: str, token: str, what: str):
+class _RequestBudget:
+    """Requests one event-supply evaluation may spend before failing closed.
+
+    Counting lives here rather than in a module-level total so that the ceiling
+    is per-evaluation and testable without network: the unit suite asserts the
+    exact request count for a given supply shape.
+    """
+
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        self.spent = 0
+
+    def spend(self, what: str) -> None:
+        self.spent += 1
+        if self.spent > self.limit:
+            raise AdapterError(
+                f"event-supply retrieval exceeded its {self.limit}-request "
+                f"budget at {what}; retrieval is incomplete and cannot be read "
+                "as absence. The activation cutoff is immutable by design, so "
+                "the pull requests to evaluate only accumulate — bounding this "
+                "needs durable carry-forward state, not a narrower window"
+            )
+
+
+def _github_get(endpoint: str, token: str, what: str,
+                budget: _RequestBudget | None = None):
     """Read-only authenticated GET against the GitHub API. Raises AdapterError."""
+    if budget is not None:
+        budget.spend(what)
     request = Request(endpoint, headers={
         "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {token}",
@@ -266,6 +317,7 @@ def _collect_relevant_pulls(
     event: str,
     token: str,
     since: datetime,
+    budget: _RequestBudget | None = None,
 ) -> list[dict]:
     """Pull requests with GitHub-recorded activity at or after `since`.
 
@@ -297,6 +349,7 @@ def _collect_relevant_pulls(
             }),
             token,
             f"{event} supply on {repository} page {page}",
+            budget,
         )
         if not isinstance(pull_page, list):
             raise AdapterError(
@@ -336,6 +389,7 @@ def _collect_target_runs(
     event: str,
     token: str,
     since: datetime,
+    budget: _RequestBudget | None = None,
 ) -> list:
     """Every `pull_request_target` run back to the activation cutoff.
 
@@ -358,6 +412,7 @@ def _collect_target_runs(
             + urlencode({"event": event, "per_page": 100, "page": page}),
             token,
             f"{workflow} secured pull-request runs page {page}",
+            budget,
         )
         page_runs = (payload.get("workflow_runs")
                      if isinstance(payload, dict) else None)
@@ -426,8 +481,11 @@ def default_event_supply_runner(
             f"`{event}`; without one the relevant history has no boundary"
         )
 
+    budget = _RequestBudget(_MAX_SUPPLY_REQUESTS)
     repo_path = quote(repository, safe="/")
-    pulls = _collect_relevant_pulls(repo_path, repository, event, token, since)
+    pulls = _collect_relevant_pulls(
+        repo_path, repository, event, token, since, budget
+    )
     if not pulls:
         return []
 
@@ -435,7 +493,7 @@ def default_event_supply_runner(
     target_runs: list | None = None
     if event == "pull_request_target":
         target_runs = _collect_target_runs(
-            repo_path, workflow, event, token, since
+            repo_path, workflow, event, token, since, budget
         )
 
     for index, pull in enumerate(pulls):
@@ -475,6 +533,7 @@ def default_event_supply_runner(
                 }),
                 token,
                 f"{workflow} runs for {head_sha}",
+                budget,
             )
             runs = payload.get("workflow_runs") if isinstance(payload, dict) else None
             if not isinstance(runs, list):
@@ -501,6 +560,7 @@ def default_event_supply_runner(
                 f"{quote(head_sha, safe='')}",
                 token,
                 f"head commit {head_sha}",
+                budget,
             )
             commit_data = commit.get("commit") if isinstance(commit, dict) else None
             committer = (commit_data.get("committer")
@@ -552,6 +612,7 @@ def default_event_supply_runner(
                     f"{quote(head_sha, safe='')}/pulls",
                     token,
                     f"pull requests associated with {head_sha}",
+                    budget,
                 )
                 if not isinstance(associated_pulls, list):
                     raise AdapterError(

--- a/scripts/test_ecosystem_freshness.py
+++ b/scripts/test_ecosystem_freshness.py
@@ -1432,6 +1432,170 @@ class EcosystemFreshnessTest(unittest.TestCase):
                     "pull_request", "secret", SINCE,
                 )
 
+    # ── retrieval cost vs. sticky obligations (#963) ───────────────────────
+
+    def _routed_urlopen(self, pulls, seen, run_for_head=None):
+        """urlopen stub that answers by ENDPOINT, not by call order.
+
+        Order-indexed stubs cannot express "N pulls, therefore N run lookups",
+        which is exactly the cost shape #963 is about.
+        """
+        def fake_urlopen(request, timeout):
+            seen.append(request)
+            url = request.full_url
+            query = parse_qs(urlparse(url).query)
+            if "/pulls?" in url:
+                page = int(query.get("page", ["1"])[0])
+                payload = pulls if page == 1 else []
+            elif "/runs?" in url:
+                head = query.get("head_sha", [""])[0]
+                run = run_for_head(head) if run_for_head else None
+                payload = {"workflow_runs": [run] if run else []}
+            elif url.endswith("/pulls"):  # commits/{sha}/pulls association
+                payload = []
+            else:  # commits/{sha}
+                payload = {"commit": {"committer":
+                                      {"date": "2026-05-19T00:00:00Z"}}}
+            return self._json_urlopen([payload], [])(request, timeout)
+
+        return fake_urlopen
+
+    def test_supply_retrieval_cost_grows_with_the_number_of_pull_requests(self):
+        """Baseline: one listing request plus one run lookup PER pull request.
+
+        The activation cutoff is fixed forever, so the set of pull requests
+        "updated since the cutoff" only ever grows, and with it this request
+        count — the operational fuse #963 exists to bound. Recorded here as an
+        executable baseline so any bounding change has a number to beat.
+        """
+        def measure(pull_count):
+            seen = []
+            pulls = [{
+                "number": n,
+                "state": "open",
+                "created_at": "2026-07-17T00:00:00Z",
+                "updated_at": "2026-07-17T00:00:00Z",
+                "head": {"sha": f"h{n}"},
+            } for n in range(pull_count)]
+            run_for_head = lambda head: {
+                "id": 1,
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-07-17T01:00:00Z",
+                "run_started_at": "2026-07-17T01:00:00Z",
+                "head_sha": head,
+                "pull_requests": [{"number": int(head[1:]),
+                                   "head": {"sha": head}}],
+            }
+            with patch.object(ef, "urlopen",
+                              self._routed_urlopen(pulls, seen, run_for_head)):
+                supplies = ef.default_event_supply_runner(
+                    "cross-model-review.yml", "pull_request",
+                    "GuitarAlchemist/Demerzel", "secret",
+                    ("opened", "synchronize"), SINCE,
+                )
+            self.assertEqual(len(supplies), pull_count)
+            return len(seen)
+
+        self.assertEqual(measure(10), 11)
+        self.assertEqual(measure(60), 61)
+        # …and the whole growth curve stays under the budget for a long time.
+        self.assertGreater(ef._MAX_SUPPLY_REQUESTS, 61)
+
+    def test_supply_retrieval_fails_closed_at_its_request_budget(self):
+        """Cost is bounded by failing loudly, never by retrieving less.
+
+        GITHUB_TOKEN's hourly ceiling would otherwise stop retrieval mid-flight
+        as an opaque 403. The budget fires first and says so — and it raises
+        rather than returning the obligations it managed to collect, because a
+        partial supply read as a complete one is silent green.
+        """
+        seen = []
+        pulls = [{
+            "number": n,
+            "state": "open",
+            "created_at": "2026-07-17T00:00:00Z",
+            "updated_at": "2026-07-17T00:00:00Z",
+            "head": {"sha": f"h{n}"},
+        } for n in range(10)]
+        with patch.object(ef, "_MAX_SUPPLY_REQUESTS", 4):
+            with patch.object(ef, "urlopen", self._routed_urlopen(pulls, seen)):
+                with self.assertRaises(ef.AdapterError) as caught:
+                    ef.default_event_supply_runner(
+                        "cross-model-review.yml", "pull_request",
+                        "GuitarAlchemist/Demerzel", "secret",
+                        ("opened", "synchronize"), SINCE,
+                    )
+        self.assertIn("budget", str(caught.exception))
+        self.assertIn("cannot be read as absence", str(caught.exception))
+        self.assertEqual(len(seen), 4, "the budget must stop the spending")
+
+    def test_request_budget_does_not_leak_across_evaluations(self):
+        # A module-level total would make the second daily loop inherit the
+        # first one's spending and fail for a cost it never incurred.
+        pulls = [{
+            "number": 1,
+            "state": "open",
+            "created_at": "2026-07-17T00:00:00Z",
+            "updated_at": "2026-07-17T00:00:00Z",
+            "head": {"sha": "h1"},
+        }]
+        with patch.object(ef, "_MAX_SUPPLY_REQUESTS", 3):
+            for _ in range(3):
+                with patch.object(ef, "urlopen",
+                                  self._routed_urlopen(pulls, [])):
+                    supplies = ef.default_event_supply_runner(
+                        "cross-model-review.yml", "pull_request",
+                        "GuitarAlchemist/Demerzel", "secret",
+                        ("opened", "synchronize"), SINCE,
+                    )
+                self.assertEqual(len(supplies), 1)
+
+    def test_unanswered_obligation_survives_beyond_any_moving_horizon(self):
+        """Sticky-red past PR closure AND past a proposed sliding window.
+
+        The tracer bullet floated in #963 —
+        `retrieval_floor = max(activation_cutoff, now - k * max_stale_days)` —
+        filters the pull listing on `updated_at`. This pull request's last
+        GitHub-recorded activity is far older than that horizon for any small
+        `k`, its head never got a run, and it is closed. Under a sliding floor
+        it would be paginated away and the board would read "no event has
+        occurred" — green — while the obligation is still unanswered.
+        """
+        max_stale_days = self.EVENT_SPEC["reviewer.yml"]["max_stale_days"]
+        horizon = NOW - timedelta(days=3 * max_stale_days)
+        updated_at = NOW - timedelta(days=60)
+        self.assertLess(
+            updated_at, horizon,
+            "fixture must sit beyond the proposed moving horizon to be a test")
+
+        seen = []
+        pulls = [{
+            "number": 17,
+            "state": "closed",
+            "created_at": _iso(NOW - timedelta(days=62)),
+            "updated_at": _iso(updated_at),
+            "head": {"sha": "abandoned-head"},
+        }]
+        with patch.object(ef, "urlopen", self._routed_urlopen(pulls, seen)):
+            supplies = ef.default_event_supply_runner(
+                "cross-model-review.yml", "pull_request",
+                "GuitarAlchemist/Demerzel", "secret",
+                ("opened", "synchronize"), SINCE,
+            )
+        self.assertEqual(
+            len(supplies), 1,
+            "an unanswered obligation must not age out of retrieval")
+        obligation, run = supplies[0]
+        self.assertIsNone(run)
+        self.assertEqual(obligation["pull_state"], "closed")
+
+        # …and it must still be RED end-to-end, not merely retrievable.
+        findings = self._event_findings(lambda *args: supplies)
+        finding = self._one(findings, "reviewer.yml")
+        self.assertEqual(finding["kind"], "silent_green")
+        self.assertEqual(ef.exit_code(findings), 1)
+
     # ── author-controlled commit dates cannot buy allowance (defect 2) ─────
 
     def test_future_commit_timestamp_cannot_extend_the_allowance(self):


### PR DESCRIPTION
## Summary

- add a per-evaluation 600-request fuse to event-supply retrieval
- fail closed with `AdapterError` before exhausting GitHub's primary rate limit
- preserve unresolved obligations instead of applying an unsafe moving window
- document the durable proven-watermark design

## Why

The immutable activation cutoff makes request cost grow with repository history. A sliding retrieval floor would eventually erase old unresolved obligations and create a false green result. This change bounds cost by failing loudly while preserving correctness.

## Scope

Partial implementation for #963. This PR deliberately does **not** close the issue. Durable steady-state bounding requires a committed watermark and protected workflow changes, which should be delivered as a separate human-reviewed PR.

The 600-request ceiling is an explicitly approved operational guardrail. The current live baseline is 22 requests in approximately 10.9 seconds for 11 obligations.

## Evidence

- `python -m unittest scripts.test_ecosystem_freshness`: 97 passed
- `pwsh scripts/verify.ps1`: exit 0; 639 passed, 1 skipped
- live read-only evaluation: `cross-model-review.yml` healthy; the same four unrelated pre-existing loop alerts remain
- `git diff --check`: clean
- no paid provider/API use beyond the Claude Max seat and read-only GitHub requests

Refs #963